### PR TITLE
Open social media links in new tabs

### DIFF
--- a/src/components/AletheiaSocialMediaFooter.tsx
+++ b/src/components/AletheiaSocialMediaFooter.tsx
@@ -1,6 +1,6 @@
-import {SocialIcon} from "react-social-icons";
+import { SocialIcon } from "react-social-icons";
 import colors from "../styles/colors";
-import {Row} from "antd";
+import { Row } from "antd";
 import React from "react";
 
 const AletheiaSocialMediaFooter = () => {
@@ -12,10 +12,10 @@ const AletheiaSocialMediaFooter = () => {
                 padding: "35px 10% 20px 10%",
             }}
         >
-            <SocialIcon url="https://www.facebook.com/AletheiaFactorg-107521791638412" bgColor={colors.white} />
-            <SocialIcon url="https://www.instagram.com/aletheiafact" bgColor={colors.white} />
-            <SocialIcon url="https://www.linkedin.com/in/aletheiafact-org" bgColor={colors.white} />
-            <SocialIcon url="https://www.github.com/in/aletheiafact" bgColor={colors.white} />
+            <SocialIcon url="https://www.facebook.com/AletheiaFactorg-107521791638412" bgColor={colors.white} target='_blank' />
+            <SocialIcon url="https://www.instagram.com/aletheiafact" bgColor={colors.white} target='_blank' />
+            <SocialIcon url="https://www.linkedin.com/in/aletheiafact-org" bgColor={colors.white} target='_blank' />
+            <SocialIcon url="https://www.github.com/in/aletheiafact" bgColor={colors.white} target='_blank' />
         </Row>
     );
 }


### PR DESCRIPTION
## What was changed?

-  Set target blank on SocialIcon to open links on new tabs

## How to test it

- Click on social media icons in the footer of a page and check that it opens on new tab

Closes #253 