### PR TITLE
Show custom 404 page

### DIFF
--- a/public/locales/en/notFound.json
+++ b/public/locales/en/notFound.json
@@ -1,0 +1,3 @@
+{
+    "message": "Page not found."
+}

--- a/public/locales/pt/notFound.json
+++ b/public/locales/pt/notFound.json
@@ -1,0 +1,3 @@
+{
+    "message": "Página não encontrada."
+}

--- a/server/app.module.ts
+++ b/server/app.module.ts
@@ -13,6 +13,8 @@ import { ConfigModule } from "@nestjs/config";
 import { ViewModule } from "./view/view.module";
 import { HomeModule } from "./home/home.module";
 import { EmailModule } from "./email/email.module";
+import { APP_FILTER } from "@nestjs/core";
+import { NotFoundFilter } from "./filters/not-found.filter";
 
 @Module({})
 export class AppModule {
@@ -41,6 +43,12 @@ export class AppModule {
                 EmailModule
             ],
             controllers: [RootController],
+            providers: [
+                {
+                  provide: APP_FILTER,
+                  useClass: NotFoundFilter,
+                },
+              ],
         };
     }
 }

--- a/server/filters/not-found.filter.ts
+++ b/server/filters/not-found.filter.ts
@@ -1,0 +1,15 @@
+import { ArgumentsHost, Catch, ExceptionFilter, NotFoundException } from '@nestjs/common'
+import { Response } from 'express';
+
+/**
+ * Filters out not found exceptions and redirect to our custom 404 page, avoiding the default json error message
+ */
+@Catch(NotFoundException)
+export class NotFoundFilter<NotFoundException> implements ExceptionFilter {
+  catch(exception: NotFoundException, host: ArgumentsHost) {
+    const context = host.switchToHttp();
+    const response = context.getResponse<Response>();
+
+    response.redirect('/404')
+  }
+}

--- a/server/view/view.controller.ts
+++ b/server/view/view.controller.ts
@@ -71,4 +71,19 @@ export class ViewController {
             .getNextServer()
             .render(req, res, parsedUrl.pathname, parsedUrl.query);
     }
+
+    /**
+     * Redirects to our custom 404 page.
+     * The render404() method was not used here as it conflicts with our i18n strategy.
+     */
+    @Get("404")
+    public async show404(@Req() req: Request, @Res() res: Response) {
+        const parsedUrl = parse(req.url, true);
+        // @ts-ignore
+        req.language = req.headers["accept-language"] || "en";
+
+        await this.viewService
+            .getNextServer()
+            .render(req,res, '/404-page', Object.assign(parsedUrl.query))
+    }
 }

--- a/src/components/Aletheia404.tsx
+++ b/src/components/Aletheia404.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useTranslation } from "next-i18next";
+
+const Aletheia404 = () => {
+    const { t } = useTranslation();
+    return (
+        <div
+            style={{
+                width: '100%',
+                marginTop: '60px',
+                textAlign: 'center',
+                fontSize: "1rem",
+                fontWeight: 500,
+            }}
+        >
+            <div> {t("notFound:message")}</div>
+        </div>
+    );
+}
+
+export default Aletheia404

--- a/src/pages/404-page.tsx
+++ b/src/pages/404-page.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { NextPage } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import Aletheia404 from "../components/Aletheia404";
+const parser = require('accept-language-parser');
+
+const Custom404Page: NextPage = () => {
+    return (
+        <Aletheia404 />
+    )
+};
+
+export async function getServerSideProps({ locale, locales, req }) {
+    locale = parser.pick(locales, req.language) || locale || "en";
+    return {
+        props: {
+            ...(await serverSideTranslations(locale)),
+        },
+    };
+}
+
+
+export default Custom404Page;


### PR DESCRIPTION
### What was changed?

- Added a custom 404 page
- Added a exception filter on the server to handle not found exceptions redirecting to our custom 404 page

### How to test it

- Try to acces to a page that doesn't exist in our domain  ([example](http://localhost:3000/lalala)) and check that it displays a custom 404 page.

Closes #247