### PR TITLE
Fix redirect after login

### DIFF
--- a/src/components/Login/LoginView.tsx
+++ b/src/components/Login/LoginView.tsx
@@ -10,11 +10,12 @@ import Input from "../Input";
 import Button, { ButtonType } from "../Button";
 import colors from "../../styles/colors";
 
-const LoginView = () => {
+const LoginView = (props) => {
     const { t } = useTranslation();
+    const { previousUrl, host } = props
     const router = useRouter();
-
     const [formType, setFormType] = useState("login");
+    const shouldGoBack = previousUrl.startsWith(host)
 
     const onFinishFailed = errorInfo => {
         if (typeof errorInfo === "string") {
@@ -31,7 +32,12 @@ const LoginView = () => {
             onFinishFailed(result.message);
         } else {
             message.success(t("login:loginSuccessfulMessage"));
-            router.back();
+            if (shouldGoBack) {
+                router.back()
+            }
+            else {
+                router.push('/home')
+            }
         }
     };
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,17 +1,19 @@
-import {NextPage} from "next";
-import {serverSideTranslations} from "next-i18next/serverSideTranslations";
+import { NextPage } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import LoginView from "../components/Login/LoginView";
 const parser = require('accept-language-parser');
 
 const LoginPage: NextPage<{ data: any }> = (props) => {
-    return <LoginView />
+    return <LoginView {...props} />
 }
 
-export async function getServerSideProps({ query, locale, locales, req }) {
+export async function getServerSideProps({ locale, locales, req }) {
     locale = parser.pick(locales, req.language) || locale || "en";
     return {
         props: {
             ...(await serverSideTranslations(locale)),
+            previousUrl: req.headers.referer || 'none',
+            host: req.protocol + '://' + req.get('host')
         },
     };
 }


### PR DESCRIPTION
### What was changed?

- Uses the referrer of login page to determine if router shouldreturn or redirect to the home page after login

### How to test it

- Access the login page from a link within our domain, such as the link in the side menu, after a successful login you should be redirected to the previous page. 
- Access the login page by typing in the address bar or from a link outside our domain, after a successful login you should be redirected to the home page.


Closes #257