### PR TITLE
Fix condition to show 'load more' button

### DIFF
--- a/src/components/List/BaseList.tsx
+++ b/src/components/List/BaseList.tsx
@@ -43,7 +43,7 @@ const BaseList = ({
     }
 
     const loadMoreButton =
-        totalPages >= query.page ? (
+        totalPages > query.page ? (
             <div
                 style={{
                     textAlign: "center",


### PR DESCRIPTION
### What was changed?

- Change the condition to show the "load more" button only while the total is greater than the number of pages loaded

### How to test it

- Go to a page with a list and check if the "load more" button only appears if there are more items to be loaded

Closes #256