### PR TITLE
Remove ellipsis from claim review content

### DIFF
--- a/src/components/ClaimReview/ClaimSentenceCard.tsx
+++ b/src/components/ClaimReview/ClaimSentenceCard.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Col, Comment, Row, Tooltip, Typography } from "antd";
+import { Avatar, Col, Comment, Tooltip, Typography } from "antd";
 import React from "react";
 import ClaimSummary from "../Claim/ClaimSummary";
 
@@ -10,7 +10,6 @@ const ClaimSentenceCard = ({ personality, sentence, summaryClassName = "" }) => 
         return (
             <Col span={24}>
                 <Comment
-                    review="true"
                     author={personality.name}
                     avatar={
                         <Avatar
@@ -22,12 +21,7 @@ const ClaimSentenceCard = ({ personality, sentence, summaryClassName = "" }) => 
                         <>
                             <ClaimSummary className={summaryClassName}>
                                 <Col>
-                                    <Paragraph
-                                        ellipsis={{
-                                            rows: 4,
-                                            expandable: false
-                                        }}
-                                    >
+                                    <Paragraph>
                                         {content}
                                     </Paragraph>
                                 </Col>


### PR DESCRIPTION
### What was changed?

- Remove ellipsis from claim review content paragraph

### How to test it

- Go to a Claim Review page for a paragraph longer than 4 lines and check if the ellipsis appear at the end of the sentence

Closes #254
