### PR TITLE
Finish UI: Claim Card Header

### DIFF
--- a/public/locales/en/claim.json
+++ b/public/locales/en/claim.json
@@ -10,5 +10,9 @@
     "initialInfo": "Choose a sentence to review by clicking on it",
     "sourceSectionTitle": "Fontes:",
     "sourceFooter": "Unable to find reliable source linking this speech to this personality?",
-    "sourceFooterReport": "Please, report here. "
+    "sourceFooterReport": "Please, report here. ",
+    "cardHeader1": "Stated on",
+    "cardHeader2": "in",
+    "typeSpeech": "Oficial speech",
+    "typeTwitter": "Twitter post"
 }

--- a/public/locales/pt/claim.json
+++ b/public/locales/pt/claim.json
@@ -10,5 +10,9 @@
     "initialInfo": "Clique em uma frase para iniciar uma revisão",
     "sourceSectionTitle": "Fontes:",
     "sourceFooter": "Não consegue encontrar uma fonte ligada ao discurso dessa personalidade?",
-    "sourceFooterReport": "Por favor, reporte aqui. "
+    "sourceFooterReport": "Por favor, reporte aqui. ",
+    "cardHeader1": "Declarou em",
+    "cardHeader2": "em um",
+    "typeSpeech": "Discurso oficial",
+    "typeTwitter": "post no Twitter"
 }

--- a/src/components/Claim/ClaimCard.tsx
+++ b/src/components/Claim/ClaimCard.tsx
@@ -1,10 +1,11 @@
-import { Avatar, Col, Comment, Row, Tooltip, Typography } from "antd";
+import { Avatar, Col, Comment, Row, Typography } from "antd";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import ReviewColors from "../../constants/reviewColors";
 import CardBase from "../CardBase";
 import ClaimSummary from "./ClaimSummary";
 import Button, { ButtonType } from "../Button";
+import ClaimCardHeader from "./ClaimCardHeader";
 
 const { Paragraph } = Typography;
 
@@ -15,16 +16,20 @@ const ClaimCard = ({ personality, claim }) => {
     if (!claim) {
         return <div></div>;
     }
-
     return (
         <CardBase>
             <Row>
                 <Comment
-                    // review="true"
                     style={{
                         padding: "15px 15px 0px 15px"
                     }}
-                    author={personality.name}
+                    author={
+                        <ClaimCardHeader
+                            personality={personality}
+                            date={claim?.date}
+                            claimType={claim?.type}
+                        />
+                    }
                     avatar={
                         <Avatar
                             src={personality.image}
@@ -32,40 +37,33 @@ const ClaimCard = ({ personality, claim }) => {
                         />
                     }
                     content={
-                        <>
-                            <ClaimSummary
-                                style={{
-                                    padding: "15px"
-                                }}
-                            >
+                        <ClaimSummary
+                            style={{
+                                padding: "15px"
+                            }}
+                        >
+                            <Col>
                                 <Col>
-                                    <Col>
-                                        <Paragraph
-                                            ellipsis={{
-                                                rows: 4,
-                                                expandable: false
-                                            }}
-                                        >
-                                            {claim.content.text || claim.title}
-                                        </Paragraph>
-                                    </Col>
-                                    <a
-                                        href={`/personality/${personality.slug}/claim/${claim.slug}`}
-                                        style={{
-                                            textDecoration: "underline"
+                                    <Paragraph
+                                        ellipsis={{
+                                            rows: 4,
+                                            expandable: false
                                         }}
                                     >
-                                        {t("claim:cardLinkToFullText")}
-                                    </a>
+                                        {claim.content.text || claim.title}
+                                    </Paragraph>
                                 </Col>
-                            </ClaimSummary>
+                                <a
+                                    href={`/personality/${personality.slug}/claim/${claim.slug}`}
+                                    style={{
+                                        textDecoration: "underline"
+                                    }}
+                                >
+                                    {t("claim:cardLinkToFullText")}
+                                </a>
+                            </Col>
+                        </ClaimSummary>
 
-                        </>
-                    }
-                    datetime={
-                        <Tooltip title={claim?.date}>
-                            <span>{claim?.date}</span>
-                        </Tooltip>
                     }
                 />
             </Row>

--- a/src/components/Claim/ClaimCardHeader.tsx
+++ b/src/components/Claim/ClaimCardHeader.tsx
@@ -1,0 +1,34 @@
+import { Col, Row } from 'antd'
+import Text from 'antd/lib/typography/Text'
+import { useTranslation } from 'next-i18next'
+import React from 'react'
+import colors from '../../styles/colors'
+
+const ClaimCardHeader = ({ personality, date, claimType = 'speech' }) => {
+    const { t } = useTranslation()
+    const formattedDate = new Date(date).toLocaleDateString()
+    const speechTypeTranslation =
+        claimType === 'speech'
+            ? t('claim:typeSpeech')
+            : t('claim:typeTwitter')
+    return (
+        <Col span={24} style={{
+            color: colors.black,
+            width: '100%'
+        }}>
+            <Text style={{ fontSize: 16 }}>
+                {personality.name}
+            </Text>
+            <Row>{personality.description}</Row>
+            <Row>
+                {t('claim:cardHeader1')}&nbsp;
+                <strong>{formattedDate}</strong>&nbsp;
+                {t('claim:cardHeader2')}&nbsp;
+                <strong>{speechTypeTranslation}</strong>
+            </Row>
+        </Col>
+
+    )
+}
+
+export default ClaimCardHeader

--- a/src/components/ClaimReview/ClaimReviewView.tsx
+++ b/src/components/ClaimReview/ClaimReviewView.tsx
@@ -37,6 +37,7 @@ const ClaimReviewView = ({ personality, claim, sentence, sitekey }) => {
                     personality={personality}
                     sentence={sentence}
                     summaryClassName="claim-review"
+                    claimType={claim?.type}
                 />
                 {sentence.userReview && (
                     <Row

--- a/src/components/ClaimReview/ClaimSentenceCard.tsx
+++ b/src/components/ClaimReview/ClaimSentenceCard.tsx
@@ -1,16 +1,24 @@
-import { Avatar, Col, Comment, Tooltip, Typography } from "antd";
+import { Avatar, Col, Comment, Typography } from "antd";
 import React from "react";
+import ClaimCardHeader from "../Claim/ClaimCardHeader";
 import ClaimSummary from "../Claim/ClaimSummary";
 
 
 const { Paragraph } = Typography;
-const ClaimSentenceCard = ({ personality, sentence, summaryClassName = "" }) => {
+const ClaimSentenceCard = ({ personality, sentence, claimType, summaryClassName = "" }) => {
     const content = sentence?.content;
+
     if (content) {
         return (
             <Col span={24}>
                 <Comment
-                    author={personality.name}
+                    author={
+                        <ClaimCardHeader
+                            personality={personality}
+                            date={sentence?.date}
+                            claimType={claimType}
+                        />
+                    }
                     avatar={
                         <Avatar
                             src={personality.image}
@@ -27,11 +35,6 @@ const ClaimSentenceCard = ({ personality, sentence, summaryClassName = "" }) => 
                                 </Col>
                             </ClaimSummary>
                         </>
-                    }
-                    datetime={
-                        <Tooltip title={sentence?.date}>
-                            <span>{sentence?.date}</span>
-                        </Tooltip>
                     }
                 />
             </Col>


### PR DESCRIPTION
Add personality description and speech information to the claim header.

Closes #292 