### PR TITLE
fix mongoDB warnings

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -25,8 +25,6 @@ const initApp = async (options) => {
         options: {
             useUnifiedTopology: true,
             useNewUrlParser: true,
-            useCreateIndex: true,
-            useFindAndModify: false,
         }
     }
     const app = await NestFactory.create<NestExpressApplication>(

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -16,8 +16,6 @@ const initApp = async (options) => {
         options: {
             useUnifiedTopology: true,
             useNewUrlParser: true,
-            useCreateIndex: true,
-            useFindAndModify: false,
         }
     }
     options.logger.log("info", `Loading AppModule`);


### PR DESCRIPTION
fix mongodb warnings
Node] (node:13216) [MONGODB DRIVER] Warning: the options [useCreateIndex] is not supported
[Node] (node:13216) [MONGODB DRIVER] Warning: the options [useFindAndModify] is not supported