### PR TITLE
#323  Create a History Module that tracks creation and update between revisions for Claim and Personality

### DIFF
--- a/server/app.module.ts
+++ b/server/app.module.ts
@@ -18,6 +18,8 @@ import { NotFoundFilter } from "./filters/not-found.filter";
 import { ThrottlerModule, ThrottlerGuard } from "@nestjs/throttler";
 import { SitemapModule } from "./sitemap/sitemap.module";
 import { ClaimRevisionModule } from "./claim-revision/claim-revision.module";
+import { HistoryModule } from "./history/history.module";
+
 @Module({})
 export class AppModule {
     static register(options): DynamicModule {
@@ -43,6 +45,7 @@ export class AppModule {
                 ClaimModule,
                 ClaimReviewModule,
                 ClaimRevisionModule,
+                HistoryModule,
                 SourceModule,
                 StatsModule,
                 ViewModule,

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -117,7 +117,7 @@ export class ClaimController {
     }
     
     @UseGuards(SessionGuard)
-    @Put("api/claim")
+    @Put("api/claim/:id")
     update(@Param("id") claimId, @Body() updateClaimDTO: UpdateClaimDTO) {
         return this.claimService.update(claimId, updateClaimDTO);
     }

--- a/server/claim/claim.module.ts
+++ b/server/claim/claim.module.ts
@@ -11,6 +11,7 @@ import { HttpModule } from "@nestjs/axios";
 import { ViewModule } from "../view/view.module";
 import { SourceModule } from "../source/source.module";
 import { ClaimRevisionModule } from "../claim-revision/claim-revision.module"
+import { HistoryModule } from "../history/history.module";
 
 const ClaimModel = MongooseModule.forFeature([
     {
@@ -26,6 +27,7 @@ const ClaimModel = MongooseModule.forFeature([
         ClaimRevisionModule,
         ParserModule,
         PersonalityModule,
+        HistoryModule,
         ConfigModule,
         HttpModule,
         ViewModule,

--- a/server/history/history.module.ts
+++ b/server/history/history.module.ts
@@ -1,0 +1,30 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { History, HistorySchema } from "./schema/history.schema";
+import { ParserModule } from "../parser/parser.module";
+import { ConfigModule } from "@nestjs/config";
+import { HttpModule } from "@nestjs/axios";
+import { ViewModule } from "../view/view.module";
+import { SourceModule } from "../source/source.module";
+import { HistoryService } from "./history.service";
+
+const HistoryModel = MongooseModule.forFeature([
+    {
+        name: History.name,
+        schema: HistorySchema,
+    },
+]);
+
+@Module({
+    imports: [
+        HistoryModel,
+        ParserModule,
+        ConfigModule,
+        HttpModule,
+        ViewModule,
+        SourceModule,
+    ],
+    exports: [HistoryService],
+    providers: [HistoryService],
+})
+export class HistoryModule {}

--- a/server/history/history.service.ts
+++ b/server/history/history.service.ts
@@ -1,0 +1,25 @@
+import {Injectable, Logger} from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model, Types } from "mongoose";
+import { History, HistoryDocument } from "./schema/history.schema";
+
+@Injectable()
+export class HistoryService {
+    private optionsToUpdate: { new: boolean; upsert: boolean };
+    private readonly logger = new Logger("HistoryService");
+
+    constructor(
+        @InjectModel(History.name)
+        private HistoryModel: Model<HistoryDocument>,
+    ) {
+        this.optionsToUpdate = {
+            new: true,
+            upsert: true,
+        };
+    }
+
+    async createHistory(data) {
+        const newHistory = new this.HistoryModel(data);
+        return newHistory.save();
+    }
+}

--- a/server/history/schema/history.schema.ts
+++ b/server/history/schema/history.schema.ts
@@ -1,0 +1,44 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import * as mongoose from "mongoose";
+import { User } from "../../users/schemas/user.schema";
+import { HistoryType } from "../../claim/claim.service";
+
+export type HistoryDocument = History & mongoose.Document;
+
+@Schema({ toObject: {virtuals: true}, toJSON: {virtuals: true} })
+export class History {
+    @Prop({
+        type: mongoose.Types.ObjectId,
+        required: true,
+        refPath: "onModel",
+    })
+    targetId: mongoose.Types.ObjectId;
+
+    @Prop({
+        required: true,
+        enum: ["Claim", "Personality"],
+    })
+    targetModel: string;
+
+    @Prop({
+      type: mongoose.Types.ObjectId,
+      required: true,
+      ref: "User",
+    })
+    user: User;
+        
+    @Prop({
+      required: true,
+    })
+    type: HistoryType
+
+    @Prop({
+      type: Object,
+      required: true,
+    })
+    details: object
+}
+
+export const HistorySchema = SchemaFactory.createForClass(History);
+
+//ter uma validação dos tipos, caso seja um tipo create, é obrigatório um after


### PR DESCRIPTION
So far, we can track changes to claims when creating and updating