### PR TITLE
Fix useLayoutEffect warning

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,8 @@
 import Document from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
+import React from 'react';
+
+React.useLayoutEffect = typeof document !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
 export default class MyDocument extends Document {
     static async getInitialProps(ctx) {


### PR DESCRIPTION
Fix the Warning: useLayoutEffect does nothing on the server by replacing useLayoutEffect with useEffect when the document has not yet been created.

Closes #258 