### PR TITLE
fixed bug when get specific revisions

### DIFF
--- a/server/claim-revision/claim-revision.service.ts
+++ b/server/claim-revision/claim-revision.service.ts
@@ -25,10 +25,11 @@ export class ClaimRevisionService {
     }
 
     /** get ClaimRevision by ID */
-    getRevision(claimId) {
+    getRevision(match) {
         try {
-            return this.ClaimRevisionModel.findById(claimId)
+            return this.ClaimRevisionModel.findOne(match)
                 .populate("personality", "_id name")
+                .lean()
         } catch {
             throw new NotFoundException()
         }

--- a/server/claim/claim.service.ts
+++ b/server/claim/claim.service.ts
@@ -166,7 +166,7 @@ export class ClaimService {
             // This line may cause a false positive in sonarCloud because if we remove the await, we cannot iterate through the results
             const revision = await this.claimRevisionService.getRevision({
                 _id: revisionId,
-                personality: match.personality
+                claimId: rawClaim._id
             })
 
             if (!revision || !rawClaim) {


### PR DESCRIPTION
Previously when we tried to get a specific revision of a claim and provided an revision id of another claim, we are not redirected to 404 page