### PR TITLE
Fix mobile carousel

### DIFF
--- a/src/components/Home/HomeCarousel.style.tsx
+++ b/src/components/Home/HomeCarousel.style.tsx
@@ -6,6 +6,10 @@ const HomeCarouselStyle = styled(Row)`
         background: #222;
     }
 
+    .slick-slide > div > div > span {
+        min-height: 443px;
+    }
+
     .carousel-title-container {
         margin: 64px 0 32px 0;
     }
@@ -62,14 +66,14 @@ const HomeCarouselStyle = styled(Row)`
             order: 3;
             display: flex;
         }
-        
+
         .stats-container {
             order: 2;
             flex-direction: column;
             margin: 0 0 16px 0;
             height: auto;
         }
-        
+
         .ant-col-7.stats-child-container {
             max-width: 100%;
             margin-left: 0;
@@ -124,8 +128,8 @@ const HomeCarouselStyle = styled(Row)`
     @media (max-width: 610px) {
         .carousel-subtitle-container {
             width: 100%;
-        }   
-        
+        }
+
         .CTA-container {
             display: grid;
             grid-template-columns: 1fr 1fr;

--- a/src/components/Home/HomeCarousel.tsx
+++ b/src/components/Home/HomeCarousel.tsx
@@ -2,6 +2,7 @@ import { Carousel, Col, Row } from 'antd';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
 import React from 'react';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 import colors from '../../styles/colors';
 import CTASection from './CTASection';
@@ -9,7 +10,9 @@ import HomeCarouselStyle from './HomeCarousel.style';
 import HomeStats from './HomeStats';
 
 const HomeCarousel = ({ isLoggedIn, personalities, stats }) => {
-    const { t } = useTranslation();
+    const isMobile = useMediaQuery("(max-width: 767px)")
+
+    const { t } = useTranslation()
 
     return (
         <HomeCarouselStyle>
@@ -40,13 +43,12 @@ const HomeCarousel = ({ isLoggedIn, personalities, stats }) => {
                                     width="100%"
                                     height="100%"
                                     layout="responsive"
-                                    objectFit="contain"
-                                    objectPosition={"center calc(443px / 2 * -1)"}
+                                    objectFit={isMobile ? "cover" : "contain"}
+                                    objectPosition={`center ${isMobile ? '-50px' : 'calc(443px / 2 * -1)'}`}
                                     style={{
                                         color: colors.white,
                                         lineHeight: "160px",
                                         textAlign: "center",
-                                        width: "auto",
                                         filter: "grayscale(100%)",
                                         background: 'none',
                                     }}
@@ -97,7 +99,7 @@ const HomeCarousel = ({ isLoggedIn, personalities, stats }) => {
                                     margin: 0,
                                 }}
                             >
-                                <span className="carousel-subtitle">{t("home:subtitle0")}</span>
+                                <span className="carousel-subtitle">{t("home:subtitle0")}</span>{' '}
                                 <span className="carousel-subtitle">{t("home:subtitle1")}</span>
                             </h2>
                         </Row>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+
+/**
+ * This hook allows to use media queries outside of styled components or style props
+ * @param query in the style of css media queries
+ * @returns true if window state matches the query, false otherwise
+ * @example useMediaQuery("(max-width: 600px)")
+ *  will return true if window width is 600px or smaller and false otherwise
+ */
+export function useMediaQuery(query: string): boolean {
+    const [matches, setMatches] = useState(false);
+
+    useEffect(() => {
+        const media = window.matchMedia(query);
+
+        if (media.matches !== matches) {
+            setMatches(media.matches);
+        }
+        const listener = () => {
+            setMatches(media.matches);
+        };
+
+        // subscribe to changes in window state
+        media.addEventListener("change", listener);
+        return () => media.removeEventListener("change", listener);
+    }, [matches, query]);
+
+    return matches;
+}


### PR DESCRIPTION
- Created a custom hook to allow us to use media queries outside of styled components or style props.
- Used the new hook to adjust the object-fit and object-position of the carousel image when the window is smaller than 768px, which is the ant design's breakpoint between small and medium.

400px
![image](https://user-images.githubusercontent.com/8875518/180082985-da61b0c5-a757-4087-928a-8f09330caab3.png)

700px 
![image](https://user-images.githubusercontent.com/8875518/180082862-560a9b4d-f4bc-49c4-8324-33b8d6302768.png)

1440px
![image](https://user-images.githubusercontent.com/8875518/180083122-c51b06ab-77d5-4e87-9cf1-3547ea89c2a1.png)
