### PR TITLE
Reorganize tests to use fixture files

### DIFF
--- a/cypress/fixtures/claim.ts
+++ b/cypress/fixtures/claim.ts
@@ -1,0 +1,8 @@
+const claim = {
+    title: "Cantora e Dançarina?",
+    content: "Ela é uma ótima dançarina e cantora",
+    source: "http://wikipedia.org",
+    slug: "cantora-e-dancarina"
+}
+
+export default claim

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/fixtures/personality.ts
+++ b/cypress/fixtures/personality.ts
@@ -1,0 +1,6 @@
+const personality = {
+    name: 'Beyoncé',
+    slug: 'beyonce'
+}
+
+export default personality;

--- a/cypress/fixtures/review.ts
+++ b/cypress/fixtures/review.ts
@@ -1,0 +1,13 @@
+const review = {
+    username: 'User',
+    summary: "Conclusion summary content",
+    question1: "Question 1 content",
+    question2: "Question 2 content",
+    report: "Verification Report content",
+    process: "Verification process content",
+    source1: "http://wikipedia.org",
+    source2: "http://google.com",
+    classification: 'Arguable'
+}
+
+export default review

--- a/cypress/fixtures/user.ts
+++ b/cypress/fixtures/user.ts
@@ -1,0 +1,6 @@
+const user = {
+    email: 'test@aletheiafact.org',
+    password: 'TEST_USER_PASS'
+}
+
+export default user;

--- a/cypress/integration/tests/home.spec.ts
+++ b/cypress/integration/tests/home.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 
-import locators from "../../support/locator";
+import user from "../../fixtures/user";
+import locators from "../../support/locators";
 
 describe("Test the side menu routes", () => {
     it("Open side bar and Login", () => {
@@ -10,37 +11,37 @@ describe("Test the side menu routes", () => {
         cy.title().should("contain", "AletheiaFact.org");
         cy.get("#rcc-confirm-button").click();
 
-        cy.get(locators.MENU.SIDE_MENU).click();
+        cy.get(locators.menu.SIDE_MENU).click();
         cy.get("[data-cy=testMyAccountItem]").click();
-        cy.get(locators.LOGIN.USER).type("test@aletheiafact.org");
-        cy.get(locators.LOGIN.PASSWORD).type("TEST_USER_PASS");
-        cy.get(locators.LOGIN.BTN_LOGIN).click();
+        cy.get(locators.login.USER).type(user.email);
+        cy.get(locators.login.PASSWORD).type(user.password);
+        cy.get(locators.login.BTN_LOGIN).click();
     });
 
     it("Open side bar and click about", () => {
-        cy.get(locators.MENU.SIDE_MENU).click();
+        cy.get(locators.menu.SIDE_MENU).click();
         cy.get("[data-cy=testAboutItem]").click();
     });
 
     it("Open side bar and click privacy policy", () => {
-        cy.get(locators.MENU.SIDE_MENU).click();
+        cy.get(locators.menu.SIDE_MENU).click();
         cy.get("[data-cy=testPrivacyPolicyItem]").click();
     });
 
     it("Open side bar and click code of conduct", () => {
-        cy.get(locators.MENU.SIDE_MENU).click();
+        cy.get(locators.menu.SIDE_MENU).click();
         cy.get("[data-cy=testCodeOfConductItem]").should("contain", "Condu");
         cy.get("[data-cy=testCodeOfConductItem]").click();
     });
 
     it("Should not show log out when not logged in", () => {
-        cy.get(locators.MENU.SIDE_MENU).click();
+        cy.get(locators.menu.SIDE_MENU).click();
         cy.get("[data-cy=testLogout]").should("not.exist");
     });
 
     it("Should be able to log out when logged in", () => {
         cy.login();
-        cy.get(locators.MENU.SIDE_MENU).click();
+        cy.get(locators.menu.SIDE_MENU).click();
         cy.get("[data-cy=testLogout]").should("exist").click();
         cy.url().should(
             "contains",

--- a/cypress/integration/tests/personality.spec.ts
+++ b/cypress/integration/tests/personality.spec.ts
@@ -1,26 +1,28 @@
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 
-import locators from "../../support/locator";
+import locators from "../../support/locators";
+import claim from "../../fixtures/claim";
+import personality from "../../fixtures/personality";
 
 describe("Create personality and claim", () => {
     beforeEach('login', () => { cy.login() });
 
     it("Should search and create a new Personality", () => {
-        cy.get(locators.PERSONALITY.BTN_SEE_MORE_PERSONALITY).should('exist').click();
-        cy.get(locators.PERSONALITY.BTN_ADD_PERSONALITY).click();
-        cy.get(locators.PERSONALITY.INPUT_SEARCH_PERSONALITY).type("beyonce");
-        cy.get("[data-cy=Beyoncé]").click();
+        cy.get(locators.personality.BTN_SEE_MORE_PERSONALITY).should('exist').click();
+        cy.get(locators.personality.BTN_ADD_PERSONALITY).click();
+        cy.get(locators.personality.INPUT_SEARCH_PERSONALITY).type(personality.slug);
+        cy.get(`${locators.personality.SELECT_PERSONALITY}`).click();
     });
 
     it("Should create a Claim", () => {
-        cy.get(locators.PERSONALITY.BTN_SEE_MORE_PERSONALITY)
+        cy.get(locators.personality.BTN_SEE_MORE_PERSONALITY)
             .should("be.visible")
             .click();
-        cy.get("[data-cy=Beyoncé] > *").should("be.visible").click();
+        cy.get(`${locators.personality.SELECT_PERSONALITY} > *`).should("be.visible").click();
         cy.url().should(
             "contains",
-            "http://localhost:3000/personality/beyonce"
+            `http://localhost:3000/personality/${personality.slug}`
         );
 
         cy.get("[data-cy=testButtonAddClaim] > .anticon")
@@ -29,18 +31,18 @@ describe("Create personality and claim", () => {
 
         cy.get("[ data-cy=testTitleClaimForm]")
             .should("be.visible")
-            .type("Cantora e Dançarina?");
+            .type(claim.title);
 
         cy.get("[data-cy=testContentClaim]")
             .should("be.visible")
-            .type("Ele é uma ótima dançarina e cantora");
+            .type(claim.content);
 
         cy.get("[data-cy=dataAserSelecionada]").should("be.visible").click();
         cy.get('table.ant-picker-content').contains('7').should("be.visible").click();
 
         cy.get("[data-cy=testSource1]")
             .should("be.visible")
-            .type("http://wikipedia.org");
+            .type(claim.source);
 
         cy.get("[data-cy=testCheckboxAcceptTerms]").click();
 
@@ -48,7 +50,7 @@ describe("Create personality and claim", () => {
         cy.get("[data-cy=testSaveButton]").click();
         cy.url().should(
             "contains",
-            "http://localhost:3000/personality/beyonce/claim/cantora-e-dancarina"
+            `http://localhost:3000/personality/${personality.slug}/claim/${claim.slug}`
         );
     });
 });

--- a/cypress/integration/tests/review.spec.ts
+++ b/cypress/integration/tests/review.spec.ts
@@ -1,36 +1,43 @@
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 
-import locators from "../../support/locator";
+import claim from "../../fixtures/claim";
+import personality from "../../fixtures/personality";
+import review from "../../fixtures/review";
+import locators from "../../support/locators";
+
+const goToClaimReviewPage = () => {
+    cy.get(locators.personality.BTN_SEE_MORE_PERSONALITY)
+        .should("be.visible")
+        .click();
+    cy.get(`${locators.personality.SELECT_PERSONALITY} > *`).should("be.visible").click();
+    cy.url().should(
+        "contains",
+        `http://localhost:3000/personality/${personality.slug}`
+    );
+    cy.get('[data-cy=testSeeFullSpeech]').click()
+    cy.url().should("contains", `http://localhost:3000/personality/${personality.slug}/claim/${claim.slug}`)
+    cy.get('[data-cy=frase1]').click()
+    cy.url().should('contains', `http://localhost:3000/personality/${personality.slug}/claim/${claim.slug}/sentence`)
+}
 
 describe("Test claim review", () => {
     it('should not show start review when not logged in', () => {
-        cy.visit('http://localhost:3000/personality/beyonce/claim/cantora-e-dancarina')
+        cy.visit(`http://localhost:3000/personality/${personality.slug}/claim/${claim.slug}`)
         cy.get('[data-cy=frase1]').click()
-        cy.url().should('contains', 'http://localhost:3000/personality/beyonce/claim/cantora-e-dancarina/sentence')
-        cy.get(locators.CLAIM_REVIEW.BTN_START_CLAIM_REVIEW).should('not.exist')
+        cy.url().should('contains', `http://localhost:3000/personality/${personality.slug}/claim/${claim.slug}/sentence`)
+        cy.get(locators.claimReview.BTN_START_CLAIM_REVIEW).should('not.exist')
     })
 
-    it('should show start review and recaptcha when logged in', () => {
+    it('should be able to assign a user', () => {
         cy.login()
-        cy.get(locators.PERSONALITY.BTN_SEE_MORE_PERSONALITY)
-            .should("be.visible")
-            .click();
-        cy.get("[data-cy=Beyoncé] > *").should("be.visible").click();
-        cy.url().should(
-            "contains",
-            "http://localhost:3000/personality/beyonce"
-        );
-        cy.get('[data-cy=testSeeFullSpeech]').click()
-        cy.url().should("contains", 'http://localhost:3000/personality/beyonce/claim/cantora-e-dancarina')
-        cy.get('[data-cy=frase1]').click()
-        cy.url().should('contains', 'http://localhost:3000/personality/beyonce/claim/cantora-e-dancarina/sentence')
-        cy.get(locators.CLAIM_REVIEW.BTN_START_CLAIM_REVIEW).should('exist').click()
-        cy.get('[data-cy=testClaimReviewuserId]').should('exist').type("user", {delay: 200})
-        cy.contains("User").first().click()
+        goToClaimReviewPage()
+        cy.get(locators.claimReview.BTN_START_CLAIM_REVIEW).should('exist').click()
+        cy.get(locators.claimReview.INPUT_USER).should('exist').type(review.username, { delay: 200 })
+        cy.contains(review.username).first().click()
         cy.get('[title="reCAPTCHA"]').should('exist')
-        cy.get('[data-cy=testClaimReviewASSIGN_USER]').should('be.disabled')
+        cy.get(locators.claimReview.BTN_ASSIGN_USER).should('be.disabled')
         cy.checkRecaptcha()
-        cy.get('[data-cy=testClaimReviewASSIGN_USER]').should('be.enabled')
+        cy.get(locators.claimReview.BTN_ASSIGN_USER).should('be.enabled').click()
     })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,10 +1,11 @@
-import locators from "./locator";
+import user from "../fixtures/user";
+import locators from "./locators";
 
 Cypress.Commands.add('login', () => {
     cy.visit("http://localhost:3000/login");
-    cy.get(locators.LOGIN.USER).type("test@aletheiafact.org");
-    cy.get(locators.LOGIN.PASSWORD).type("TEST_USER_PASS");
-    cy.get(locators.LOGIN.BTN_LOGIN).click();
+    cy.get(locators.login.USER).type(user.email);
+    cy.get(locators.login.PASSWORD).type(user.password);
+    cy.get(locators.login.BTN_LOGIN).click();
     cy.intercept("/api/.ory/sessions/whoami").as("confirmLogin");
     cy.wait("@confirmLogin", { timeout: 10000 });
 })

--- a/cypress/support/locators.ts
+++ b/cypress/support/locators.ts
@@ -1,21 +1,26 @@
+import personality from "../fixtures/personality";
+
 const locators = {
-    LOGIN: {
+    login: {
         USER: "#basic_email",
         PASSWORD: "#basic_password",
         BTN_LOGIN: "[data-cy=loginButton]",
     },
 
-    PERSONALITY: {
+    personality: {
         BTN_SEE_MORE_PERSONALITY: "[data-cy=testSeeMorePersonality]",
         BTN_ADD_PERSONALITY: "[data-cy=testButtonCreatePersonality]",
         INPUT_SEARCH_PERSONALITY: "[data-cy=testInputSearchPersonality]",
+        SELECT_PERSONALITY: `[data-cy=${personality.name}]`
     },
 
-    CLAIM_REVIEW: {
+    claimReview: {
         BTN_START_CLAIM_REVIEW: "[data-cy=testAddReviewButton]",
+        INPUT_USER: "[data-cy=testClaimReviewuserId]",
+        BTN_ASSIGN_USER: "[data-cy=testClaimReviewASSIGN_USER]",
     },
 
-    MENU: {
+    menu: {
         SIDE_MENU: "[data-cy=testSideMenuClosed]"
     }
 };


### PR DESCRIPTION
This should make it easier to maintain tests by separating out any data that will be typed, such as the content of claims and reviews, or variable text that will be checked, such as the slugs of personality names and claim titles