### PR TITLE
Fix MongoDB deprecation warning

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -5,6 +5,7 @@ import Logger from "./logger";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { ValidationPipe } from "@nestjs/common";
 const cookieParser = require("cookie-parser");
+const mongoose = require("mongoose");
 
 const initApp = async (options) => {
     const corsOptions = {
@@ -23,14 +24,16 @@ const initApp = async (options) => {
         }
     );
 
+    mongoose.set("useCreateIndex", true);
+
     app.useGlobalPipes(
         new ValidationPipe({
             transform: true,
-            transformOptions: {enableImplicitConversion: true},
+            transformOptions: { enableImplicitConversion: true },
             whitelist: true,
             forbidNonWhitelisted: true,
-        }),
-    )
+        })
+    );
 
     app.use(cookieParser());
     app.useStaticAssets(join(__dirname, "..", "public"));


### PR DESCRIPTION
Fix collection.ensureIndex MongoDB deprecation warning
```
(node:49) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
(Use node --trace-deprecation ... to show where the warning was created)
```

### I think i resolve this warning, see the build console to be sure
![image](https://user-images.githubusercontent.com/73478823/181135128-8ddbf7f8-8003-4884-aeaf-f248b8795b2e.png)
![image](https://user-images.githubusercontent.com/73478823/181135172-45d38763-b21e-405a-bd9f-2eeb3d33e322.png)

closes #588 