### PR TITLE
Fix sentence hash in sitemap

### DIFF
--- a/server/sitemap/sitemap.service.ts
+++ b/server/sitemap/sitemap.service.ts
@@ -46,15 +46,14 @@ export class SitemapService {
                     url: `/personality/${personality.slug}/claim/${claim.slug}`,
                 });
                 // This line may cause a false positive in sonarCloud because if we remove the await, we cannot iterate through the results
-                //TODO: maybe with the changes, we have to change something
                 const reviews =
                     await this.claimReviewService.getReviewsByClaimId(
                         claim._id
                     );
                 for (const review of reviews) {
                     sites.push({
-                        url: `/personality/${personality.slug}/claim/${claim.slug}/sentence/${review._id}`,
-                        priority: 0.9,
+                        url: `/personality/${personality.slug}/claim/${claim.slug}/sentence/${review._id.sentence_hash}`,
+                        priority: 1,
                     });
                 }
             }


### PR DESCRIPTION
Fix the url for claim reviews in the sitemap by getting the correct nested prop of the review object.
Change the priority for the review page from 0.9 to 1, the highest possible.
![image](https://user-images.githubusercontent.com/8875518/183087385-0aaac975-f9da-49d9-bde1-0110f00d7545.png)

Closes #641 