### PR TITLE
Fix kanban query error

### DIFF
--- a/server/claim-review-task/claim-review-task.controller.ts
+++ b/server/claim-review-task/claim-review-task.controller.ts
@@ -25,7 +25,7 @@ export class ClaimReviewController {
         private claimReviewTaskService: ClaimReviewTaskService,
         private captchaService: CaptchaService,
         private viewService: ViewService
-    ) { }
+    ) {}
 
     @IsPublic()
     @Get("api/claimreviewtask")
@@ -33,7 +33,6 @@ export class ClaimReviewController {
         const { page = 0, pageSize = 10, order = 1, value } = getTasksDTO;
         return Promise.all([
             this.claimReviewTaskService.listAll(page, pageSize, order, value),
-            // This should count the number of documents for the original query without pagination
             this.claimReviewTaskService.count({ "machine.value": value }),
         ]).then(([tasks, totalTasks]) => {
             const totalPages = Math.ceil(totalTasks / pageSize);

--- a/server/claim-review-task/claim-review-task.service.ts
+++ b/server/claim-review-task/claim-review-task.service.ts
@@ -30,7 +30,7 @@ export class ClaimReviewTaskService {
 
     async listAll(page, pageSize, order, value) {
         const reviewTasks = await this.ClaimReviewTaskModel.find({
-            "machine.value": value,
+            [`machine.value.${value}`]: { $exists: true },
         })
             .skip(page * pageSize)
             .limit(pageSize)


### PR DESCRIPTION
- Since we save machine value as an object we need to query by key value
![image](https://user-images.githubusercontent.com/73478823/183501362-f612cf6c-9296-4d43-809a-3fa3ebdb45c9.png)
- Now we can differentiate if the task is in draft or not
