### PR TITLE
Added space between sentences in the claim page and claim card

### DIFF
--- a/src/components/Claim/ClaimCard.tsx
+++ b/src/components/Claim/ClaimCard.tsx
@@ -26,10 +26,10 @@ const ClaimCard = ({ personality, claim }) => {
         let textContent = "";
         claim.content.forEach((paragraph) => {
             paragraph.content.forEach((sentence) => {
-                return (textContent += sentence.content);
+                return (textContent += `${sentence.content} `);
             });
         });
-        setClaimContent(textContent);
+        setClaimContent(textContent.trim());
     };
 
     useEffect(() => {

--- a/src/components/Claim/ClaimSentence.tsx
+++ b/src/components/Claim/ClaimSentence.tsx
@@ -14,12 +14,18 @@ const ClaimSentence = styled.a`
     }
 `;
 
-const Sentence = ({ showHighlights, properties, data_hash, content, generateHref }) => {
+const Sentence = ({
+    showHighlights,
+    properties,
+    data_hash,
+    content,
+    generateHref,
+}) => {
     let style = {};
     if (properties.classification && showHighlights) {
         style = {
             ...style,
-            backgroundColor: highlightColors[properties.classification]
+            backgroundColor: highlightColors[properties.classification],
         };
     }
     const href = generateHref({ data_hash });
@@ -33,17 +39,16 @@ const Sentence = ({ showHighlights, properties, data_hash, content, generateHref
                 className="claim-sentence"
                 data-cy={`frase${properties.id}`}
             >
-                {content}
+                {content}{" "}
             </ClaimSentence>
             {properties.classification && showHighlights && (
                 <sup
                     style={{
-                        color:
-                            highlightColors[properties.classification],
+                        color: highlightColors[properties.classification],
                         fontWeight: 600,
                         fontSize: "14px",
                         lineHeight: "22px",
-                        paddingLeft: "5px"
+                        paddingLeft: "5px",
                     }}
                 >
                     {1}
@@ -51,6 +56,6 @@ const Sentence = ({ showHighlights, properties, data_hash, content, generateHref
             )}
         </>
     );
-}
+};
 
 export default Sentence;


### PR DESCRIPTION
### Background Image

In Claim Page 

![image](https://user-images.githubusercontent.com/93331277/183726064-0f2db524-f371-4535-abba-f1a1d09ef997.png)

In Claim Card

![image](https://user-images.githubusercontent.com/93331277/183726728-0b52eaa8-8a17-49cf-8894-531606ba2a51.png)
