### PR TITLE
Refactor getClaimReviewPage

### DIFF
--- a/server/claim-review/claim-review.service.ts
+++ b/server/claim-review/claim-review.service.ts
@@ -42,23 +42,6 @@ export class ClaimReviewService {
         return this.ClaimReviewModel.countDocuments().where(query);
     }
 
-    async getReviewStatsBySentenceHash(match: any) {
-        const reviews = await this.ClaimReviewModel.aggregate([
-            { $match: match },
-            {
-                $lookup: {
-                    from: "reports",
-                    localField: "report",
-                    foreignField: "_id",
-                    as: "report",
-                },
-            },
-            { $group: { _id: "$report.classification", count: { $sum: 1 } } },
-            { $sort: { count: -1 } },
-        ]);
-        return this.util.formatStats(reviews);
-    }
-
     async getReviewStatsByClaimId(claimId) {
         const reviews = await this.ClaimReviewModel.aggregate([
             { $match: { claim: claimId, isDeleted: false, isPublished: true } },
@@ -165,7 +148,9 @@ export class ClaimReviewService {
     async getReviewBySentenceHash(
         sentence_hash: string
     ): Promise<LeanDocument<ClaimReviewDocument>> {
-        return await this.ClaimReviewModel.findOne({ sentence_hash }).lean();
+        return await this.ClaimReviewModel.findOne({ sentence_hash })
+            .populate("report")
+            .lean();
     }
 
     async getReport(match): Promise<LeanDocument<ReportDocument>> {

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -155,7 +155,7 @@ export class ClaimController {
         );
     }
 
-    @Get("personality/:slug/claim/create/")
+    @Get("personality/:personalitySlug/claim/create/")
     public async claimCreatePage(@Req() req: Request, @Res() res: Response) {
         const { personalitySlug } = req.params;
         const parsedUrl = parse(req.url, true);

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -4,7 +4,6 @@ import {
     Delete,
     Get,
     Logger,
-    NotFoundException,
     Param,
     Post,
     Put,

--- a/server/personality/personality.controller.ts
+++ b/server/personality/personality.controller.ts
@@ -112,10 +112,11 @@ export class PersonalityController {
     ) {
         const parsedUrl = parse(req.url, true);
 
-        const personality = await this.personalityService.getBySlug(
-            req.params.slug,
-            req.language
-        );
+        const personality =
+            await this.personalityService.getClaimsPersonalityBySlug(
+                req.params.slug,
+                req.language
+            );
 
         const { personalities } = await this.personalityService.combinedListAll(
             {
@@ -158,19 +159,18 @@ export class PersonalityController {
     ) {
         const parsedUrl = parse(req.url, true);
 
-        const personality = await this.personalityService.getBySlug(
-            req.params.slug
-        );
-        await this.viewService
-            .getNextServer()
-            .render(
-                req,
-                res,
-                "/history-page",
-                Object.assign(parsedUrl.query, {
-                    targetId: personality._id,
-                    targetModel: TargetModel.Personality,
-                })
+        const personality =
+            await this.personalityService.getClaimsPersonalityBySlug(
+                req.params.slug
             );
+        await this.viewService.getNextServer().render(
+            req,
+            res,
+            "/history-page",
+            Object.assign(parsedUrl.query, {
+                targetId: personality._id,
+                targetModel: TargetModel.Personality,
+            })
+        );
     }
 }

--- a/server/sentence/sentence.module.ts
+++ b/server/sentence/sentence.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
+import { ReportModule } from "../report/report.module";
 import { Sentence, SentenceSchema } from "./schemas/sentence.schema";
 import { SentenceService } from "./sentence.service";
 
@@ -11,7 +12,7 @@ const SentenceModel = MongooseModule.forFeature([
 ]);
 
 @Module({
-    imports: [SentenceModel],
+    imports: [SentenceModel, ReportModule],
     providers: [SentenceService],
     exports: [SentenceService],
 })

--- a/server/sentence/sentence.service.ts
+++ b/server/sentence/sentence.service.ts
@@ -1,13 +1,15 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { Model } from "mongoose";
 import { SentenceDocument, Sentence } from "./schemas/sentence.schema";
 import { InjectModel } from "@nestjs/mongoose";
+import { ReportService } from "../report/report.service";
 
 @Injectable()
 export class SentenceService {
     constructor(
         @InjectModel(Sentence.name)
-        private SentenceModel: Model<SentenceDocument>
+        private SentenceModel: Model<SentenceDocument>,
+        private reportService: ReportService
     ) {}
 
     async create(sentenceBody) {
@@ -15,7 +17,18 @@ export class SentenceService {
         return newSentence._id;
     }
 
-    getByDataHash(data_hash) {
-        return this.SentenceModel.findOne({ data_hash });
+    async getByDataHash(data_hash) {
+        //Fix me
+        const report = await this.reportService.findBySentenceHash(data_hash);
+        const sentence = await this.SentenceModel.findOne({ data_hash });
+        if (sentence) {
+            sentence.props = {
+                classification: report?.classification,
+                ...sentence.props,
+            };
+            return sentence;
+        } else {
+            throw new NotFoundException();
+        }
     }
 }

--- a/src/components/ClaimReview/ClaimReviewView.tsx
+++ b/src/components/ClaimReview/ClaimReviewView.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import ClaimSentenceCard from "./ClaimSentenceCard";
 import { Col, Row } from "antd";
-import ClassificationText from "../ClassificationText";
 import { useTranslation } from "next-i18next";
 import colors from "../../styles/colors";
 import Button, { ButtonType } from "../Button";
@@ -16,14 +15,12 @@ const ClaimReviewView = ({
     href,
     claimReviewTask,
     isLoggedIn,
-    review,
     sitekey,
 }) => {
     const { t } = useTranslation();
     const claimId = claim._id;
     const personalityId = personality._id;
     const sentenceHash = sentence.data_hash;
-    const stats = sentence?.stats;
     const [formCollapsed, setFormCollapsed] = useState(
         claimReviewTask ? false : true
     );
@@ -45,85 +42,40 @@ const ClaimReviewView = ({
             >
                 <ClaimSentenceCard
                     personality={personality}
-                    sentence={sentence}
+                    date={claim.date}
+                    content={sentence?.content}
                     summaryClassName="claim-review"
                     claimType={claim?.type}
                 />
-                {review && (
-                    <Row
-                        style={{
-                            justifyContent: "center",
-                            flexWrap: "wrap",
-                            width: "100%",
-                            paddingBottom: "1em",
-                        }}
-                    >
-                        <div
-                            style={{
-                                display: "flex",
-                                width: "100%",
-                                justifyContent: "center",
-                            }}
-                        >
-                            <p style={{ marginBottom: 0 }}>
-                                {t("claimReview:claimReview")}&nbsp;
-                            </p>
-                            <ClassificationText
-                                classification={sentence.props?.classification}
-                            />
-                        </div>
-                    </Row>
-                )}
                 {formCollapsed && (
                     <Row
                         style={{
                             width: "100%",
                             padding: "0px 0px 15px 0px",
-                            justifyContent: "space-between",
+                            justifyContent: "center",
                         }}
                     >
-                        {!sentence.userReview && (
-                            <>
-                                <span
-                                    style={{
-                                        fontSize: "14px",
-                                    }}
+                        <>
+                            {isLoggedIn && (
+                                <Button
+                                    type={ButtonType.blue}
+                                    onClick={toggleFormCollapse}
+                                    icon={<PlusOutlined />}
+                                    data-cy={"testAddReviewButton"}
                                 >
-                                    {t("claim:metricsHeaderInfo", {
-                                        totalReviews: stats?.total,
-                                    })}
-                                </span>{" "}
-                                <br />
-                                {review && (
-                                    <span
-                                        style={{
-                                            fontSize: "10px",
-                                        }}
-                                    >
-                                        {t("claim:cardOverallReviewPrefix")}{" "}
-                                        <ClassificationText
-                                            classification={
-                                                review?.classification
-                                            }
-                                        />
-                                        ({review?.count})
-                                    </span>
-                                )}
-                                {!review && isLoggedIn && (
-                                    <Button
-                                        type={ButtonType.blue}
-                                        onClick={toggleFormCollapse}
-                                        icon={<PlusOutlined />}
-                                        data-cy={"testAddReviewButton"}
-                                    >
-                                        {t("claimReviewForm:addReviewButton")}
-                                    </Button>
-                                )}
-                            </>
-                        )}
+                                    {t("claimReviewForm:addReviewButton")}
+                                </Button>
+                            )}
+                        </>
                     </Row>
                 )}
-                <Col style={{ display: "flex", justifyContent: "center" }}>
+                <Col
+                    style={{
+                        display: "flex",
+                        justifyContent: "center",
+                        padding: "0px 0px 15px 0px",
+                    }}
+                >
                     {!isLoggedIn && (
                         <Button href="/login">
                             {t("claimReviewForm:loginButton")}

--- a/src/components/ClaimReview/ClaimSentenceCard.tsx
+++ b/src/components/ClaimReview/ClaimSentenceCard.tsx
@@ -6,12 +6,11 @@ import ClaimSummary from "../Claim/ClaimSummary";
 
 const ClaimSentenceCard = ({
     personality,
-    sentence,
+    date,
+    content,
     claimType,
     summaryClassName = "",
 }) => {
-    const content = sentence?.content;
-
     if (content) {
         return (
             <Col span={24}>
@@ -19,7 +18,7 @@ const ClaimSentenceCard = ({
                     author={
                         <ClaimCardHeader
                             personality={personality}
-                            date={sentence?.date}
+                            date={date}
                             claimType={claimType}
                         />
                     }

--- a/src/pages/claim-review.tsx
+++ b/src/pages/claim-review.tsx
@@ -9,19 +9,21 @@ import { ClassificationEnum, ReviewTaskStates } from "../machine/enums";
 import { GetLocale } from "../utils/GetLocale";
 
 const ClaimReviewPage: NextPage<{
-    personality;
-    claim;
-    sentence;
-    sitekey;
-    href;
-    claimReviewTask;
-    isLoggedIn;
+    personality: any;
+    claim: any;
+    sentence: any;
+    sitekey: string;
+    href: string;
+    claimReviewTask: any;
+    claimReview: any;
+    isLoggedIn: boolean;
 }> = ({
     personality,
     claim,
     sentence,
     href,
     claimReviewTask,
+    claimReview,
     isLoggedIn,
     sitekey,
 }) => {
@@ -78,7 +80,6 @@ const ClaimReviewPage: NextPage<{
                     href={href}
                     claimReviewTask={claimReviewTask}
                     isLoggedIn={isLoggedIn}
-                    review={review}
                     sitekey={sitekey}
                 />
             ) : (
@@ -87,7 +88,7 @@ const ClaimReviewPage: NextPage<{
                     claim={claim}
                     sentence={sentence}
                     href={href}
-                    context={claimReviewTask.machine.context.reviewData}
+                    context={claimReview.report}
                 />
             )}
         </>
@@ -105,6 +106,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             claim: JSON.parse(JSON.stringify(query.claim)),
             sentence: JSON.parse(JSON.stringify(query.sentence)),
             claimReviewTask: JSON.parse(JSON.stringify(query.claimReviewTask)),
+            claimReview: JSON.parse(JSON.stringify(query.claimReview)),
             sitekey: query.sitekey,
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
             isLoggedIn: req.user ? true : false,


### PR DESCRIPTION
- remove _getSentenceByHashAndClaimId function, since now we query claim review, which has the same fields
- create getPersonalityBySlug which just returns personality without population
- do the same to query the claim function
- remove unused getReviewStatsBySentenceHash() 'cause will be always one review/stats
- when get a sentence to try to inject classification into props
- remove useless code in claimReviewView