### PR TITLE
The captcha component gets the sitekey from redux

### DIFF
--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -160,6 +160,7 @@ export class ClaimController {
                 sentence,
                 claimReviewTask,
                 claimReview,
+                sitekey: this.configService.get<string>("recaptcha_sitekey"),
                 description,
             })
         );
@@ -183,6 +184,7 @@ export class ClaimController {
             "/claim-create",
             Object.assign(parsedUrl.query, {
                 personality,
+                sitekey: this.configService.get<string>("recaptcha_sitekey"),
             })
         );
     }
@@ -215,6 +217,7 @@ export class ClaimController {
             Object.assign(parsedUrl.query, {
                 personality,
                 claim,
+                sitekey: this.configService.get<string>("recaptcha_sitekey"),
             })
         );
     }

--- a/src/components/AletheiaCaptcha.tsx
+++ b/src/components/AletheiaCaptcha.tsx
@@ -5,7 +5,7 @@ import React, {
     useImperativeHandle,
 } from "react";
 import ReCAPTCHA from "react-google-recaptcha";
-import { SITEKEY } from "../lib/recaptcha";
+import { useAppSelector } from "../store/store";
 const recaptchaRef = React.createRef<ReCAPTCHA>();
 
 interface CaptchaProps {
@@ -22,6 +22,7 @@ const AletheiaCaptcha = forwardRef(({ onChange }: CaptchaProps, ref) => {
         },
     }));
 
+    const { sitekey } = useAppSelector((state) => state);
     const [captchaString, setCaptchaString] = useState("");
 
     const handleChangeCaptcha = async () => {
@@ -40,7 +41,7 @@ const AletheiaCaptcha = forwardRef(({ onChange }: CaptchaProps, ref) => {
     return (
         <ReCAPTCHA
             ref={recaptchaRef}
-            sitekey={SITEKEY}
+            sitekey={sitekey}
             onChange={handleChangeCaptcha}
             onExpired={onExpiredCaptcha}
         />

--- a/src/lib/recaptcha.ts
+++ b/src/lib/recaptcha.ts
@@ -1,1 +1,0 @@
-export const SITEKEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITEKEY;

--- a/src/pages/claim-create.tsx
+++ b/src/pages/claim-create.tsx
@@ -7,18 +7,18 @@ import ClaimCreate from "../components/Claim/ClaimCreate";
 import Seo from "../components/Seo";
 import { GetLocale } from "../utils/GetLocale";
 import { useDispatch } from "react-redux";
-import { ActionTypes } from "../store/types";
 
-const ClaimCreatePage: NextPage<{ personality; isLoggedIn }> = ({
+import actions from "../store/actions";
+
+const ClaimCreatePage: NextPage<{ sitekey; personality; isLoggedIn }> = ({
+    sitekey,
     personality,
     isLoggedIn,
 }) => {
     const { t } = useTranslation();
     const dispatch = useDispatch();
-    dispatch({
-        type: ActionTypes.SET_LOGIN_STATUS,
-        login: isLoggedIn,
-    });
+    dispatch(actions.setLoginStatus(isLoggedIn));
+    dispatch(actions.setSitekey(sitekey));
     return (
         <>
             <Seo
@@ -38,6 +38,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
     return {
         props: {
             ...(await serverSideTranslations(locale)),
+            sitekey: query.sitekey,
             // Nextjs have problems with client re-hydration for some serialized objects
             // This is a hack until a better solution https://github.com/vercel/next.js/issues/11993
             personality: JSON.parse(JSON.stringify(query.personality)),

--- a/src/pages/claim-page.tsx
+++ b/src/pages/claim-page.tsx
@@ -13,6 +13,7 @@ import { GetLocale } from "../utils/GetLocale";
 export interface ClaimPageProps {
     personality: any;
     claim: any;
+    sitekey: string;
     href: string;
     isLoggedIn: boolean;
     userRole: string;
@@ -20,13 +21,14 @@ export interface ClaimPageProps {
 }
 
 const ClaimPage: NextPage<ClaimPageProps> = (props) => {
-    const { personality, claim, isLoggedIn, userRole, userId } = props;
+    const { personality, claim, isLoggedIn, userRole, userId, sitekey } = props;
     const { t } = useTranslation();
     const dispatch = useDispatch();
 
     dispatch(actions.setLoginStatus(isLoggedIn));
     dispatch(actions.setUserId(userId));
     dispatch(actions.setUserRole(userRole));
+    dispatch(actions.setSitekey(sitekey));
 
     const jsonld = {
         "@context": "https://schema.org",
@@ -68,6 +70,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             claim: JSON.parse(JSON.stringify(query.claim)),
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
             isLoggedIn: req.user ? true : false,
+            sitekey: query.sitekey,
             userRole: req?.user?.role ? req?.user?.role : null,
             userId: req?.user?._id || "",
         },

--- a/src/pages/claim-review.tsx
+++ b/src/pages/claim-review.tsx
@@ -19,6 +19,7 @@ export interface ClaimReviewPageProps {
     personality: any;
     claim: any;
     sentence: any;
+    sitekey: string;
     href: string;
     claimReviewTask: any;
     claimReview: any;
@@ -40,11 +41,13 @@ const ClaimReviewPage: NextPage<ClaimReviewPageProps> = (props) => {
         isLoggedIn,
         userRole,
         userId,
+        sitekey,
     } = props;
 
     dispatch(actions.setLoginStatus(isLoggedIn));
     dispatch(actions.setUserId(userId));
     dispatch(actions.setUserRole(userRole));
+    dispatch(actions.setSitekey(sitekey));
     dispatch({
         type: ActionTypes.SET_AUTO_SAVE,
         autoSave: false,
@@ -134,6 +137,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             sentence: JSON.parse(JSON.stringify(query.sentence)),
             claimReviewTask: JSON.parse(JSON.stringify(query.claimReviewTask)),
             claimReview: JSON.parse(JSON.stringify(query.claimReview)),
+            sitekey: query.sitekey,
             description: query.description,
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
             isLoggedIn: req.user ? true : false,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -54,6 +54,10 @@ const actions = {
         type: ActionTypes.SET_USER_ROLE,
         role: role || Roles.Regular,
     }),
+    setSitekey: (sitekey) => ({
+        type: ActionTypes.SET_SITEKEY,
+        sitekey,
+    }),
 };
 
 export default actions;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -102,6 +102,12 @@ const reducer = (state, action) => {
                 ...state,
                 userId: action.userId,
             };
+        case ActionTypes.SET_SITEKEY:
+            return {
+                ...state,
+                sitekey: action.sitekey,
+            };
+
         default:
             return state;
     }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -17,6 +17,7 @@ export enum ActionTypes {
     SET_SELECTED_CLAIM,
     SET_SELECTED_SENTENCE,
     SET_USER_ID,
+    SET_SITEKEY,
 }
 
 export interface RootState {
@@ -39,4 +40,5 @@ export interface RootState {
     selectedClaim: any;
     selectedSentence: any;
     userId: string;
+    sitekey: string;
 }


### PR DESCRIPTION
Given some problems on the production environment we decided to go back to send the sitekey from the backend, but to avoid prop drilling we store the value in redux and only access it in the captcha component