### PR TITLE
Fixed creating two different personalities at once

### DIFF
--- a/src/components/Personality/PersonalityCard.tsx
+++ b/src/components/Personality/PersonalityCard.tsx
@@ -24,7 +24,8 @@ interface PersonalityCardProps {
     hoistAvatar?: boolean;
     style?: CSSProperties;
     selectPersonality?: any;
-    onClick?: (personality: any) => {};
+    isFormSubmitted?: boolean;
+    onClick?: any;
     titleLevel?: 1 | 2 | 3 | 4 | 5;
 }
 
@@ -41,10 +42,9 @@ const PersonalityCard = ({
     onClick,
     titleLevel = 1,
     selectPersonality = null,
+    isFormSubmitted,
 }: PersonalityCardProps) => {
     const isCreatingClaim = selectPersonality !== null;
-
-    const [isFormSubmitted, setIsFormSubmitted] = useState(false);
     const { vw } = useAppSelector((state) => state);
     const personalityFoundProps = isCreatingClaim
         ? {
@@ -54,7 +54,10 @@ const PersonalityCard = ({
                   }
               },
           }
-        : { href: `${hrefBase || "/personality/"}${personality.slug}` };
+        : {
+              href: `${hrefBase || "/personality/"}${personality.slug}`,
+              onClick,
+          };
 
     const { t } = useTranslation();
     const componentStyle = {
@@ -278,6 +281,7 @@ const PersonalityCard = ({
                                         type={ButtonType.blue}
                                         data-cy={personality.name}
                                         {...personalityFoundProps}
+                                        disabled={isFormSubmitted}
                                         style={{
                                             fontSize: "12px",
                                             lineHeight: "20px",
@@ -300,7 +304,6 @@ const PersonalityCard = ({
                                         type={ButtonType.blue}
                                         onClick={() => {
                                             if (!isFormSubmitted) {
-                                                setIsFormSubmitted(true);
                                                 onClick(personality);
                                             }
                                         }}

--- a/src/components/Personality/PersonalityCard.tsx
+++ b/src/components/Personality/PersonalityCard.tsx
@@ -1,7 +1,7 @@
 import { PlusOutlined } from "@ant-design/icons";
 import { Col, Divider, Row, Typography } from "antd";
 import { useTranslation } from "next-i18next";
-import React, { CSSProperties, useState } from "react";
+import React, { CSSProperties } from "react";
 
 import colors from "../../styles/colors";
 import AletheiaAvatar from "../AletheiaAvatar";

--- a/src/components/Personality/PersonalityCreateSearch.tsx
+++ b/src/components/Personality/PersonalityCreateSearch.tsx
@@ -38,7 +38,7 @@ const PersonalityCreateSearch = ({
         if (selectPersonality !== null) {
             createClaim();
         } else {
-            router.push(path);
+            router.push(path).catch((e) => e);
         }
     };
 

--- a/src/components/Personality/PersonalityCreateSearch.tsx
+++ b/src/components/Personality/PersonalityCreateSearch.tsx
@@ -28,16 +28,18 @@ const PersonalityCreateSearch = ({
             ...personality,
             ...personalityCreated,
         };
-        const createClaim = async () => {
+        const createClaim = () => {
             selectPersonality(newPersonality);
             setIsFormSubmitted(false);
         };
 
         // Redirect to personality list in case _id is not present
         const path = slug ? `/personality/${slug}` : "/personality";
-        selectPersonality !== null
-            ? createClaim().catch((e) => e)
-            : router.push(path);
+        if (selectPersonality !== null) {
+            createClaim();
+        } else {
+            router.push(path);
+        }
     };
 
     const onClickSeeProfile = () => {

--- a/src/components/Personality/PersonalityCreateSearch.tsx
+++ b/src/components/Personality/PersonalityCreateSearch.tsx
@@ -28,14 +28,16 @@ const PersonalityCreateSearch = ({
             ...personality,
             ...personalityCreated,
         };
-        const createClaim = () => {
+        const createClaim = async () => {
             selectPersonality(newPersonality);
             setIsFormSubmitted(false);
         };
 
         // Redirect to personality list in case _id is not present
         const path = slug ? `/personality/${slug}` : "/personality";
-        selectPersonality !== null ? createClaim() : router.push(path);
+        selectPersonality !== null
+            ? createClaim().catch((e) => e)
+            : router.push(path);
     };
 
     const onClickSeeProfile = () => {

--- a/src/components/Personality/PersonalitySearchResultSection.tsx
+++ b/src/components/Personality/PersonalitySearchResultSection.tsx
@@ -1,9 +1,6 @@
 import { Row } from "antd";
-import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import React from "react";
 
-import api from "../../api/personality";
 import Label from "../Label";
 import PersonalityCard from "./PersonalityCard";
 
@@ -11,28 +8,10 @@ const PersonalitySearchResultSection = ({
     personalities,
     label,
     selectPersonality,
+    isFormSubmitted,
+    onClick,
 }) => {
-    const { t } = useTranslation();
-    const router = useRouter();
-
     const isCreatingClaim = selectPersonality !== null;
-
-    const createPersonality = async (personality) => {
-        const personalityCreated = await api.createPersonality(personality, t);
-        const { slug } = personalityCreated;
-        const newPersonality = {
-            ...personality,
-            ...personalityCreated,
-        };
-        const createClaim = () => {
-            selectPersonality(newPersonality);
-        };
-
-        // Redirect to personality list in case _id is not present
-        const path = slug ? `/personality/${slug}` : "/personality";
-
-        isCreatingClaim ? createClaim() : router.push(path);
-    };
 
     return personalities.length ? (
         <Row
@@ -53,8 +32,9 @@ const PersonalitySearchResultSection = ({
                             summarized={true}
                             enableStats={false}
                             hrefBase="./"
-                            onClick={createPersonality}
+                            onClick={onClick}
                             key={i}
+                            isFormSubmitted={isFormSubmitted}
                         />
                     )
             )}


### PR DESCRIPTION
Avoid create more than one personality at once by quickly clicking on the add personality buttons.

closes #891 