### PR TITLE
Fixed Error on Kanban page at Aletheia Production

### DIFF
--- a/migrations/20230425092159-fix_debate_transition.ts
+++ b/migrations/20230425092159-fix_debate_transition.ts
@@ -48,17 +48,15 @@ export async function up(db: Db) {
                                         .findOne({
                                             _id: ObjectId(latestRevision),
                                         });
-                                    await db
-                                        .collection("speeches")
-                                        .updateOne(
-                                            { _id: ObjectId(contentId) },
-                                            {
-                                                $set: {
-                                                    personality:
-                                                        claim.personalities[0],
-                                                },
-                                            }
-                                        );
+                                    await db.collection("speeches").updateOne(
+                                        { _id: ObjectId(contentId) },
+                                        {
+                                            $set: {
+                                                personality:
+                                                    claim.personalities[0],
+                                            },
+                                        }
+                                    );
                                     return contentId;
                                 }
                             })
@@ -87,7 +85,12 @@ export async function up(db: Db) {
                                 .collection("claimreviews")
                                 .updateMany(
                                     { claim: ObjectId(claimId) },
-                                    { $set: { claim: claimRevision.claimId } }
+                                    {
+                                        $set: {
+                                            claim: claimRevision.claimId,
+                                            isDeleted: true,
+                                        },
+                                    }
                                 );
                         });
                     }
@@ -151,6 +154,17 @@ export async function down(db: Db) {
                             .updateOne(
                                 { _id: ObjectId(claimId) },
                                 { $set: { isDeleted: false } }
+                            );
+                        await db
+                            .collection("claimreviews")
+                            .updateMany(
+                                { claim: ObjectId(claimId) },
+                                {
+                                    $set: {
+                                        claim: claimRevision.claimId,
+                                        isDeleted: false,
+                                    },
+                                }
                             );
                     });
                 }

--- a/server/claim-review-task/claim-review-task.controller.ts
+++ b/server/claim-review-task/claim-review-task.controller.ts
@@ -48,7 +48,7 @@ export class ClaimReviewController {
                 value,
                 filterUser
             ),
-            this.claimReviewTaskService.count(
+            this.claimReviewTaskService.countReviewTasksNotDeleted(
                 getQueryMatchForMachineValue(value)
             ),
         ]).then(([tasks, totalTasks]) => {

--- a/server/mongo-pipelines/lookUpPersonalityties.ts
+++ b/server/mongo-pipelines/lookUpPersonalityties.ts
@@ -1,0 +1,17 @@
+export default function () {
+    return {
+        $lookup: {
+            from: "personalities",
+            let: {
+                personalityId: {
+                    $toObjectId: "$machine.context.claimReview.personality",
+                },
+            },
+            pipeline: [
+                { $match: { $expr: { $eq: ["$_id", "$$personalityId"] } } },
+                { $project: { slug: 1, name: 1, _id: 1 } },
+            ],
+            as: "machine.context.claimReview.personality",
+        },
+    };
+}

--- a/server/mongo-pipelines/lookupClaimReviews.ts
+++ b/server/mongo-pipelines/lookupClaimReviews.ts
@@ -1,0 +1,10 @@
+export default function ({ localField = "data_hash", as }) {
+    return {
+        $lookup: {
+            from: "claimreviews",
+            localField,
+            foreignField: "data_hash",
+            as,
+        },
+    };
+}

--- a/server/mongo-pipelines/lookupClaimRevisions.ts
+++ b/server/mongo-pipelines/lookupClaimRevisions.ts
@@ -1,0 +1,10 @@
+export default function () {
+    return {
+        $lookup: {
+            from: "claimrevisions",
+            localField: "latestRevision",
+            foreignField: "_id",
+            as: "latestRevision",
+        },
+    };
+}

--- a/server/mongo-pipelines/lookupClaims.ts
+++ b/server/mongo-pipelines/lookupClaims.ts
@@ -1,0 +1,12 @@
+export default function ({ pipeline, as }) {
+    return {
+        $lookup: {
+            from: "claims",
+            let: {
+                claimId: { $toObjectId: "$machine.context.claimReview.claim" },
+            },
+            pipeline,
+            as,
+        },
+    };
+}

--- a/server/mongo-pipelines/lookupUsers.ts
+++ b/server/mongo-pipelines/lookupUsers.ts
@@ -1,0 +1,13 @@
+export default function () {
+    return {
+        $lookup: {
+            from: "users",
+            let: { usersId: "$machine.context.reviewData.usersId" },
+            pipeline: [
+                { $match: { $expr: { $in: ["$_id", "$$usersId"] } } },
+                { $project: { name: 1 } },
+            ],
+            as: "machine.context.reviewData.users",
+        },
+    };
+}


### PR DESCRIPTION
- fixed debate_transition migration, setting isDeleted field
- extract lookup stage in separate helper functions
- create count function that counts kanban elements that arent deleted
- change method .find to aggreation pipeline
- filter the results of the aggregation to bring just claimReviewTasks that doesnt have claim or claim-reviews deleted