### PR TITLE
Hotfix: Reports with old source structure are not rendering in the claim review page

### DIFF
--- a/lib/editor-parser.ts
+++ b/lib/editor-parser.ts
@@ -33,7 +33,7 @@ export class EditorParser {
     getSourceByProperty(sources, property) {
         //FIXME: Create migration
         return sources.filter(
-            (source) => source?.props?.field || source?.field === property
+            (source) => (source?.props?.field || source?.field) === property
         );
     }
 

--- a/lib/editor-parser.ts
+++ b/lib/editor-parser.ts
@@ -31,7 +31,10 @@ export class EditorParser {
     }
 
     getSourceByProperty(sources, property) {
-        return sources.filter(({ props }) => props.field === property);
+        //FIXME: Create migration
+        return sources.filter(
+            (source) => source?.props?.field || source?.field === property
+        );
     }
 
     buildHtmlContentWithoutSources(


### PR DESCRIPTION
Old sources in the report will break with the new source structure. We need to add a backwards compatibility change and work on a proper migration for the data in an follow-up PR.