### PR TITLE
Allow admins re-assign a fact-checker to a task

### DIFF
--- a/src/components/ClaimReview/ClaimReviewView.tsx
+++ b/src/components/ClaimReview/ClaimReviewView.tsx
@@ -15,6 +15,7 @@ import AdminToolBar from "../Toolbar/AdminToolBar";
 import ClaimReviewApi from "../../api/claimReviewApi";
 import { NameSpaceEnum } from "../../types/Namespace";
 import { currentNameSpace } from "../../atoms/namespace";
+import ReviewTaskAdminToolBar from "../Toolbar/ReviewTaskAdminToolBar";
 
 export interface ClaimReviewViewProps {
     personality?: any;
@@ -64,17 +65,19 @@ const ClaimReviewView = (props: ClaimReviewViewProps) => {
     return (
         <div>
             {(role === Roles.Admin || role === Roles.SuperAdmin) &&
-                review?.isPublished && (
-                    <AdminToolBar
-                        content={review}
-                        deleteApiFunction={ClaimReviewApi.deleteClaimReview}
-                        changeHideStatusFunction={
-                            ClaimReviewApi.updateClaimReviewHiddenStatus
-                        }
-                        target={TargetModel.ClaimReview}
-                        hideDescriptions={hideDescriptions}
-                    />
-                )}
+            review?.isPublished ? (
+                <AdminToolBar
+                    content={review}
+                    deleteApiFunction={ClaimReviewApi.deleteClaimReview}
+                    changeHideStatusFunction={
+                        ClaimReviewApi.updateClaimReviewHiddenStatus
+                    }
+                    target={TargetModel.ClaimReview}
+                    hideDescriptions={hideDescriptions}
+                />
+            ) : (
+                <ReviewTaskAdminToolBar />
+            )}
             <ClaimReviewHeader
                 classification={
                     review?.report?.classification || reviewData?.classification

--- a/src/components/ClaimReview/form/DynamicReviewTaskForm.tsx
+++ b/src/components/ClaimReview/form/DynamicReviewTaskForm.tsx
@@ -2,7 +2,6 @@ import AletheiaButton, { ButtonType } from "../../Button";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import {
     reviewingSelector,
-    preloadedOptionsSelector,
     reviewDataSelector,
     crossCheckingSelector,
     reportSelector,
@@ -15,16 +14,12 @@ import { ReviewTaskEvents } from "../../../machines/reviewTask/enums";
 import { ReviewTaskMachineContext } from "../../../machines/reviewTask/ReviewTaskMachineProvider";
 import { Row } from "antd";
 import Text from "antd/lib/typography/Text";
-import getNextEvents from "../../../machines/reviewTask/getNextEvent";
-import getNextForm from "../../../machines/reviewTask/getNextForm";
 import {
     isUserLoggedIn,
     currentUserId,
     currentUserRole,
 } from "../../../atoms/currentUser";
-import reviewTaskApi from "../../../api/ClaimReviewTaskApi";
 import { trackUmamiEvent } from "../../../lib/umami";
-import { useAppSelector } from "../../../store/store";
 import { useAtom } from "jotai";
 import { useForm } from "react-hook-form";
 import { useSelector } from "@xstate/react";
@@ -32,6 +27,7 @@ import { useTranslation } from "next-i18next";
 import WarningModal from "../../Modal/WarningModal";
 import { currentNameSpace } from "../../../atoms/namespace";
 import { CommentEnum, Roles } from "../../../types/enums";
+import useAutoSaveDraft from "./hooks/useAutoSaveDraft";
 
 const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
     const {
@@ -42,7 +38,9 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
         formState: { errors },
         watch,
     } = useForm();
-    const { machineService } = useContext(ReviewTaskMachineContext);
+    const { machineService, events, form, setFormAndEvents } = useContext(
+        ReviewTaskMachineContext
+    );
     const isReviewing = useSelector(machineService, reviewingSelector);
     const isCrossChecking = useSelector(machineService, crossCheckingSelector);
     const isReported = useSelector(machineService, reportSelector);
@@ -50,59 +48,25 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
         CollaborativeEditorContext
     );
     const reviewData = useSelector(machineService, reviewDataSelector);
-    const preloadedOptions = useSelector(
-        machineService,
-        preloadedOptionsSelector
-    );
 
     const { t } = useTranslation();
     const [nameSpace] = useAtom(currentNameSpace);
     const [role] = useAtom(currentUserRole);
-    const [currentForm, setCurrentForm] = useState(null);
-    const [nextEvents, setNextEvents] = useState(null);
     const [isLoading, setIsLoading] = useState({});
-    const [reviewerError, setReviewerError] = useState<boolean>(false);
+    const [reviewerError, setReviewerError] = useState(false);
     const [recaptchaString, setRecaptchaString] = useState("");
-    const [gobackWarningModal, setGobackWarningModal] =
-        useState<boolean>(false);
+    const [gobackWarningModal, setGobackWarningModal] = useState(false);
     const [finishReportWarningModal, setFinishReportWarningModal] =
-        useState<boolean>(false);
+        useState(false);
     const hasCaptcha = !!recaptchaString;
     const recaptchaRef = useRef(null);
-
-    const autoSave = useAppSelector((state) => state.autoSave);
 
     const [isLoggedIn] = useAtom(isUserLoggedIn);
     const [userId] = useAtom(currentUserId);
 
-    const setCurrentFormAndNextEvents = (param, isSameLabel = false) => {
-        if (param !== ReviewTaskEvents.draft) {
-            let nextForm = getNextForm(param, isSameLabel);
-            nextForm = setUserPreloads(nextForm);
-            setCurrentForm(nextForm);
-            setNextEvents(getNextEvents(param, isSameLabel));
-        }
-    };
-
-    const setUserPreloads = (form) => {
-        if (preloadedOptions) {
-            form.forEach((item) => {
-                if (
-                    item.type === "inputSearch" &&
-                    preloadedOptions[item.fieldName]
-                ) {
-                    item.extraProps.preloadedOptions =
-                        preloadedOptions[item.fieldName];
-                }
-            });
-        }
-
-        return form;
-    };
-
     const resetIsLoading = () => {
         const isLoading = {};
-        nextEvents?.forEach((eventName) => {
+        events?.forEach((eventName) => {
             isLoading[eventName] = false;
         });
         setIsLoading(isLoading);
@@ -110,7 +74,7 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
 
     useEffect(() => {
         if (isLoggedIn) {
-            setCurrentFormAndNextEvents(machineService.machine.config.initial);
+            setFormAndEvents(machineService.machine.config.initial);
         }
     }, [isLoggedIn]);
 
@@ -118,39 +82,13 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
         reset(reviewData);
         resetIsLoading();
         setReviewerError(false);
-    }, [nextEvents]);
+    }, [events]);
 
-    useEffect(() => {
-        if (autoSave) {
-            let timeout: NodeJS.Timeout;
-            watch((value) => {
-                if (timeout) clearTimeout(timeout);
-                timeout = setTimeout(() => {
-                    reviewTaskApi.autoSaveDraft(
-                        {
-                            data_hash,
-                            machine: {
-                                context: {
-                                    reviewData: value,
-                                    claimReview: {
-                                        personality,
-                                        claim,
-                                        isPartialReview: true,
-                                    },
-                                },
-                            },
-                        },
-                        t
-                    );
-                }, 10000);
-            });
-        }
-    }, [watch]);
+    useAutoSaveDraft(data_hash, personality, claim, watch);
 
     const sendEventToMachine = (formData, eventName) => {
         setIsLoading((current) => ({ ...current, [eventName]: true }));
-
-        machineService.send(eventName, {
+        const payload = {
             data_hash,
             reviewData: {
                 ...formData,
@@ -167,16 +105,17 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
             type: eventName,
             t,
             recaptchaString,
-            setCurrentFormAndNextEvents,
+            setFormAndEvents,
             resetIsLoading,
             currentUserId: userId,
             nameSpace,
-        });
+        };
+        machineService.send(eventName, payload);
         setRecaptchaString("");
         recaptchaRef.current?.resetRecaptcha();
     };
 
-    const ValidateSelectedReviewer = (data, event) => {
+    const validateSelectedReviewer = (data, event) => {
         const isValidReviewer =
             event === ReviewTaskEvents.sendToCrossChecking
                 ? !data.crossCheckerId ||
@@ -242,7 +181,7 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
      */
     const onSubmit = async (data, e) => {
         const event = e.nativeEvent.submitter.getAttribute("event");
-        if (ValidateSelectedReviewer(data, event)) {
+        if (validateSelectedReviewer(data, event)) {
             handleSendEvent(event, data);
         }
     };
@@ -288,10 +227,10 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
 
     return (
         <form style={{ width: "100%" }} onSubmit={handleSubmit(onSubmit)}>
-            {currentForm && (
+            {form && (
                 <>
                     <DynamicForm
-                        currentForm={currentForm}
+                        currentForm={form}
                         machineValues={reviewData}
                         control={control}
                         errors={errors}
@@ -303,7 +242,7 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
                             </Text>
                         )}
                     </div>
-                    {nextEvents?.length > 0 && showButtons && (
+                    {events?.length > 0 && showButtons && (
                         <AletheiaCaptcha
                             onChange={setRecaptchaString}
                             ref={recaptchaRef}
@@ -318,7 +257,7 @@ const DynamicReviewTaskForm = ({ data_hash, personality, claim }) => {
                         justifyContent: "space-evenly",
                     }}
                 >
-                    {nextEvents?.map((event) => {
+                    {events?.map((event) => {
                         return (
                             <AletheiaButton
                                 loading={isLoading[event]}

--- a/src/components/ClaimReview/form/hooks/useAutoSaveDraft.tsx
+++ b/src/components/ClaimReview/form/hooks/useAutoSaveDraft.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useAppSelector } from "../../../../store/store";
+import reviewTaskApi from "../../../../api/ClaimReviewTaskApi";
+import { useTranslation } from "next-i18next";
+
+const useAutoSaveDraft = (data_hash, personality, claim, watch) => {
+    const autoSave = useAppSelector((state) => state.autoSave);
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        if (autoSave) {
+            let timeout: NodeJS.Timeout;
+
+            const callback = (value) => {
+                if (timeout) clearTimeout(timeout);
+
+                timeout = setTimeout(() => {
+                    reviewTaskApi.autoSaveDraft(
+                        {
+                            data_hash,
+                            machine: {
+                                context: {
+                                    reviewData: value,
+                                    claimReview: {
+                                        personality,
+                                        claim,
+                                        isPartialReview: true,
+                                    },
+                                },
+                            },
+                        },
+                        t
+                    );
+                }, 10000);
+            };
+
+            const unsubscribe = watch(callback);
+
+            return () => {
+                clearTimeout(timeout);
+                if (unsubscribe) unsubscribe();
+            };
+        }
+    }, [autoSave, watch]);
+};
+
+export default useAutoSaveDraft;

--- a/src/components/Toolbar/AdminToolBar.tsx
+++ b/src/components/Toolbar/AdminToolBar.tsx
@@ -13,6 +13,7 @@ import { useAtom } from "jotai";
 import { currentNameSpace } from "../../atoms/namespace";
 import { NameSpaceEnum } from "../../types/Namespace";
 
+//TODO: Make admin tool bar dynamic and react based on target
 const AdminToolBar = ({
     content,
     deleteApiFunction,

--- a/src/components/Toolbar/ReviewTaskAdminToolBar.tsx
+++ b/src/components/Toolbar/ReviewTaskAdminToolBar.tsx
@@ -1,0 +1,46 @@
+import { Button, Col, Row } from "antd";
+import { Toolbar } from "@mui/material";
+import React, { useContext } from "react";
+import ManageAccountsIcon from "@mui/icons-material/ManageAccounts";
+import AdminToolBarStyle from "./AdminToolBar.style";
+import { useAtom } from "jotai";
+import { currentNameSpace } from "../../atoms/namespace";
+import colors from "../../styles/colors";
+import { ReviewTaskEvents } from "../../machines/reviewTask/enums";
+import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMachineProvider";
+
+const ReviewTaskAdminToolBar = () => {
+    const [nameSpace] = useAtom(currentNameSpace);
+    const { machineService, setFormAndEvents } = useContext(
+        ReviewTaskMachineContext
+    );
+
+    const handleReassignUser = () => {
+        machineService.send(ReviewTaskEvents.reAssignUser, {
+            type: ReviewTaskEvents.reAssignUser,
+            setFormAndEvents,
+        });
+    };
+
+    return (
+        <Row justify="center" style={{ background: colors.lightGray }}>
+            <Col xs={22} lg={18}>
+                <AdminToolBarStyle
+                    namespace={nameSpace}
+                    position="static"
+                    style={{ boxShadow: "none", background: colors.lightGray }}
+                >
+                    <Toolbar className="toolbar">
+                        <div className="toolbar-item">
+                            <Button onClick={handleReassignUser}>
+                                <ManageAccountsIcon />
+                            </Button>
+                        </div>
+                    </Toolbar>
+                </AdminToolBarStyle>
+            </Col>
+        </Row>
+    );
+};
+
+export default ReviewTaskAdminToolBar;

--- a/src/machines/reviewTask/enums.ts
+++ b/src/machines/reviewTask/enums.ts
@@ -14,6 +14,7 @@ enum ReviewTaskEvents {
     submitComment = "SUBMIT_COMMENT",
     selectedReview = "SELECTED_REVIEW",
     selectedCrossChecking = "SELECTED_CROSS_CHECKING",
+    reAssignUser = "RE_ASSIGN_USER",
 }
 
 enum ReviewTaskStates {

--- a/src/machines/reviewTask/reviewTaskMachine.ts
+++ b/src/machines/reviewTask/reviewTaskMachine.ts
@@ -63,6 +63,9 @@ export const createNewMachine = ({ value, context }) => {
                     [Events.goback]: {
                         target: States.unassigned,
                     },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
+                    },
                     [Events.finishReport]: {
                         target: States.reported,
                         actions: [saveContext],
@@ -73,6 +76,9 @@ export const createNewMachine = ({ value, context }) => {
                 on: {
                     [Events.goback]: {
                         target: States.assigned,
+                    },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
                     },
                     [Events.selectedCrossChecking]: {
                         target: States.selectCrossChecker,
@@ -87,6 +93,9 @@ export const createNewMachine = ({ value, context }) => {
                     [Events.goback]: {
                         target: States.reported,
                     },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
+                    },
                     [Events.sendToCrossChecking]: {
                         target: States.crossChecking,
                         actions: [saveContext],
@@ -97,6 +106,9 @@ export const createNewMachine = ({ value, context }) => {
                 on: {
                     [Events.goback]: {
                         target: States.reported,
+                    },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
                     },
                     [Events.sendToReview]: {
                         target: States.submitted,
@@ -110,6 +122,9 @@ export const createNewMachine = ({ value, context }) => {
                         target: States.addCommentCrossChecking,
                         actions: [saveContext],
                     },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
+                    },
                     [Events.submitCrossChecking]: {
                         target: States.reported,
                         actions: [saveContext],
@@ -120,6 +135,9 @@ export const createNewMachine = ({ value, context }) => {
                 on: {
                     [Events.goback]: {
                         target: States.crossChecking,
+                    },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
                     },
                     [Events.submitComment]: [
                         {
@@ -141,6 +159,9 @@ export const createNewMachine = ({ value, context }) => {
                     [Events.reject]: {
                         target: States.rejected,
                     },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
+                    },
                     [Events.publish]: {
                         target: States.published,
                         actions: [saveContext],
@@ -152,6 +173,9 @@ export const createNewMachine = ({ value, context }) => {
                     [Events.addRejectionComment]: {
                         target: States.assigned,
                         actions: [saveContext],
+                    },
+                    [Events.reAssignUser]: {
+                        target: States.unassigned,
                     },
                     [Events.goback]: {
                         target: States.submitted,
@@ -173,7 +197,7 @@ export const transitionHandler = (state) => {
         data_hash,
         t,
         recaptchaString,
-        setCurrentFormAndNextEvents,
+        setFormAndEvents,
         resetIsLoading,
         currentUserId,
         nameSpace,
@@ -188,9 +212,10 @@ export const transitionHandler = (state) => {
     if (
         event === Events.reject ||
         event === Events.selectedCrossChecking ||
-        event === Events.selectedReview
+        event === Events.selectedReview ||
+        event === Events.reAssignUser
     ) {
-        setCurrentFormAndNextEvents(nextState);
+        setFormAndEvents(nextState);
     } else if (event !== Events.init) {
         api.createClaimReviewTask(
             {
@@ -210,8 +235,8 @@ export const transitionHandler = (state) => {
         )
             .then(() => {
                 return event === Events.goback
-                    ? setCurrentFormAndNextEvents(nextState)
-                    : setCurrentFormAndNextEvents(
+                    ? setFormAndEvents(nextState)
+                    : setFormAndEvents(
                           event,
                           isSameLabel(state.context, state.event)
                       );

--- a/src/machines/reviewTask/selectors.ts
+++ b/src/machines/reviewTask/selectors.ts
@@ -37,16 +37,11 @@ const reviewDataSelector = (state) => {
     return state.context.reviewData;
 };
 
-const preloadedOptionsSelector = (state) => {
-    return state.context.preloadedOptions;
-};
-
 export {
     publishedSelector,
     crossCheckingSelector,
     reviewingSelector,
     reviewNotStartedSelector,
     reviewDataSelector,
-    preloadedOptionsSelector,
     reportSelector,
 };


### PR DESCRIPTION
- Create reviewTask admin tool bar
- Move setFormAndEvents function to globalContext file
- Add reAssignUser Event
---
![image](https://github.com/AletheiaFact/aletheia/assets/73478823/4e7d435b-ddb3-4a48-9725-39281a7e442e)
