### PR TITLE
Fixed namespace guard

### DIFF
--- a/server/auth/name-space/dto/create-namespace.dto.ts
+++ b/server/auth/name-space/dto/create-namespace.dto.ts
@@ -12,4 +12,9 @@ export class CreateNameSpaceDTO {
     @IsOptional()
     @ApiProperty()
     users: User[];
+
+    @IsString()
+    @IsOptional()
+    @ApiProperty()
+    slug: string;
 }

--- a/server/auth/name-space/name-space.controller.ts
+++ b/server/auth/name-space/name-space.controller.ts
@@ -22,13 +22,18 @@ import {
     CheckAbilities,
 } from "../../auth/ability/ability.decorator";
 import { AbilitiesGuard } from "../../auth/ability/abilities.guard";
+import { Types } from "mongoose";
+import { Roles } from "../../auth/ability/ability.factory";
+import { NotificationService } from "../../notifications/notifications.service";
+import slugify from "slugify";
 
 @Controller()
 export class NameSpaceController {
     constructor(
         private nameSpaceService: NameSpaceService,
         private usersService: UsersService,
-        private viewService: ViewService
+        private viewService: ViewService,
+        private notificationService: NotificationService
     ) {}
 
     @ApiTags("name-space")
@@ -36,6 +41,16 @@ export class NameSpaceController {
     @UseGuards(AbilitiesGuard)
     @CheckAbilities(new AdminUserAbility())
     async create(@Body() namespace: CreateNameSpaceDTO) {
+        namespace.slug = slugify(namespace.name, {
+            lower: true,
+            strict: true,
+        });
+
+        namespace.users = await this.updateNameSpaceUsers(
+            namespace.users,
+            namespace.slug
+        );
+
         return await this.nameSpaceService.create(namespace);
     }
 
@@ -43,8 +58,31 @@ export class NameSpaceController {
     @Put("api/name-space/:id")
     @UseGuards(AbilitiesGuard)
     @CheckAbilities(new AdminUserAbility())
-    async update(@Param("id") id, @Body() namespace: UpdateNameSpaceDTO) {
-        return await this.nameSpaceService.update(id, namespace);
+    async update(@Param("id") id, @Body() namespaceBody: UpdateNameSpaceDTO) {
+        const nameSpace = await this.nameSpaceService.getById(id);
+        const newNameSpace = {
+            ...nameSpace.toObject(),
+            ...namespaceBody,
+        };
+
+        newNameSpace.slug = slugify(nameSpace.name, {
+            lower: true,
+            strict: true,
+        });
+
+        newNameSpace.users = await this.updateNameSpaceUsers(
+            newNameSpace.users,
+            nameSpace.slug
+        );
+
+        await this.findNameSpaceUsersAndDelete(
+            id,
+            nameSpace.slug,
+            newNameSpace.users,
+            nameSpace.users
+        );
+
+        return await this.nameSpaceService.update(id, newNameSpace);
     }
 
     @ApiTags("name-space")
@@ -61,5 +99,59 @@ export class NameSpaceController {
                 "/admin-namespaces",
                 Object.assign(parsedUrl.query, { nameSpaces, users })
             );
+    }
+
+    private async updateNameSpaceUsers(users, key) {
+        const promises = users.map(async (user) => {
+            const userId = Types.ObjectId(user._id);
+            const existingUser = await this.usersService.getById(userId);
+
+            if (!existingUser.role[key]) {
+                await this.usersService.updateUser(existingUser._id, {
+                    role: {
+                        ...existingUser.role,
+                        [key]: Roles.Regular,
+                    },
+                });
+            }
+
+            return userId;
+        });
+
+        return await Promise.all(promises);
+    }
+
+    private async findNameSpaceUsersAndDelete(
+        id,
+        nameSpaceSlug,
+        users,
+        previousUsersId
+    ) {
+        const usersIdSet = new Set(users.map((user) => user.toString()));
+        const nameSpaceUsersTodelete = previousUsersId.filter(
+            (previousUserId) => !usersIdSet.has(previousUserId.toString())
+        );
+
+        if (nameSpaceUsersTodelete.length > 0) {
+            this.notificationService.removeTopicSubscriber(
+                id,
+                nameSpaceUsersTodelete
+            );
+            return await this.deleteUsersNameSpace(
+                nameSpaceUsersTodelete,
+                nameSpaceSlug
+            );
+        }
+    }
+
+    private async deleteUsersNameSpace(usersId, key) {
+        const updatePromises = usersId.map(async (userId) => {
+            const id = Types.ObjectId(userId);
+            const user = await this.usersService.getById(id);
+            delete user.role[key];
+            return this.usersService.updateUser(user._id, { role: user.role });
+        });
+
+        await Promise.all(updatePromises);
     }
 }

--- a/server/auth/name-space/name-space.service.ts
+++ b/server/auth/name-space/name-space.service.ts
@@ -1,10 +1,7 @@
 import { Injectable } from "@nestjs/common";
-import { Model, Types } from "mongoose";
+import { Model } from "mongoose";
 import { NameSpaceDocument, NameSpace } from "./schemas/name-space.schema";
 import { InjectModel } from "@nestjs/mongoose";
-import slugify from "slugify";
-import { UsersService } from "../../users/users.service";
-import { Roles } from "../../auth/ability/ability.factory";
 import { UpdateNameSpaceDTO } from "./dto/update-name-space.dto";
 import { NotificationService } from "../../notifications/notifications.service";
 
@@ -13,8 +10,7 @@ export class NameSpaceService {
     constructor(
         @InjectModel(NameSpace.name)
         private NameSpaceModel: Model<NameSpaceDocument>,
-        private notificationService: NotificationService,
-        private usersService: UsersService
+        private notificationService: NotificationService
     ) {}
 
     listAll() {
@@ -22,16 +18,6 @@ export class NameSpaceService {
     }
 
     async create(nameSpace) {
-        nameSpace.slug = slugify(nameSpace.name, {
-            lower: true,
-            strict: true,
-        });
-
-        nameSpace.users = await this.updateNameSpaceUsers(
-            nameSpace.users,
-            nameSpace.slug
-        );
-
         const newNameSpace = await new this.NameSpaceModel(nameSpace).save();
 
         await this.notificationService.createTopic(
@@ -47,25 +33,9 @@ export class NameSpaceService {
         return newNameSpace;
     }
 
-    async update(id, nameSpaceBody: UpdateNameSpaceDTO) {
-        const nameSpace = await this.getById(id);
-        const newNameSpace = {
-            ...nameSpace.toObject(),
-            ...nameSpaceBody,
-        };
-
-        newNameSpace.slug = slugify(newNameSpace.name, {
-            lower: true,
-            strict: true,
-        });
-
+    async update(id, newNameSpace: UpdateNameSpaceDTO) {
         const isNameSpaceTopic = await this.notificationService.getTopic(
             newNameSpace._id
-        );
-
-        newNameSpace.users = await this.updateNameSpaceUsers(
-            newNameSpace.users,
-            nameSpace.slug
         );
 
         await this.ensureTopicAndSubscribers(
@@ -75,15 +45,8 @@ export class NameSpaceService {
             isNameSpaceTopic
         );
 
-        await this.findNameSpaceUsersAndDelete(
-            id,
-            nameSpace.slug,
-            newNameSpace.users,
-            nameSpace.users
-        );
-
         return await this.NameSpaceModel.updateOne(
-            { _id: nameSpace._id },
+            { _id: newNameSpace._id },
             newNameSpace
         );
     }
@@ -101,59 +64,6 @@ export class NameSpaceService {
             );
         }
         await this.notificationService.addTopicSubscriber(namespaceId, users);
-    }
-
-    async updateNameSpaceUsers(users, key) {
-        const promises = users.map(async (user) => {
-            const userId = Types.ObjectId(user._id);
-            const existingUser = await this.usersService.getById(userId);
-
-            if (!user.role[key]) {
-                await this.usersService.updateUser(existingUser._id, {
-                    role: {
-                        ...existingUser.role,
-                        [key]: Roles.Regular,
-                    },
-                });
-            }
-
-            return userId;
-        });
-
-        return await Promise.all(promises);
-    }
-
-    async deleteUsersNameSpace(usersId, key) {
-        const updatePromises = usersId.map(async (userId) => {
-            const id = Types.ObjectId(userId);
-            const user = await this.usersService.getById(id);
-            delete user.role[key];
-            return this.usersService.updateUser(user._id, { role: user.role });
-        });
-
-        await Promise.all(updatePromises);
-    }
-
-    async findNameSpaceUsersAndDelete(
-        id,
-        nameSpaceSlug,
-        users,
-        previousUsersId
-    ) {
-        const usersIdSet = new Set(users.map((user) => user.toString()));
-        const nameSpaceUsersTodelete = previousUsersId.filter(
-            (previousUserId) => !usersIdSet.has(previousUserId.toString())
-        );
-        if (nameSpaceUsersTodelete.length > 0) {
-            this.notificationService.removeTopicSubscriber(
-                id,
-                nameSpaceUsersTodelete
-            );
-            return await this.deleteUsersNameSpace(
-                nameSpaceUsersTodelete,
-                nameSpaceSlug
-            );
-        }
     }
 
     findOne(match) {


### PR DESCRIPTION
For some reason when we were importing the `user.service` in the `name-space.service` module class, the `namespace.guard.ts` stopped to work, since the guard injects the `name-space service`. So i moved the logic that was dependent from the `user-service` to the `name-space.controller` file