### PR TITLE
CTA Button's text responsive in small screens

### DIFF
--- a/src/components/Home/CTAButton.tsx
+++ b/src/components/Home/CTAButton.tsx
@@ -15,12 +15,16 @@ const CTAButton = ({ type }) => {
             style={{
                 alignItems: "center",
                 justifyContent: "center",
-                height: "40px",
-                padding: "0 15px",
+                height: "max-content",
                 fontWeight: 700,
+                whiteSpace: "normal",
+                lineHeight: "20px",
+
             }}
         >
-            {t("CTARegistration:button")}
+            <span style={{ padding: "6px 0px" }}>
+                {t("CTARegistration:button")}
+            </span>
         </Button>
     );
 };


### PR DESCRIPTION
before
![Captura de tela de 2024-08-03 17-47-33](https://github.com/user-attachments/assets/5efb8bc5-afaa-4af2-a401-81c9cd79c484)
after
![Captura de tela de 2024-08-03 18-04-20](https://github.com/user-attachments/assets/8a2abc2e-7429-42d6-a899-b606294d205f)
closes #1318 
