### PR TITLE
CTA Button's text responsive in small screens

### DIFF
--- a/src/components/Profile/Totp.tsx
+++ b/src/components/Profile/Totp.tsx
@@ -210,7 +210,9 @@ export const Totp = ({ flow, setFlow }) => {
                             display: "flex",
                             justifyContent: "center",
                             alignItems: "center",
-                            paddingBottom: 0,
+                            padding: "08px 15px",
+                            height: "max-content",
+                            whiteSpace: "normal",
                         }}
                         type={ButtonType.blue}
                     >
@@ -220,6 +222,7 @@ export const Totp = ({ flow, setFlow }) => {
                                 fontSize: 14,
                                 color: colors.white,
                                 fontWeight: 400,
+                                margin: 0,
                             }}
                         >
                             {t("profile:totpUnLinkSubmit")}


### PR DESCRIPTION
before
![Captura de tela de 2024-08-03 17-47-33](https://github.com/user-attachments/assets/5efb8bc5-afaa-4af2-a401-81c9cd79c484)
after
![Captura de tela de 2024-08-03 18-04-20](https://github.com/user-attachments/assets/8a2abc2e-7429-42d6-a899-b606294d205f)
closes #1318 
