### PR TITLE
Language error corrected in the text of the isended debate

### DIFF
--- a/public/locales/pt/debates.json
+++ b/public/locales/pt/debates.json
@@ -2,7 +2,7 @@
     "liveLabel": "Ao vivo",
     "addClaimEditorButton": "Adicionar afirmação de",
     "saveButtonLabel": "Salvar",
-    "isEnded": "Debate ended",
+    "isEnded": "Debate encerrado",
     "seeDebate": "Acompanhe as checagens do debate",
     "finishDebateButtonLabel": "Encerrar debate",
     "reopenDebateButtonLabel": "Reabrir debate"


### PR DESCRIPTION
before
![Captura de tela de 2024-08-08 21-26-20](https://github.com/user-attachments/assets/e0b29f8f-a3f7-426c-bfd9-d5192d31da34)
after
![Captura de tela de 2024-08-08 21-25-57](https://github.com/user-attachments/assets/d2d9bdc4-487a-4ec8-9485-1f471bf62614)
closes  #852