### PR TITLE
Fix: ensure sitemap.xml is accessible in production environment

### DIFF
--- a/server/personality/personality.service.ts
+++ b/server/personality/personality.service.ts
@@ -109,9 +109,15 @@ export class PersonalityService {
             );
         }
 
-        return Promise.all(
+        return await Promise.all(
             personalities.map(async (personality) => {
-                return await this.postProcess(personality, language);
+                try {
+                    return await this.postProcess(personality, language);
+                } catch (error) {
+                    this.logger.log(
+                        `It was not possible to do postProcess the personality ${personality}`
+                    );
+                }
             })
         );
     }

--- a/server/sitemap/sitemap.service.ts
+++ b/server/sitemap/sitemap.service.ts
@@ -36,6 +36,9 @@ export class SitemapService {
         );
 
         for (const personality of personalities) {
+            if (!personality) {
+                continue;
+            }
             sites.push({ url: `/personality/${personality.slug}` });
             const claims = await this.claimService.listAll(0, 0, "asc", {
                 personality: personality._id,

--- a/server/wikidata/wikidata.service.ts
+++ b/server/wikidata/wikidata.service.ts
@@ -80,7 +80,7 @@ export class WikidataService {
 
         const siteLinkName = this.getSiteLinkName(language);
 
-        if (wikidata?.sitelinks[siteLinkName]) {
+        if (wikidata?.sitelinks && wikidata?.sitelinks[siteLinkName]) {
             const wikiLang = siteLinkName.match(/^(.*)wiki$/)[1];
             const wikiTitle = wikidata.sitelinks[siteLinkName].title;
             if (wikiLang && wikiTitle) {
@@ -126,7 +126,7 @@ export class WikidataService {
             wikidataProps.avatar = await this.getCommonsThumbURL(fileName, 100);
         }
         // Extract Twitter accounts if they exist
-        if (wikidata.claims?.P2002) {
+        if (wikidata?.claims?.P2002) {
             wikidata.claims.P2002.forEach((claim) => {
                 const twitterAccount = claim.mainsnak.datavalue.value;
                 wikidataProps.twitterAccounts.push(twitterAccount);


### PR DESCRIPTION
Resolved an issue where the `sitemap.xml` was not being properly generated or accessible in the production environment. This fix ensures that the sitemap is correctly generated and can be accessed by search engines, allowing the site to be indexed by Google.

- Updated the sitemap generation script to run correctly in the production environment.

This change should improve the site's visibility in search engine results.