### PR TITLE
Adding a debouncing mechanism when searching wikidata topics

### DIFF
--- a/src/components/topics/TopicDisplay.tsx
+++ b/src/components/topics/TopicDisplay.tsx
@@ -22,14 +22,15 @@ const TopicDisplay = ({
     const [tags, setTags] = useState<any[]>([]);
     const { t } = useTranslation();
     const dispatch = useDispatch();
+    let timeout: NodeJS.Timeout;
 
     useEffect(() => {
         const inputValueFormatted = inputValue.map((inputValue) =>
             inputValue?.value
                 ? {
-                      label: inputValue?.label.toLowerCase().replace(" ", "-"),
-                      value: inputValue?.value,
-                  }
+                    label: inputValue?.label.toLowerCase().replace(" ", "-"),
+                    value: inputValue?.value,
+                }
                 : inputValue
         );
 
@@ -44,22 +45,25 @@ const TopicDisplay = ({
         setTags(topicsArray?.concat(filterValues) || []);
     }, [inputValue, topicsArray]);
 
-    const fetchTopicList = async (
+    const fetchTopicList = (
         topic: string
-    ): Promise<{ label: string; value: string }[]> => {
-        const topicSearchResults = await TopicsApi.getTopics({
-            topicName: topic,
-            t: t,
-            dispatch: dispatch,
-        });
+    ) => new Promise<{ label: string; value: string }[]>((resolve) => {
+        if (timeout) clearTimeout(timeout);
 
-        return (
-            topicSearchResults?.map((topic) => ({
-                label: topic.name,
-                value: topic.wikidata,
-            })) || []
-        );
-    };
+        timeout = setTimeout(async () => {
+            const topicSearchResults = await TopicsApi.getTopics({
+                topicName: topic,
+                t,
+                dispatch,
+            });
+            resolve(
+                topicSearchResults?.map(({ name, wikidata }) => ({
+                    label: name,
+                    value: wikidata
+                })) || []
+            );
+        }, 1000);
+    });
 
     const handleClose = async (removedTopicValue: any) => {
         const newTopicsArray = topicsArray.filter(


### PR DESCRIPTION
Adding a debouncing mechanism ensures that the function is only executed after a period of inactivity. This prevents the function from running with each character.
Example:
![Captura de tela de 2024-09-13 14-09-48](https://github.com/user-attachments/assets/e48b59b4-52bd-4876-bcee-d9d2b866cd46)

closes #1326