### PR TITLE
feat/fix: Add polling mechanism for annotation plugin initialization when annotations are enabled

### DIFF
--- a/src/components/Collaborative/Comment/CommentCardContent.tsx
+++ b/src/components/Collaborative/Comment/CommentCardContent.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect } from "react";
-import {
-    useCurrentSelection,
-    useHelpers,
-    useRemirrorContext,
-} from "@remirror/react";
+import { useCurrentSelection, useHelpers } from "@remirror/react";
 import CommentCardForm from "./CommentCardForm";
 import CommentCardHeader from "./CommentCardHeader";
 import { Divider } from "@mui/material";
@@ -11,6 +7,7 @@ import reviewColors from "../../../constants/reviewColors";
 import { useTranslation } from "next-i18next";
 import { CommentEnum } from "../../../types/enums";
 import { useAppSelector } from "../../../store/store";
+import { usePluginReady } from "../utils/usePluginReady";
 
 const CommentCardContent = ({
     user,
@@ -35,11 +32,11 @@ const CommentCardContent = ({
     const { t } = useTranslation();
     const { from } = useCurrentSelection();
     const { getAnnotationsAt } = useHelpers();
-    const { getPluginState } = useRemirrorContext({ autoUpdate: true });
-    const pluginState = getPluginState("annotation");
+
+    const isPluginReady = usePluginReady("annotation", enableEditorAnnotations);
 
     useEffect(() => {
-        if (enableEditorAnnotations && pluginState) {
+        if (enableEditorAnnotations && isPluginReady) {
             const annotations = getAnnotationsAt(from);
             const hasMatchingId = annotations.some(
                 (annotation) => annotation?.id === content?._id
@@ -52,6 +49,7 @@ const CommentCardContent = ({
         from,
         getAnnotationsAt,
         setIsSelected,
+        isPluginReady,
     ]);
 
     return (

--- a/src/components/Collaborative/Comment/CommentContainer.tsx
+++ b/src/components/Collaborative/Comment/CommentContainer.tsx
@@ -13,6 +13,7 @@ import userApi from "../../../api/userApi";
 import { useAtom } from "jotai";
 import { currentUserId } from "../../../atoms/currentUser";
 import { useAppSelector } from "../../../store/store";
+import { usePluginReady } from "../utils/usePluginReady";
 
 const CommentContainer = ({ state, isCommentVisible, setIsCommentVisible }) => {
     const enableEditorAnnotations = useAppSelector(
@@ -25,9 +26,9 @@ const CommentContainer = ({ state, isCommentVisible, setIsCommentVisible }) => {
     const hasSession = !!userId;
     const [user, setUser] = useState(null);
     const { setAnnotations } = useCommands();
-    const { getPluginState } = useRemirrorContext({ autoUpdate: true });
     const { getAnnotations } = useHelpers();
-    const pluginState = getPluginState("annotation");
+
+    const isPluginReady = usePluginReady("annotation", enableEditorAnnotations);
 
     const crossCheckingComments = useMemo(
         () =>
@@ -57,7 +58,7 @@ const CommentContainer = ({ state, isCommentVisible, setIsCommentVisible }) => {
 
             setComments(combinedComments);
 
-            if (enableEditorAnnotations && pluginState) {
+            if (enableEditorAnnotations && isPluginReady) {
                 const annotations = getAnnotations();
                 if (combinedComments.length > 0) {
                     setAnnotations(combinedComments);
@@ -71,7 +72,7 @@ const CommentContainer = ({ state, isCommentVisible, setIsCommentVisible }) => {
         setComments,
         reviewData?.reviewComments,
         crossCheckingComments,
-        pluginState,
+        isPluginReady,
         setAnnotations,
     ]);
 

--- a/src/components/Collaborative/Comment/CommentContainer.tsx
+++ b/src/components/Collaborative/Comment/CommentContainer.tsx
@@ -1,7 +1,7 @@
 import "remirror/styles/all.css";
 
 import React, { useContext, useEffect, useMemo, useState } from "react";
-import { useCommands, useHelpers, useRemirrorContext } from "@remirror/react";
+import { useCommands, useHelpers } from "@remirror/react";
 import { VisualEditorContext } from "../VisualEditorProvider";
 import { Row } from "antd";
 import CommentsList from "./CommentsList";

--- a/src/components/Collaborative/utils/usePluginReady.ts
+++ b/src/components/Collaborative/utils/usePluginReady.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useRemirrorContext } from "@remirror/react";
 
 export const usePluginReady = (pluginName, enableEditorAnnotations) => {
-    const [isPluginReady, setPluginReady] = useState(false);
+    const [isPluginReady, setIsPluginReady] = useState(false);
     const { getPluginState } = useRemirrorContext({ autoUpdate: true });
 
     // Polling to ensure the annotation plugin is fully initialized before using it.
@@ -13,7 +13,7 @@ export const usePluginReady = (pluginName, enableEditorAnnotations) => {
             const interval = setInterval(() => {
                 const pluginState = getPluginState(pluginName);
                 if (pluginState) {
-                    setPluginReady(true);
+                    setIsPluginReady(true);
                     clearInterval(interval);
                 }
             }, 100);

--- a/src/components/Collaborative/utils/usePluginReady.ts
+++ b/src/components/Collaborative/utils/usePluginReady.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { useRemirrorContext } from "@remirror/react";
+
+export const usePluginReady = (pluginName, enableEditorAnnotations) => {
+    const [isPluginReady, setPluginReady] = useState(false);
+    const { getPluginState } = useRemirrorContext({ autoUpdate: true });
+
+    // Polling to ensure the annotation plugin is fully initialized before using it.
+    // This is necessary because the plugin might load slower than the rest of the page,
+    // which could cause errors when trying to access it prematurely.
+    useEffect(() => {
+        if (enableEditorAnnotations) {
+            const interval = setInterval(() => {
+                const pluginState = getPluginState(pluginName);
+                if (pluginState) {
+                    setPluginReady(true);
+                    clearInterval(interval);
+                }
+            }, 100);
+
+            return () => clearInterval(interval);
+        }
+    }, [pluginName, enableEditorAnnotations, getPluginState]);
+
+    return isPluginReady;
+};


### PR DESCRIPTION
# Description
- Introduced a custom hook `usePluginReady` to modularize and reuse the logic for polling the annotation plugin's readiness across multiple components.
- Implemented polling to ensure that the annotation plugin is fully initialized before being accessed. This prevents errors when the plugin loads slower than the rest of the page.
- Replaced inline polling logic in `CommentCardContent` and `CommentContainer` components with the new reusable `usePluginReady` hook.
- Improved code readability and maintainability by avoiding duplicated logic and centralizing the plugin readiness check.

Fixes #1379

# Type of change
*Please delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue)     
- [x] Existing feature enhancement (non-breaking change which modifies existing functionality)     

# Testing
*Provide relevant testing instructions. What scenarios are impacted? What build may be necessary to test this change?*


# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas     
- [ ] Repository documentation has been updated (Readme.md) with additional steps required for a local environment setup.
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY. The exception to this is for new (MVP/Prototype) functionality where the abstraction layer may not be clear (comments should be added to explain the violation of DRY in these scenarios).   
- [ ] Documented with TSDoc all library and controller new functions

## Frontend Changes
- [x] No new styling is added through CSS files (Unless it's a bugfix/hotfix)
- [ ] All types are added correctly

### Tests
- [ ] All existing unit and end to end tests pass across all services     
- [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected     

# Merge Request Review Checklist 
- [x] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)     
- [x] High risk and core workflows have been tested and verified in a local environment.     
- [x] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in JIRA issues if not being addressed.     
- [x] Any dependent changes have been merged and published in downstream modules     
- [x] Changes to multiple services can be deployed in parallel and independently. If not, changes should be broken out into separate merge requests and deployed in order.