### PR TITLE
Remove width unnecessary in svg 

### DIFF
--- a/src/components/Header/Logo.tsx
+++ b/src/components/Header/Logo.tsx
@@ -26,7 +26,6 @@ const Logo = ({
                 :
                 <LogoAletheia
                     height={height}
-                    width={width}
                     color={color}
                 />
         );

--- a/src/components/Header/LogoAletheia.tsx
+++ b/src/components/Header/LogoAletheia.tsx
@@ -2,18 +2,15 @@ import React from "react"
 
 const LogoAletheia = ({
   height = "",
-  width = "",
   color = "",
 }: {
   height: string,
-  width: string,
   color: any,
 }) => {
   return (
     <svg
       viewBox="0 0 957 517"
       height={height}
-      width={width}
       xmlns="http://www.w3.org/2000/svg"
     >
       <path


### PR DESCRIPTION
# Description
*This width is unnecessary because by defining only the height, the width will be proportional. It was breaking on the platform of some volunteers.*

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)     
- [ ] New feature (non-breaking change which adds functionality)     
- [ ] Existing feature enhancement (non-breaking change which modifies existing functionality)     

# Testing
before in some volunteers:
![Captura de tela de 2024-10-31 22-52-28](https://github.com/user-attachments/assets/1e30d891-2c21-451a-850e-d33163b4a11f)
after:
![Captura de tela de 2024-10-31 22-44-27](https://github.com/user-attachments/assets/77737dcd-3307-4988-89cd-802df96ab6a2)