### PR TITLE
Disabling donation button in sidebar with LocalConfig

### DIFF
--- a/src/components/AletheiaMenu.tsx
+++ b/src/components/AletheiaMenu.tsx
@@ -11,6 +11,7 @@ import colors from "../styles/colors";
 import { Roles } from "../types/enums";
 import { NameSpaceEnum } from "../types/Namespace";
 import { currentNameSpace } from "../atoms/namespace";
+import localConfig from "../../config/localConfig";
 
 const AletheiaMenu = () => {
     const { t } = useTranslation();
@@ -163,9 +164,12 @@ const AletheiaMenu = () => {
                 {t("menu:supportiveMaterials")}
             </Menu.Item>
 
-            <Menu.Item key="/donate" onClick={handleClick}>
-                {t("header:donateButton")}
-            </Menu.Item>
+            {localConfig.header.donateButton.show
+                ?
+                <Menu.Item key="/donate" onClick={handleClick}>
+                    {t("header:donateButton")}
+                </Menu.Item>
+                : null}
         </Menu>
     );
 };


### PR DESCRIPTION
# Description
*I added the sidebar donation button to the LocalConfig conditional along with the other two home buttons*
Fixes #1456 
before:
![Screenshot from 2024-11-15 12-06-33](https://github.com/user-attachments/assets/213f4ae2-c7a1-4913-90c6-cafba73e63c7)
after:
![Screenshot from 2024-11-15 12-07-19](https://github.com/user-attachments/assets/293e4969-5437-4e5e-a33d-40674d774cb1)

# Question
![Screenshot from 2024-11-15 12-28-01](https://github.com/user-attachments/assets/b1124634-6766-4ed1-87e0-c76eab0b8a73)
*When we disable the donation button on the home page and the user is not logged in, the sign up button remains in the same place when perhaps it should occupy the corner where the donation button was, does it make sense to resolve this in this PR?*

