### PR TITLE
Resolving ory login bug

### DIFF
--- a/server/auth/ory/ory.controller.ts
+++ b/server/auth/ory/ory.controller.ts
@@ -16,10 +16,8 @@ export default class OryController {
     @Get("sessions/whoami")
     public async whoAmI(@Req() req: Request, @Res() res: Response) {
         try {
-            const sessionToken =
-                req.cookies["ory_kratos_session"] ||
-                req.headers["authorization"];
-            const data = await this.oryService.whoAmI(sessionToken);
+            // forward cookie string because the cookie names may vary between ory cloud installations
+            const data = await this.oryService.whoAmI(req.headers["cookie"]);
             return res.status(200).json(data);
         } catch (error) {
             if (error.status) {

--- a/server/auth/ory/ory.service.ts
+++ b/server/auth/ory/ory.service.ts
@@ -135,10 +135,10 @@ export default class OryService {
         });
     }
 
-    async whoAmI(sessionToken: string): Promise<any> {
+    async whoAmI(sessionCookies: string): Promise<any> {
         return await fetch(`${this.url}/sessions/whoami`, {
             headers: {
-                Cookie: `ory_kratos_session=${sessionToken}`,
+                Cookie: sessionCookies,
             },
         }).then((response) => {
             if (response.ok) {


### PR DESCRIPTION
# Description
The login flow is not working locally when using a Ory Cloud development instance. The reason was because the cookie was hardcoded to work specifically with a local kratos instance. Now we are just forwarding the cookie to the `/whoami` call and it should work with every type of instance.

before:
![Screenshot from 2024-11-18 19-47-05](https://github.com/user-attachments/assets/cec03d06-fc10-4337-9247-7748b6e8303c)
after:
![Screenshot from 2024-11-18 19-44-54](https://github.com/user-attachments/assets/c901f11d-908b-49e7-a650-8c465c7fcdc0)


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)     
- [ ] New feature (non-breaking change which adds functionality)     
- [ ] Existing feature enhancement (non-breaking change which modifies existing functionality)     
