### PR TITLE
Adapting imports of {Row} alone and { Row, Col } together to Grid/mui 

### DIFF
--- a/src/components/CardBase.tsx
+++ b/src/components/CardBase.tsx
@@ -1,9 +1,9 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import colors from "../styles/colors";
 
 const CardBase = ({ children, style = {} }) => {
     return (
-        <Row style={{
+        <Grid container style={{
             background: colors.white,
             border: `1px solid ${colors.lightNeutralSecondary}`,
             boxSizing: "border-box",
@@ -13,7 +13,7 @@ const CardBase = ({ children, style = {} }) => {
             ...style
         }}>
             {children}
-        </Row>
+        </Grid>
     )
 }
 

--- a/src/components/Claim/ClaimListView.tsx
+++ b/src/components/Claim/ClaimListView.tsx
@@ -1,4 +1,4 @@
-import { Row, Col } from "antd";
+import { Grid } from "@mui/material"
 import React from "react";
 import ClaimList from "./ClaimList";
 import SourceList from "../Source/SourceList";
@@ -8,19 +8,19 @@ const ClaimListView = () => {
     const { t } = useTranslation();
     return (
         <>
-            <Row justify="center" style={{ marginTop: "64px" }}>
-                <Col sm={22} md={14} lg={21}>
+            <Grid container style={{ marginTop: "64px", justifyContent:"center" }}>
+                <Grid item sm={11} md={7} lg={10.5}>
                     <h1 style={{ fontSize: 32 }}>
                         {t("claim:claimListTitle")}
                     </h1>
-                </Col>
-                <Col sm={22} md={14} lg={12}>
+                </Grid>
+                <Grid item sm={11} md={7} lg={6}>
                     <SourceList />
-                </Col>
-                <Col offset={1} sm={22} md={14} lg={8}>
+                </Grid>
+                <Grid item style={{margin:"0 20px"}} sm={11} md={7} lg={4}>
                     <ClaimList columns={1} personality={{ _id: null }} />
-                </Col>
-            </Row>
+                </Grid>
+            </Grid>
         </>
     );
 };

--- a/src/components/Claim/ClaimSummary.tsx
+++ b/src/components/Claim/ClaimSummary.tsx
@@ -1,8 +1,8 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import styled from "styled-components";
 import colors from "../../styles/colors";
 
-const ClaimSummary = styled(Row)`
+const ClaimSummary = styled(Grid)`
     position: relative;
     background: ${colors.lightNeutralSecondary};
     display:flex;

--- a/src/components/Claim/CreateClaim/ClaimSelectType.tsx
+++ b/src/components/Claim/CreateClaim/ClaimSelectType.tsx
@@ -53,8 +53,9 @@ const ClaimSelectType = () => {
                 </p>
             </div>
 
-            <Grid
+            <Grid container
                 style={{
+                    gap: "10px",
                     margin: "24px 0",
                     display: "flex",
                     justifyContent: "space-evenly",

--- a/src/components/Claim/CreateClaim/ClaimUploadImage.tsx
+++ b/src/components/Claim/CreateClaim/ClaimUploadImage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import { UploadFile } from "antd/lib/upload/interface";
 import { useAtom } from "jotai";
 import { useTranslation } from "next-i18next";
@@ -94,13 +94,13 @@ const ClaimUploadImage = () => {
                 isLoading={isLoading}
                 dateExtraText={t("claimForm:dateFieldHelpImage")}
                 content={
-                    <Row style={{ marginBottom: 24 }}>
+                    <Grid container style={{ marginBottom: 24 }}>
                         <Label required>{t("claimForm:fileInputButton")}</Label>
                         <ImageUpload
                             onChange={handleAntdChange}
                             error={imageError}
                         />
-                    </Row>
+                    </Grid>
                 }
             />
         </>

--- a/src/components/Claim/CreateClaim/CreateClaimView.tsx
+++ b/src/components/Claim/CreateClaim/CreateClaimView.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import { useAtom } from "jotai";
 import React, { useState } from "react";
 
@@ -77,8 +77,8 @@ const CreateClaimView = () => {
     };
 
     return (
-        <Row justify="center">
-            <Col span={18} style={{ marginTop: 32 }}>
+        <Grid container style={{justifyContent:"center"}}>
+            <Grid item xs={9} style={{ marginTop: 32 }}>
                 {!isLoading &&
                     claimData?.group &&
                     claimData?.group?.content?.length > 0 && (
@@ -101,7 +101,7 @@ const CreateClaimView = () => {
                 {addDebate && <ClaimCreateDebate />}
                 {isLoading && <Loading />}
                 {addUnattributed && <ClaimCreate />}
-            </Col>
+            </Grid>
 
             <VerificationRequestDrawer
                 groupContent={claimData.group.content}
@@ -110,7 +110,7 @@ const CreateClaimView = () => {
                 onCloseDrawer={onCloseDrawer}
                 onRemove={onRemove}
             />
-        </Row>
+        </Grid>
     );
 };
 

--- a/src/components/ClaimReview/ClaimReviewDrawer.tsx
+++ b/src/components/ClaimReview/ClaimReviewDrawer.tsx
@@ -2,7 +2,7 @@ import {
     ArrowLeftOutlined,
     ExclamationCircleOutlined,
 } from "@ant-design/icons";
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import { useTranslation } from "next-i18next";
 import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -62,16 +62,16 @@ const ClaimReviewDrawer = () => {
                     }
                 >
                     <VisualEditorProvider data_hash={data_hash}>
-                        <Row
-                            justify="space-between"
+                        <Grid container
                             style={{
                                 width: "100%",
                                 padding: "1rem",
                                 display: "flex",
                                 flexDirection: "column",
+                                justifyContent:"space-between"
                             }}
                         >
-                            <Col style={{ display: "flex", gap: 32 }}>
+                            <Grid item style={{ display: "flex", gap: 32 }}>
                                 <AletheiaButton
                                     icon={<ArrowLeftOutlined />}
                                     onClick={() =>
@@ -82,7 +82,7 @@ const ClaimReviewDrawer = () => {
                                 >
                                     {t("common:back_button")}
                                 </AletheiaButton>
-                                <Col span={vw?.xs ? 8 : 14}>
+                                <Grid item xs={vw?.xs ? 4 : 7}>
                                     <AletheiaButton
                                         href={generateReviewContentPath(
                                             nameSpace,
@@ -102,10 +102,10 @@ const ClaimReviewDrawer = () => {
                                     >
                                         {t("reviewTask:seeFullPage")}
                                     </AletheiaButton>
-                                </Col>
-                            </Col>
+                                </Grid>
+                            </Grid>
                             {enableCopilotChatBot && (
-                                <Col
+                                <Grid item
                                     style={{
                                         display: "flex",
                                         justifyContent: "center",
@@ -128,9 +128,9 @@ const ClaimReviewDrawer = () => {
                                     >
                                         {t("copilotChatBot:copilotWarning")}
                                     </span>
-                                </Col>
+                                </Grid>
                             )}
-                        </Row>
+                        </Grid>
                         <ClaimReviewView
                             personality={personality}
                             target={target}

--- a/src/components/ClaimReview/ClaimReviewForm.tsx
+++ b/src/components/ClaimReview/ClaimReviewForm.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import React, { useContext, useEffect, useState } from "react";
 import {
     reviewingSelector,
@@ -72,13 +72,14 @@ const ClaimReviewForm = ({
     }, [isUnassigned]);
 
     return (
-        <Row
+        <Grid container
             style={{
                 background: colors.lightNeutral,
                 padding: "20px 15px",
+                justifyContent:"center"
             }}
         >
-            <Col span={componentStyle.span} offset={componentStyle.offset}>
+            <Grid item xs={componentStyle.span}>
                 {formCollapsed && (
                     <ReportModelButtons setFormCollapsed={setFormCollapsed} />
                 )}
@@ -90,8 +91,8 @@ const ClaimReviewForm = ({
                         target={target?._id}
                     />
                 )}
-            </Col>
-        </Row>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/ClaimReview/ClaimReviewHeader.tsx
+++ b/src/components/ClaimReview/ClaimReviewHeader.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "@xstate/react";
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import React, { useContext } from "react";
 
 import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMachineProvider";
@@ -45,8 +45,9 @@ const ClaimReviewHeader = ({
         reviewTaskType === ReviewTaskTypeEnum.VerificationRequest;
 
     return (
-        <Row
+        <Grid container
             style={{
+                justifyContent:"center",
                 background:
                     isPublished &&
                     reviewTaskType !== ReviewTaskTypeEnum.VerificationRequest
@@ -54,16 +55,11 @@ const ClaimReviewHeader = ({
                         : colors.lightNeutral,
             }}
         >
-            <Col offset={componentStyle.offset} span={componentStyle.span}>
-                <Row>
-                    <Col
-                        lg={{
-                            order: 1,
-                            span: 24,
-                        }}
-                        md={{ order: 2, span: 24 }}
-                        sm={{ order: 2, span: 24 }}
-                        xs={{ order: 2, span: 24 }}
+            <Grid item xs={componentStyle.span}>
+                <Grid container>
+                    <Grid item
+                       xs={12} 
+                       order={{ xs: 2, lg: 1 }}
                     >
                         <SentenceReportCard
                             personality={personality}
@@ -84,16 +80,16 @@ const ClaimReviewHeader = ({
                                 topics={content?.topics || []}
                             />
                         )}
-                    </Col>
+                    </Grid>
 
                     <ReviewAlert
                         isHidden={isHidden}
                         isPublished={isPublished}
                         hideDescription={hideDescription}
                     />
-                </Row>
-            </Col>
-        </Row>
+                </Grid>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/ClaimReview/ClaimReviewView.tsx
+++ b/src/components/ClaimReview/ClaimReviewView.tsx
@@ -55,13 +55,11 @@ const ClaimReviewView = (props: ClaimReviewViewProps) => {
     const isSourceOrVerificationRequest = reviewTaskType === "Source" || reviewTaskType === "VerificationRequest";
 
     const componentStyle = {
-        span: 18,
-        offset: 3,
+        span: 9,
     };
 
     if (!reviewDrawerCollapsed) {
-        componentStyle.span = 22;
-        componentStyle.offset = 1;
+        componentStyle.span = 11;
     }
 
     const reviewContentPath = generateReviewContentPath(

--- a/src/components/ClaimReview/ReportModelButtons.tsx
+++ b/src/components/ClaimReview/ReportModelButtons.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import React, { useContext } from "react";
 import Button, { ButtonType } from "../Button";
 import {
@@ -28,15 +28,15 @@ const ReportModelButtons = ({ setFormCollapsed }) => {
     };
 
     return (
-        <Row
+        <Grid container
             style={{
                 width: "100%",
                 padding: "0px 0px 15px 0px",
                 justifyContent: "center",
             }}
         >
-            <Col
-                span={24}
+            <Grid item
+                xs={12}
                 style={{
                     display: "flex",
                     justifyContent: "center",
@@ -102,8 +102,8 @@ const ReportModelButtons = ({ setFormCollapsed }) => {
                         )}
                     </>
                 )}
-            </Col>
-        </Row>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/ClaimReview/form/DynamicReviewTaskForm.tsx
+++ b/src/components/ClaimReview/form/DynamicReviewTaskForm.tsx
@@ -12,7 +12,7 @@ import { VisualEditorContext } from "../../Collaborative/VisualEditorProvider";
 import DynamicForm from "../../Form/DynamicForm";
 import { ReviewTaskEvents } from "../../../machines/reviewTask/enums";
 import { ReviewTaskMachineContext } from "../../../machines/reviewTask/ReviewTaskMachineProvider";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import Text from "antd/lib/typography/Text";
 import {
     isUserLoggedIn,
@@ -118,9 +118,9 @@ const DynamicReviewTaskForm = ({ data_hash, personality, target }) => {
         const isValidReviewer =
             event === ReviewTaskEvents.sendToCrossChecking
                 ? !data.crossCheckerId ||
-                  !reviewData.usersId.includes(data.crossCheckerId)
+                !reviewData.usersId.includes(data.crossCheckerId)
                 : !data.reviewerId ||
-                  !reviewData.usersId.includes(data.reviewerId);
+                !reviewData.usersId.includes(data.reviewerId);
 
         setReviewerError(!isValidReviewer);
         return isValidReviewer;
@@ -244,10 +244,11 @@ const DynamicReviewTaskForm = ({ data_hash, personality, target }) => {
                 </>
             )}
             {showButtons && (
-                <Row
+                <Grid container
                     style={{
                         padding: "32px 0 0",
                         justifyContent: "space-evenly",
+                        gap: "10px"
                     }}
                 >
                     {events?.map((event) => {
@@ -266,7 +267,7 @@ const DynamicReviewTaskForm = ({ data_hash, personality, target }) => {
                             </AletheiaButton>
                         );
                     })}
-                </Row>
+                </Grid>
             )}
 
             <WarningModal

--- a/src/components/Collaborative/Comment/CommentContainer.tsx
+++ b/src/components/Collaborative/Comment/CommentContainer.tsx
@@ -3,7 +3,7 @@ import "remirror/styles/all.css";
 import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useCommands, useHelpers } from "@remirror/react";
 import { VisualEditorContext } from "../VisualEditorProvider";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import CommentsList from "./CommentsList";
 import { ReviewTaskMachineContext } from "../../../machines/reviewTask/ReviewTaskMachineProvider";
 import { useSelector } from "@xstate/react";
@@ -77,7 +77,7 @@ const CommentContainer = ({ state, isCommentVisible, setIsCommentVisible }) => {
     ]);
 
     return (
-        <Row
+        <Grid container
             style={{
                 order: 3,
                 width: "280px",
@@ -96,7 +96,7 @@ const CommentContainer = ({ state, isCommentVisible, setIsCommentVisible }) => {
             )}
 
             <CommentsList comments={comments} user={user} />
-        </Row>
+        </Grid>
     );
 };
 

--- a/src/components/Collaborative/Form/CardStyle.tsx
+++ b/src/components/Collaborative/Form/CardStyle.tsx
@@ -1,8 +1,8 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import styled from "styled-components";
 import colors from "../../../styles/colors";
 
-const CardStyle = styled(Row)`
+const CardStyle = styled(Grid)`
     width: 100%;
     display: flex;
     justify-content: space-between;

--- a/src/components/Collaborative/Form/EditorCard.tsx
+++ b/src/components/Collaborative/Form/EditorCard.tsx
@@ -21,9 +21,9 @@ const EditorCard = ({
     inputSize = 100,
 }: EditorCardProps) => {
     return (
-        <CardStyle>
+        <CardStyle container>
             <label>{label}</label>
-            <Grid container xs={span} className="card-container">
+            <Grid item xs={span} className="card-container">
                 <div
                     className="card-content"
                     data-cy={dataCy}

--- a/src/components/Collaborative/Form/QuestionCard.tsx
+++ b/src/components/Collaborative/Form/QuestionCard.tsx
@@ -33,7 +33,7 @@ const QuestionCard = ({ forwardRef, node, initialPosition }) => {
             forwardRef={forwardRef}
             inputSize={40}
             extra={
-                <Grid container xs={1}
+                <Grid item xs={1}
                     style={{alignContent:"center"}}>
                     <Button
                         style={{ height: "40px", margin: "0 auto" }}

--- a/src/components/Copilot/CopilotConversationCard.style.tsx
+++ b/src/components/Copilot/CopilotConversationCard.style.tsx
@@ -1,8 +1,8 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import colors from "../../styles/colors";
 import styled from "styled-components";
 
-const CopilotConversationCardStyle = styled(Row)`
+const CopilotConversationCardStyle = styled(Grid)`
     display: flex;
     flex-direction: column;
 

--- a/src/components/Copilot/CopilotConversationCard.tsx
+++ b/src/components/Copilot/CopilotConversationCard.tsx
@@ -9,7 +9,7 @@ const CopilotConversationCard = ({ message }) => {
     const { t } = useTranslation();
     const { type, sender, content } = message;
     return (
-        <CopilotConversationCardStyle>
+        <CopilotConversationCardStyle item>
             <div className="conversation-card-header">
                 {sender === SenderEnum.Assistant ? (
                     <img

--- a/src/components/CreateCTAButton.tsx
+++ b/src/components/CreateCTAButton.tsx
@@ -1,4 +1,4 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import React from "react";
 import { useTranslation } from "next-i18next";
 
@@ -6,7 +6,7 @@ const CreateCTAButton = ({ children }) => {
     const { t } = useTranslation();
 
     return (
-        <Row
+        <Grid container
             style={{
                 flexDirection: "column",
                 alignItems: "center",
@@ -19,7 +19,7 @@ const CreateCTAButton = ({ children }) => {
             </p>
             <p>{children}</p>
             <p>{t("personalityCTA:footer")}</p>
-        </Row>
+        </Grid>
     );
 };
 

--- a/src/components/Dashboard/DashboardView.style.tsx
+++ b/src/components/Dashboard/DashboardView.style.tsx
@@ -1,9 +1,10 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import styled from "styled-components";
 import colors from "../../styles/colors";
 
-const DashboardViewStyle = styled(Row)`
-    row-gap: 64px;
+const DashboardViewStyle = styled(Grid)`
+    gap: 64px;
+    justify-content: center;
 
     .dashboard-item {
         padding: 20px;

--- a/src/components/Dashboard/DashboardView.tsx
+++ b/src/components/Dashboard/DashboardView.tsx
@@ -16,8 +16,8 @@ const DashboardView = () => {
     const { t, i18n } = useTranslation();
 
     return (
-        <DashboardViewStyle justify="space-around">
-            <Grid container className="dashboard-item" sm={12} md={5} lg={3.5}>
+        <DashboardViewStyle container>
+            <Grid item className="dashboard-item" sm={12} md={5} lg={3.5}>
                 <BaseList
                     title={t("admin:dashboardHiddenPersonalities")}
                     apiCall={personalitiesApi.getPersonalities}
@@ -39,7 +39,7 @@ const DashboardView = () => {
                 />
             </Grid>
 
-            <Grid container className="dashboard-item" sm={12} md={5} lg={3.5}>
+            <Grid item className="dashboard-item" sm={12} md={5} lg={3.5}>
                 <BaseList
                     title={t("admin:dashboardHiddenClaims")}
                     apiCall={claimApi.get}
@@ -61,7 +61,7 @@ const DashboardView = () => {
                 />
             </Grid>
 
-            <Grid container className="dashboard-item" sm={12} md={5} lg={3.5}>
+            <Grid item className="dashboard-item" sm={12} md={5} lg={3.5}>
                 <BaseList
                     title={t("admin:dashboardHiddenReviews")}
                     apiCall={claimReviewApi.get}

--- a/src/components/Debate/DebateView.tsx
+++ b/src/components/Debate/DebateView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import { Provider as CallbackTimerProvider, useAtom } from "jotai";
 import { useTranslation } from "next-i18next";
 import claimApi from "../../api/claim";
@@ -44,7 +44,7 @@ const DebateView = ({ claim }) => {
                     [currentNameSpace, nameSpace],
                 ]}
             >
-                <Row
+                <Grid container
                     style={{
                         width: "100%",
                         justifyContent: "center",
@@ -56,7 +56,7 @@ const DebateView = ({ claim }) => {
                         personalities={claim?.personalities}
                         userRole={userRole}
                     />
-                    <Row
+                    <Grid item
                         style={{
                             padding: "30px 10%",
                             width: "100%",
@@ -66,8 +66,8 @@ const DebateView = ({ claim }) => {
                             speeches={speeches}
                             isLive={debate.isLive}
                         />
-                    </Row>
-                </Row>
+                    </Grid>
+                </Grid>
             </CallbackTimerProvider>
         </>
     );

--- a/src/components/Editor/EditorContent.tsx
+++ b/src/components/Editor/EditorContent.tsx
@@ -6,7 +6,8 @@ import { useTranslation } from "next-i18next";
 import EditorApi from "../../api/editor";
 import { callbackTimerAtom } from "../../machines/callbackTimer/provider";
 import Button from "../Button";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
+
 export const EditorContent = ({ reference, isLive }) => {
     const { t } = useTranslation();
     // this needs to be called inside the scope of the provider
@@ -20,7 +21,7 @@ export const EditorContent = ({ reference, isLive }) => {
     return (
         <>
             <EditorComponent />
-            <Row justify="space-between" style={{ marginTop: 16 }}>
+            <Grid container style={{ marginTop: 16 }}>
                 {isLive && (
                     <Button
                         onMouseDown={(event) => event.preventDefault()}
@@ -29,7 +30,7 @@ export const EditorContent = ({ reference, isLive }) => {
                         {t("debates:saveButtonLabel")}
                     </Button>
                 )}
-            </Row>
+            </Grid>
         </>
     );
 };

--- a/src/components/Footer/FooterInfo.tsx
+++ b/src/components/Footer/FooterInfo.tsx
@@ -1,5 +1,5 @@
 import { FileTextOutlined } from "@ant-design/icons";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import { useTranslation } from "next-i18next";
 import React from "react";
 import { useAppSelector } from "../../store/store";
@@ -14,7 +14,7 @@ const FooterInfo = () => {
     const href = " https://github.com/AletheiaFact/aletheia";
 
     return (
-        <Row justify={vw?.sm ? "center" : "start"}>
+        <Grid container style={{ justifyContent: vw?.sm ? "center" : "start" }}>
             <span style={{ textAlign: "justify", marginBottom: "16px" }}>
                 {t("about:alertInfo")}
                 <a
@@ -42,7 +42,7 @@ const FooterInfo = () => {
                     </>
                 </AletheiaButton>
             ) : null}
-        </Row>
+        </Grid>
     );
 };
 

--- a/src/components/Form/DynamicForm.tsx
+++ b/src/components/Form/DynamicForm.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 
 import { Controller } from "react-hook-form";
 import DynamicInput from "./DynamicInput";
@@ -31,8 +31,8 @@ const DynamicForm = ({
                 const defaultValue = machineValues[fieldName];
 
                 return (
-                    <Row key={fieldName + index}>
-                        <Col span={24}>
+                    <Grid container key={fieldName + index}>
+                        <Grid item xs={12}>
                             <h4
                                 style={{
                                     color: colors.blackSecondary,
@@ -43,8 +43,8 @@ const DynamicForm = ({
                             >
                                 {t(label)}
                             </h4>
-                        </Col>
-                        <Col span={24} style={{ margin: "10px 0" }}>
+                        </Grid>
+                        <Grid item xs={12} style={{ margin: "10px 0" }}>
                             <Controller
                                 name={fieldName}
                                 control={control}
@@ -70,8 +70,8 @@ const DynamicForm = ({
                                     {t(errors[fieldName].message)}
                                 </Text>
                             )}
-                        </Col>
-                    </Row>
+                        </Grid>
+                    </Grid>
                 );
             })}
         </div>

--- a/src/components/Home/CTA/CTASection.style.tsx
+++ b/src/components/Home/CTA/CTASection.style.tsx
@@ -1,9 +1,9 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import styled from "styled-components";
 import { queries } from "../../../styles/mediaQueries";
 import colors from "../../../styles/colors";
 
-const CTASectionStyle = styled(Row)`
+const CTASectionStyle = styled(Grid)`
     display: flex;
     width: 100%;
     margin-top: 24px;
@@ -20,7 +20,7 @@ const CTASectionStyle = styled(Row)`
         display: flex;
         flex-wrap: wrap;
         justify-content: ${({ isloggedin }) =>
-            isloggedin === "true" ? "flex-end" : "space-between"};
+        isloggedin === "true" ? "flex-end" : "space-between"};
     }
 
     @media ${queries.md} {

--- a/src/components/Home/CTA/CTASection.tsx
+++ b/src/components/Home/CTA/CTASection.tsx
@@ -9,7 +9,7 @@ const CTASection = () => {
     const [isLoggedIn] = useAtom(isUserLoggedIn);
 
     return (
-        <CTASectionStyle isloggedin={isLoggedIn.toString()}>
+        <CTASectionStyle container isloggedin={isLoggedIn.toString()}>
             <CTASectionTitle />
             <CTASectionButtons />
         </CTASectionStyle>

--- a/src/components/Home/CTA/CTASectionButtons.tsx
+++ b/src/components/Home/CTA/CTASectionButtons.tsx
@@ -21,7 +21,7 @@ const CTASectionButtons = () => {
     };
 
     return (
-        <Grid container
+        <Grid item
             xs={7}
             sm={6}
             className="CTA-button-container"

--- a/src/components/Home/CTA/CTASectionTitle.tsx
+++ b/src/components/Home/CTA/CTASectionTitle.tsx
@@ -1,15 +1,12 @@
 import { Grid } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import React from "react";
-import { isUserLoggedIn } from "../../../atoms/currentUser";
-import { useAtom } from "jotai";
 
 const CTASectionTitle = () => {
     const { t } = useTranslation();
-    const [isLoggedIn] = useAtom(isUserLoggedIn);
 
     return (
-        <Grid container md={6} sm={isLoggedIn ? 12 : 6} xs={12} className="footer-text">
+        <Grid item sm={6} xs={12} className="footer-text">
             <p className="CTA-title">{t("home:statsFooter")}</p>
         </Grid>
     );

--- a/src/components/Home/HomeContent.tsx
+++ b/src/components/Home/HomeContent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import CTARegistration from "./CTARegistration";
-import { Row, Col } from "antd";
+import { Grid } from "@mui/material"
 import SocialMediaShare from "../SocialMediaShare";
 import { isUserLoggedIn } from "../../atoms/currentUser";
 import { useAtom } from "jotai";
@@ -26,52 +26,53 @@ const HomeContent = ({ personalities, href, title, debateClaims, reviews }) => {
 
     return (
         <>
-            <Row
+            <Grid container
                 style={{
                     width: "100%",
                     paddingTop: "32px",
                     justifyContent: "center",
                 }}
             >
-                <Col xs={22} sm={22} md={18}>
+                <Grid item xs={11} sm={11} md={9}>
                     <HomeFeed searchResults={results} />
-                </Col>
-                <Col xs={22} sm={22} md={18} style={{ marginBottom: 32 }}>
+                </Grid>
+                <Grid item xs={11} sm={11} md={9} style={{ marginBottom: 32 }}>
                     <ReviewsGrid
                         reviews={reviews}
                         title={t("home:latestReviewsTitle")}
                     />
-                </Col>
+                </Grid>
                 {Array.isArray(debateClaims) && debateClaims.length > 0 && (
-                    <Col
-                        xs={{ span: 20, order: 1 }}
-                        sm={{ span: 20, order: 1 }}
-                        md={{ span: 18, order: 1 }}
-                        style={{
+                    <Grid item
+                        order={1}
+                        xs={10}
+                        sm={10}
+                        md={9}
+                         style={{
                             width: "100%",
                             paddingBottom: "32px",
                             justifyContent: "center",
                         }}
                     >
                         <DebateGrid debates={debateClaims} />
-                    </Col>
+                    </Grid>
                 )}
-                <Col xs={22} sm={22} md={18}>
+                <Grid item xs={11} sm={11} md={9}>
                     <PersonalitiesGrid
                         personalities={personalities}
                         title={title}
                     />
-                </Col>
+                </Grid>
 
                 {!isLoggedIn && (
-                    <Col xs={24} lg={18} order={3}>
+                    <Grid item xs={12} lg={9} order={3}>
                         <CTARegistration />
-                    </Col>
+                    </Grid>
                 )}
-                <Col span={24} order={4}>
+                <Grid item xs={12} order={4}>
                     <SocialMediaShare href={href} />
-                </Col>
-            </Row>
+                </Grid>
+            </Grid>
         </>
     );
 };

--- a/src/components/InputTextList.tsx
+++ b/src/components/InputTextList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
 import { useFieldArray, useForm } from "react-hook-form";
 
@@ -59,14 +59,14 @@ export default function InputTextList({
         <div>
             {controlledFields.map((_field, index) => {
                 return (
-                    <Row
+                    <Grid container
                         key={`fieldArray.${index}.content`}
                         style={{
                             marginBottom: 20,
                             justifyContent: "space-between",
                         }}
                     >
-                        <Col span={index > 0 ? 20 : 24}>
+                        <Grid item xs={index > 0 ? 10 : 12}>
                             <AletheiaInput
                                 {...register(
                                     `fieldArray.${index}.content` as const
@@ -76,9 +76,9 @@ export default function InputTextList({
                                 data-cy={`${dataCy}${index}`}
                                 white={white}
                             />
-                        </Col>
+                        </Grid>
                         {index > 0 && (
-                            <Col span={3}>
+                            <Grid item xs={1.5}>
                                 <Button
                                     style={{ height: "40px", margin: "0 auto" }}
                                     onClick={() => {
@@ -92,9 +92,9 @@ export default function InputTextList({
                                 >
                                     <DeleteOutlined />
                                 </Button>
-                            </Col>
+                            </Grid>
                         )}
-                    </Row>
+                    </Grid>
                 );
             })}
 

--- a/src/components/SentenceReport/SentenceReportPreviewView.tsx
+++ b/src/components/SentenceReport/SentenceReportPreviewView.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "@xstate/react";
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material"
 import React, { useContext } from "react";
 
 import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMachineProvider";
@@ -91,7 +91,7 @@ const SentenceReportPreviewView = ({
 
     return (
         reviewTaskType !== ReviewTaskTypeEnum.VerificationRequest && (
-            <Row
+            <Grid container
                 style={
                     (isCrossChecking || isReport || isReviewing) && {
                         backgroundColor: colors.lightNeutral,
@@ -112,7 +112,7 @@ const SentenceReportPreviewView = ({
                         onClose={handleClickViewPreview}
                         open={viewPreview}
                     >
-                        <Col
+                        <Grid item
                             style={{
                                 height: "100%",
                                 display: "flex",
@@ -128,8 +128,7 @@ const SentenceReportPreviewView = ({
                                 hideDescription={hideDescriptions}
                                 target={target}
                                 componentStyle={{
-                                    span: 20,
-                                    offset: 2,
+                                    span: 10,
                                 }}
                             />
                             <SentenceReportPreview
@@ -137,14 +136,13 @@ const SentenceReportPreviewView = ({
                                 context={context}
                                 href={href}
                                 componentStyle={{
-                                    span: 20,
-                                    offset: 2,
+                                    span: 10,
                                 }}
                             />
-                        </Col>
+                        </Grid>
                     </LargeDrawer>
                 )}
-            </Row>
+            </Grid>
         )
     );
 };

--- a/src/components/SharedFormFooter.tsx
+++ b/src/components/SharedFormFooter.tsx
@@ -1,7 +1,7 @@
 // File: src/components/SharedFormFooter.js
 
 import React, { useRef } from "react";
-import { Row } from "antd";
+import { Grid } from "@mui/material"
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import AletheiaCaptcha from "./AletheiaCaptcha";
@@ -15,7 +15,7 @@ const SharedFormFooter = ({ isLoading, setRecaptchaString, hasCaptcha }) => {
     return (
         <>
             <AletheiaCaptcha onChange={setRecaptchaString} ref={recaptchaRef} />
-            <Row
+            <Grid container
                 style={{
                     padding: "32px 0 0",
                     justifyContent: "space-evenly",
@@ -36,7 +36,7 @@ const SharedFormFooter = ({ isLoading, setRecaptchaString, hasCaptcha }) => {
                 >
                     {t("claimForm:saveButton")}
                 </AletheiaButton>
-            </Row>
+            </Grid>
         </>
     );
 };


### PR DESCRIPTION
# Description
*In this PR, I addressed all the issues created during the switch from Ant to MUI that involved importing only { Row } and { Row, Col } together. I adapted them to use { Grid } from MUI without losing the standard layout. This way, we can resolve issues that require similar and/or minor changes.*

# Testing 
*You should go to each component where the switch from Ant to MUI was made and test the design and responsiveness. In this case, since it involves replacing a component that handles columns, you only need to ensure that nothing is broken or out of place.*

Each components:
- [ ] #1600  
- [ ] #1582  
- [ ] #1578  
- [ ] #1576  
- [ ] #1571  
- [ ] #1520  
- [ ] #1544  
- [ ] #1536  
- [ ] #1568  
- [ ] #1508  
- [ ] #1565  
- [ ] #1556  
- [ ] #1553  
- [ ] #1549  
- [ ] #1548  
- [ ] #1547  
- [ ] #1546  
- [ ] #1545  
- [ ] #1513  
- [ ] #1586  
- [ ] #1596  
- [ ] #1535  

*A visual document outlining which visual parts of the site are intended to facilitate testing:*
...
[testing geral responsividade.pdf](https://github.com/user-attachments/files/18172536/testing.geral.responsividade.pdf)

## OBS:
*I was unable to test Copilotconversation.style.tsx. I think it's unlikely that it broke, but I did it blindly.*