### PR TITLE
Change all typography antd for muy

### DIFF
--- a/src/components/AletheiaTitle.tsx
+++ b/src/components/AletheiaTitle.tsx
@@ -1,11 +1,10 @@
 import colors from "../styles/colors"
-import { Typography } from "antd";
+import Typography  from "@mui/material/Typography"
 
-const { Title } = Typography
 const AletheiaTitle = (props) => {
     return (
-        <Title
-            level={props.level}
+        <Typography
+            variant={props.variant}
             style={{
                 fontSize: 14,
                 color: colors.white,
@@ -15,7 +14,7 @@ const AletheiaTitle = (props) => {
             }}
         >
             {props.children}
-        </Title>
+        </Typography>
     )
 }
 

--- a/src/components/Claim/ClaimCard.tsx
+++ b/src/components/Claim/ClaimCard.tsx
@@ -1,4 +1,4 @@
-import { Col, Comment, Row, Typography } from "antd";
+import { Grid, Typography } from "@mui/material"
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import ReviewColors from "../../constants/reviewColors";
@@ -7,7 +7,6 @@ import ClaimSummary from "./ClaimSummary";
 import Button, { ButtonType } from "../Button";
 import ClaimCardHeader from "./ClaimCardHeader";
 import colors from "../../styles/colors";
-import styled from "styled-components";
 import ClaimSummaryContent from "./ClaimSummaryContent";
 import ClaimSpeechBody from "./ClaimSpeechBody";
 import actions from "../../store/actions";
@@ -17,15 +16,6 @@ import { useAppSelector } from "../../store/store";
 import { useAtom } from "jotai";
 import { currentNameSpace } from "../../atoms/namespace";
 import { NameSpaceEnum } from "../../types/Namespace";
-
-const { Paragraph } = Typography;
-
-const CommentStyled = styled(Comment)`
-    width: 100%;
-    .ant-comment-inner {
-        padding: 0;
-    }
-`;
 
 const ClaimCard = ({
     personality,
@@ -87,51 +77,45 @@ const ClaimCard = ({
 
     return (
         <CardBase style={{ padding: "16px 12px" }}>
-            <Row style={{ width: "100%" }}>
-                <CommentStyled
-                    author={
-                        <ClaimCardHeader
-                            personality={personality}
-                            date={claim?.date}
-                            claimType={claim?.contentModel}
-                        />
-                    }
-                    content={
-                        <ClaimSummary
-                            style={{
-                                padding: "12px 16px",
-                                width: "100%",
-                            }}
-                        >
-                            {collapsed ? (
-                                <ClaimSummaryContent
-                                    claimTitle={claim?.title}
-                                    claimContent={claimContent}
-                                    contentModel={claim?.contentModel}
-                                    href={href}
-                                />
-                            ) : (
-                                <ClaimSpeechBody
-                                    handleSentenceClick={
-                                        dispatchPersonalityAndClaim
-                                    }
-                                    paragraphs={paragraphs}
-                                    showHighlights={true}
-                                />
-                            )}
-                        </ClaimSummary>
-                    }
+            <Grid container style={{ width: "100%" }}>
+                <ClaimCardHeader
+                    personality={personality}
+                    date={claim?.date}
+                    claimType={claim?.contentModel}
                 />
-            </Row>
-            <Row
+                <ClaimSummary
+                    style={{
+                        padding: "12px 16px",
+                        width: "100%",
+                    }}
+                >
+                    {collapsed ? (
+                        <ClaimSummaryContent
+                            claimTitle={claim?.title}
+                            claimContent={claimContent}
+                            contentModel={claim?.contentModel}
+                            href={href}
+                        />
+                    ) : (
+                        <ClaimSpeechBody
+                            handleSentenceClick={
+                                dispatchPersonalityAndClaim
+                            }
+                            paragraphs={paragraphs}
+                            showHighlights={true}
+                        />
+                    )}
+                </ClaimSummary>
+            </Grid>
+            <Grid container
                 style={{
+                    justifyContent:"space-between",
                     padding: "4px 15px 0 0",
                     width: "100%",
                 }}
-                justify="space-between"
             >
-                <Col
-                    span={16}
+                <Grid item
+                    xs={8}
                     style={{
                         display: "flex",
                         flexWrap: "wrap",
@@ -152,7 +136,8 @@ const ClaimCard = ({
                             })}
                         </p>
                     )}{" "}
-                    <Paragraph
+                    <Typography
+                        variant="body1"
                         style={{
                             fontSize: "10px",
                             lineHeight: "18px",
@@ -178,9 +163,9 @@ const ClaimCard = ({
                                 ({review?.count})
                             </span>
                         )}
-                    </Paragraph>
-                </Col>
-                <Col>
+                    </Typography>
+                </Grid>
+                <Grid item>
                     {!isInsideDebate && (
                         <Button
                             type={ButtonType.blue}
@@ -201,8 +186,8 @@ const ClaimCard = ({
                             </span>
                         </Button>
                     )}
-                </Col>
-            </Row>
+                </Grid>
+            </Grid>
         </CardBase>
     );
 };

--- a/src/components/Claim/ClaimCardHeader.tsx
+++ b/src/components/Claim/ClaimCardHeader.tsx
@@ -1,11 +1,9 @@
-import { Col, Row, Typography } from "antd";
+import { Grid, Typography } from "@mui/material"
 import { useTranslation } from "next-i18next";
 import React from "react";
 import colors from "../../styles/colors";
 import { ContentModelEnum } from "../../types/enums";
 import LocalizedDate from "../LocalizedDate";
-
-const { Paragraph } = Typography;
 
 const ClaimCardHeader = ({
     personality,
@@ -23,8 +21,8 @@ const ClaimCardHeader = ({
 
     const speechTypeTranslation = speechTypeMapping[claimType];
     return (
-        <Col
-            span={24}
+        <Grid item
+            xs={12}
             style={{
                 color: colors.blackSecondary,
                 width: "100%",
@@ -32,7 +30,8 @@ const ClaimCardHeader = ({
         >
             {personality && (
                 <>
-                    <Paragraph
+                    <Typography
+                        variant="body1"
                         style={{
                             fontSize: "14px",
                             lineHeight: "20px",
@@ -42,10 +41,11 @@ const ClaimCardHeader = ({
                         }}
                     >
                         {personality.name}
-                    </Paragraph>
+                    </Typography>
 
-                    <Row>
-                        <Paragraph
+                    <Grid container>
+                        <Typography
+                            variant="body1"
                             style={{
                                 fontSize: 10,
                                 fontWeight: 400,
@@ -54,13 +54,14 @@ const ClaimCardHeader = ({
                             }}
                         >
                             {personality.description}
-                        </Paragraph>
-                    </Row>
+                        </Typography>
+                    </Grid>
                 </>
             )}
-            <Row>
+            <Grid container>
                 {!isImage ? (
-                    <Paragraph
+                    <Typography
+                        variant="body1"
                         style={{
                             fontSize: 10,
                             fontWeight: 400,
@@ -76,9 +77,10 @@ const ClaimCardHeader = ({
                         <span style={{ fontWeight: 700 }}>
                             {speechTypeTranslation}
                         </span>
-                    </Paragraph>
+                    </Typography>
                 ) : (
-                    <Paragraph
+                    <Typography
+                        variant="body1"
                         style={{
                             fontSize: 10,
                             fontWeight: 400,
@@ -90,10 +92,10 @@ const ClaimCardHeader = ({
                         {t("claim:cardHeader3")}
                         &nbsp;
                         <LocalizedDate date={date || new Date()} />
-                    </Paragraph>
+                    </Typography>
                 )}
-            </Row>
-        </Col>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/Claim/ClaimInfo.tsx
+++ b/src/components/Claim/ClaimInfo.tsx
@@ -1,21 +1,8 @@
 import React from "react";
-
-import { Typography } from "antd";
+import Typography from "@mui/material/Typography";
 import { useTranslation } from "next-i18next";
 import LocalizedDate from "../LocalizedDate";
 import colors from "../../styles/colors";
-import styled from "styled-components";
-
-const { Paragraph } = Typography;
-
-const ClaimInfoParagraph = styled(Paragraph)`
-    font-size: 10px;
-    font-weight: 400;
-    line-height: 15px;
-    margin-bottom: 0;
-    margin-top: 20px;
-    color: ${colors.blackSecondary};
-`;
 
 const ClaimInfo = ({
     isImage,
@@ -24,22 +11,35 @@ const ClaimInfo = ({
     style = {},
 }) => {
     const { t } = useTranslation();
+    const textstyle = {
+        marginTop: 20,
+        color: colors.blackSecondary,
+        fontSize: 10,
+        lineHeight: "16px",
+        ...style
+    }
 
     return (
         <>
             {!isImage ? (
-                <ClaimInfoParagraph style={style}>
+                <Typography
+                    variant="body1"
+                    style={textstyle}
+                >
                     {t("claim:cardHeader1")}&nbsp;
                     <LocalizedDate date={date || new Date()} />
                     &nbsp;
                     {t("claim:cardHeader2")}&nbsp;
                     <strong>{t(speechTypeTranslation)}</strong>
-                </ClaimInfoParagraph>
+                </Typography>
             ) : (
-                <ClaimInfoParagraph style={style}>
+                <Typography
+                    variant="body1"
+                    style={textstyle}
+                    >
                     {t("claim:cardHeader3")}&nbsp;
                     <LocalizedDate date={date || new Date()} />
-                </ClaimInfoParagraph>
+                </Typography>
             )}
         </>
     );

--- a/src/components/Claim/ClaimView.tsx
+++ b/src/components/Claim/ClaimView.tsx
@@ -135,7 +135,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                             </Grid>
                             {sources.length > 0 && (
                                 <>
-                                    <Typography variant="h6" style={{fontFamily:"initial", fontWeight: 700}}>
+                                    <Typography variant="h4" style={{fontSize: 24, fontFamily:"initial", fontWeight: 700}}>
                                         {t("claim:sourceSectionTitle")}
                                     </Typography>
                                     <ClaimSourceList

--- a/src/components/Claim/ClaimView.tsx
+++ b/src/components/Claim/ClaimView.tsx
@@ -1,4 +1,5 @@
-import { Affix, Col, Row, Typography } from "antd";
+import { Affix } from "antd";
+import { Grid, Typography} from "@mui/material"
 import React, { useEffect, useState } from "react";
 
 import { ContentModelEnum, Roles, TargetModel } from "../../types/enums";
@@ -16,8 +17,6 @@ import AdminToolBar from "../Toolbar/AdminToolBar";
 import claimApi from "../../api/claim";
 import { currentUserRole } from "../../atoms/currentUser";
 import { useAtom } from "jotai";
-
-const { Title } = Typography;
 
 const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
     const dispatch = useDispatch();
@@ -55,8 +54,8 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                 />
             )}
 
-            <Row justify="center">
-                <Col xs={22} sm={22} md={18}>
+            <Grid container justifyContent="center">
+                <Grid item xs={11} sm={11} md={9}>
                     <article>
                         {personality && (
                             <PersonalityCard
@@ -68,21 +67,23 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                         )}
                         <section>
                             <ClaimInfo isImage={isImage} date={claim?.date} />
-                            <Row
+                            <Grid container
                                 style={{ paddingBottom: "15px" }}
-                                justify="center"
+                                justifyContent="center"
                             >
-                                <Col xs={24} md={22} lg={20}>
-                                    <Title
-                                        level={1}
+                                <Grid item xs={12} md={11} lg={10}>
+                                    <Typography
+                                        variant="h1"
                                         style={{
+                                            fontFamily:"initial",
+                                            fontWeight: 700,
                                             margin: "20px 0",
                                             fontSize: 20,
                                             lineHeight: 1.4,
                                         }}
                                     >
                                         {title}
-                                    </Title>
+                                    </Typography>
                                     <ClaimContentDisplay
                                         isImage={isImage}
                                         title={title}
@@ -92,7 +93,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                             dispatchPersonalityAndClaim
                                         }
                                     />
-                                </Col>
+                                </Grid>
 
                                 <Affix
                                     offsetBottom={15}
@@ -114,12 +115,12 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                         )}
                                     />
                                 </Affix>
-                            </Row>
+                            </Grid>
                             {sources.length > 0 && (
                                 <>
-                                    <Typography.Title level={4}>
+                                    <Typography variant="h6" style={{fontFamily:"initial", fontWeight: 700}}>
                                         {t("claim:sourceSectionTitle")}
-                                    </Typography.Title>
+                                    </Typography>
                                     <ClaimSourceList
                                         sources={sources}
                                         seeMoreHref={`${href}/sources`}
@@ -129,8 +130,8 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                         </section>
                         {stats.total !== 0 && <MetricsOverview stats={stats} />}
                     </article>
-                </Col>
-            </Row>
+                </Grid>
+            </Grid>
             <SocialMediaShare
                 quote={personality?.name}
                 href={href}

--- a/src/components/Claim/ClaimView.tsx
+++ b/src/components/Claim/ClaimView.tsx
@@ -1,6 +1,5 @@
-import { Affix } from "antd";
-import { Grid, Typography} from "@mui/material"
-import React, { useEffect, useState } from "react";
+import { Box ,Grid , Typography} from "@mui/material"
+import React, { useEffect, useRef, useState } from "react";
 
 import { ContentModelEnum, Roles, TargetModel } from "../../types/enums";
 import MetricsOverview from "../Metrics/MetricsOverview";
@@ -19,6 +18,8 @@ import { currentUserRole } from "../../atoms/currentUser";
 import { useAtom } from "jotai";
 
 const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
+    const [isAffixed, setIsAffixed] = useState(true);
+    const ref = useRef<HTMLDivElement | null>(null);
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const [role] = useAtom(currentUserRole);
@@ -41,6 +42,22 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
             dispatch(actions.setSelectContent(claimContent));
         }
     }, [claim, claimContent, dispatch, isImage, personality, t]);
+
+    useEffect(() => {
+      const handleScroll = () => {
+        if (!ref.current) return;
+
+        const { bottom } = ref.current.getBoundingClientRect();
+        const windowHeight = window.innerHeight;
+  
+        if (bottom > windowHeight) {
+          setIsAffixed(true);
+        } else {
+          setIsAffixed(false);
+        }
+      };  
+      window.addEventListener("scroll", handleScroll);
+    }, []);
 
     return (
         <>
@@ -71,7 +88,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                 style={{ paddingBottom: "15px" }}
                                 justifyContent="center"
                             >
-                                <Grid item xs={12} md={11} lg={10}>
+                                <Grid ref={ref} item xs={12} md={11} lg={10}>
                                     <Typography
                                         variant="h1"
                                         style={{
@@ -94,10 +111,10 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                         }
                                     />
                                 </Grid>
-
-                                <Affix
-                                    offsetBottom={15}
+                                <Box
                                     style={{
+                                        position: isAffixed ? "fixed" : "relative",
+                                        bottom: isAffixed ? 15 : "auto",
                                         textAlign: "center",
                                         width: "100%",
                                     }}
@@ -114,7 +131,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                             "claim:hideHighlightsButton"
                                         )}
                                     />
-                                </Affix>
+                                </Box>
                             </Grid>
                             {sources.length > 0 && (
                                 <>

--- a/src/components/ClaimReview/ReviewContent.tsx
+++ b/src/components/ClaimReview/ReviewContent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ImageClaim from "../ImageClaim";
 import ReviewContentStyled from "./ReviewContent.style";
-import { Typography } from "antd";
+import Typography from "@mui/material/Typography";
 
 const ReviewContent = ({
     title,
@@ -14,16 +14,17 @@ const ReviewContent = ({
 }) => {
     return (
         <ReviewContentStyled>
-            <Typography.Paragraph
-                ellipsis={
-                    ellipsis
-                        ? {
-                              rows: 4,
-                              expandable: false,
-                          }
-                        : null
-                }
-                style={{ marginBottom: 0, ...style }}
+            <Typography
+                variant="body1"
+                style={{
+                    display: "-webkit-box",
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    WebkitLineClamp: ellipsis ? 4 : "none",
+                    marginBottom: 0,
+                    ...style,
+                  }}
             >
                 <cite>{title}</cite>
                 {isImage && <ImageClaim src={content} title={title} />}
@@ -32,7 +33,7 @@ const ReviewContent = ({
                         {linkText}
                     </a>
                 )}
-            </Typography.Paragraph>
+            </Typography>
             {ellipsis && contentPath && linkText && (
                 <a
                     href={contentPath}

--- a/src/components/CodeOfConduct/CodeOfConduct.tsx
+++ b/src/components/CodeOfConduct/CodeOfConduct.tsx
@@ -14,6 +14,14 @@ const CodeOfConductStyle = styled(Grid)`
     padding: 20px;
 
     .title-conduct{
+        font-size: 32px;
+        margin: 20px 0;
+        font-Family: serif; 
+        font-Weight: 600;
+    }
+
+    .subtitle-conduct{
+        font-size: 25px;
         margin: 20px 0;
         font-Family: serif; 
         font-Weight: 600;
@@ -24,28 +32,28 @@ const CodeOfConduct = () => {
     const { t } = useTranslation();
     return (
         <CodeOfConductStyle item>
-            <Typography style={{ fontSize:40,textAlign:"center", fontFamily: "initial", fontWeight:600}} variant="h4">
+            <Typography style={{ fontSize:40,textAlign:"center", fontFamily: "initial", fontWeight:600}} variant="h1">
                 {t("codeOfConduct:title")}
             </Typography>            
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:introductionSection")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:introductionSectionFirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:principlesSection")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:principlesSectionFirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:dutiesSection")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:dutiesSectionFirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:methodologySection")}
             </Typography>
             <Paragraph>
@@ -65,31 +73,31 @@ const CodeOfConduct = () => {
             <Paragraph>
                 {t("codeOfConduct:methodologySectionSecondParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:expectedBehaviorSection")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:expectedBehaviorSectionFirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:expectedBehaviorSubSection1")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:expectedBehaviorSubSection1FirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:expectedBehaviorSubSection2")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:expectedBehaviorSubSection2FirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:unacceptableBehaviorSection")}
             </Typography>
             <Paragraph>
                 {t("codeOfConduct:unacceptableBehaviorSectionFirstParagraph")}
             </Paragraph>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:unacceptableBehaviorSubSection1")}
             </Typography>
             <Paragraph>
@@ -97,7 +105,7 @@ const CodeOfConduct = () => {
                     "codeOfConduct:unacceptableBehaviorSubSection1FirstParagraph"
                 )}
             </Paragraph>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:unacceptableBehaviorSubSection2")}
             </Typography>
             <Paragraph>
@@ -105,7 +113,7 @@ const CodeOfConduct = () => {
                     "codeOfConduct:unacceptableBehaviorSubSection2FirstParagraph"
                 )}
             </Paragraph>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:unacceptableBehaviorSubSection3")}
             </Typography>
             <Paragraph>
@@ -113,10 +121,10 @@ const CodeOfConduct = () => {
                     "codeOfConduct:unacceptableBehaviorSubSection3FirstParagraph"
                 )}
             </Paragraph>
-            <Typography className="title-conduct" variant="h4">
+            <Typography className="title-conduct" variant="h2">
                 {t("codeOfConduct:responsibilitiesSection")}
             </Typography>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:responsibilitiesSectionSubSection1")}
             </Typography>
             <Paragraph>
@@ -124,7 +132,7 @@ const CodeOfConduct = () => {
                     "codeOfConduct:responsibilitiesSectionSubSection1FirstParagraph"
                 )}
             </Paragraph>
-            <Typography className="title-conduct" variant="h5">
+            <Typography className="subtitle-conduct" variant="h3">
                 {t("codeOfConduct:responsibilitiesSectionSubSection2")}
             </Typography>
             <Paragraph>

--- a/src/components/CodeOfConduct/CodeOfConduct.tsx
+++ b/src/components/CodeOfConduct/CodeOfConduct.tsx
@@ -1,47 +1,53 @@
-import { Row, Typography } from "antd";
+import { Grid, Typography } from "@mui/material"
 import colors from "../../styles/colors";
 import { useTranslation } from "next-i18next";
 import Paragraph from "../Paragraph";
+import styled from "styled-components";
 
-const { Title } = Typography;
+const CodeOfConductStyle = styled(Grid)`
+    color: ${colors.primary};
+    justify-content: "center";
+    width: "100%";
+    font-size: 1rem;
+    letter-Spacing: 1px;
+    font-weight: 600;
+    padding: 20px;
+
+    .title-conduct{
+        margin: 20px 0;
+        font-Family: serif; 
+        font-Weight: 600;
+    }
+`;
 
 const CodeOfConduct = () => {
     const { t } = useTranslation();
     return (
-        <Row
-            style={{
-                color: colors.primary,
-                justifyContent: "center",
-                width: "100%",
-                fontSize: "1rem",
-                letterSpacing: "1px",
-                fontWeight: 600,
-                padding: "20px",
-            }}
-        >
-            <Title>{t("codeOfConduct:title")}</Title>
-
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+        <CodeOfConductStyle item>
+            <Typography style={{ fontSize:40,textAlign:"center", fontFamily: "initial", fontWeight:600}} variant="h4">
+                {t("codeOfConduct:title")}
+            </Typography>            
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:introductionSection")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:introductionSectionFirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:principlesSection")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:principlesSectionFirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:dutiesSection")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:dutiesSectionFirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:methodologySection")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:methodologySectionFirstParagraph")}
             </Paragraph>
@@ -59,68 +65,68 @@ const CodeOfConduct = () => {
             <Paragraph>
                 {t("codeOfConduct:methodologySectionSecondParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:expectedBehaviorSection")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:expectedBehaviorSectionFirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:expectedBehaviorSubSection1")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:expectedBehaviorSubSection1FirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:expectedBehaviorSubSection2")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:expectedBehaviorSubSection2FirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:unacceptableBehaviorSection")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t("codeOfConduct:unacceptableBehaviorSectionFirstParagraph")}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:unacceptableBehaviorSubSection1")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t(
                     "codeOfConduct:unacceptableBehaviorSubSection1FirstParagraph"
                 )}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:unacceptableBehaviorSubSection2")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t(
                     "codeOfConduct:unacceptableBehaviorSubSection2FirstParagraph"
                 )}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:unacceptableBehaviorSubSection3")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t(
                     "codeOfConduct:unacceptableBehaviorSubSection3FirstParagraph"
                 )}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={2}>
+            <Typography className="title-conduct" variant="h4">
                 {t("codeOfConduct:responsibilitiesSection")}
-            </Title>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            </Typography>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:responsibilitiesSectionSubSection1")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t(
                     "codeOfConduct:responsibilitiesSectionSubSection1FirstParagraph"
                 )}
             </Paragraph>
-            <Title style={{ width: "100%", marginTop: "10px" }} level={3}>
+            <Typography className="title-conduct" variant="h5">
                 {t("codeOfConduct:responsibilitiesSectionSubSection2")}
-            </Title>
+            </Typography>
             <Paragraph>
                 {t(
                     "codeOfConduct:responsibilitiesSectionSubSection2FirstParagraph"
@@ -131,7 +137,7 @@ const CodeOfConduct = () => {
                     "codeOfConduct:responsibilitiesSectionSubSection2SecondParagraph"
                 )}
             </Paragraph>
-        </Row>
+        </CodeOfConductStyle>
     );
 };
 

--- a/src/components/Debate/DebateGrid.tsx
+++ b/src/components/Debate/DebateGrid.tsx
@@ -1,4 +1,4 @@
-import { Col, Row, Typography } from "antd";
+import { Grid, Typography } from "@mui/material"
 import { useTranslation } from "next-i18next";
 import React from "react";
 
@@ -10,8 +10,6 @@ import PersonalityMinimalCard from "../Personality/PersonalityMinimalCard";
 import { NameSpaceEnum } from "../../types/Namespace";
 import { useAtom } from "jotai";
 import { currentNameSpace } from "../../atoms/namespace";
-
-const { Title } = Typography;
 
 const DebateGrid = ({ debates }) => {
     const { t } = useTranslation();
@@ -43,9 +41,9 @@ const DebateGrid = ({ debates }) => {
                                 width: "100%",
                             }}
                         >
-                            <Row>
-                                <Title
-                                    level={3}
+                            <Grid container>
+                                <Typography
+                                    variant="h3"
                                     style={{
                                         fontSize: "22px",
                                         lineHeight: "32px",
@@ -56,30 +54,30 @@ const DebateGrid = ({ debates }) => {
                                 >
                                     {debateClaim.title} (
                                     {t("debates:liveLabel")})
-                                </Title>
-                            </Row>
-                            <Row
+                                </Typography>
+                            </Grid>
+                            <Grid container
                                 style={{
                                     justifyContent: "space-evenly",
                                 }}
                             >
                                 {debateClaim.personalities.map((p) => {
                                     return (
-                                        <Col key={p._id} xs={24} md={11}>
+                                        <Grid item key={p._id} xs={12} md={5.5}>
                                             <PersonalityMinimalCard
                                                 personality={p}
                                             />
-                                        </Col>
+                                        </Grid>
                                     );
                                 })}
-                            </Row>
-                            <Row
+                            </Grid>
+                            <Grid container
                                 style={{
                                     justifyContent: "center",
                                     marginTop: "16px",
                                 }}
                             >
-                                <Col>
+                                <Grid item>
                                     <Button
                                         href={
                                             nameSpace !== NameSpaceEnum.Main
@@ -91,8 +89,8 @@ const DebateGrid = ({ debates }) => {
                                             {t("debates:seeDebate")}
                                         </span>
                                     </Button>
-                                </Col>
-                            </Row>
+                                </Grid>
+                            </Grid>
                         </div>
                     </CardBase>
                 );

--- a/src/components/Footer/AletheiaSocialMediaIcons.tsx
+++ b/src/components/Footer/AletheiaSocialMediaIcons.tsx
@@ -9,7 +9,7 @@ import { Grid } from "@mui/material";
 const AletheiaSocialMediaIcons = () => {
     const [nameSpace] = useAtom(currentNameSpace);
     return (
-        <Grid container xs={12}
+        <Grid container item xs={12}
             style={{justifyContent:"center"}}>
             <SocialIcon
                 url="https://www.instagram.com/aletheiafact"

--- a/src/components/Header/HeaderContent.tsx
+++ b/src/components/Header/HeaderContent.tsx
@@ -68,7 +68,7 @@ const HeaderContent = () => {
                 <Logo />
             </a>
             <SearchOverlay />
-            <HeaderActionsStyle xs={7} sm={5} md={3}>
+            <HeaderActionsStyle item xs={7} sm={5} md={3}>
                 {vw?.xs && !router.pathname.includes("/home-page") && (
                     <AletheiaButton
                         onClick={handleClickSearchIcon}

--- a/src/components/Home/HomeStats.tsx
+++ b/src/components/Home/HomeStats.tsx
@@ -8,7 +8,7 @@ const HomeStats = ({ stats }) => {
     const { t } = useTranslation();
 
     return (
-        <Grid container
+        <Grid container item
             sm={9}
             md={8}
             xl={6}

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,15 +1,14 @@
 import React from "react";
-import { Typography } from "antd";
 import colors from "../styles/colors";
-const { Text } = Typography;
+import Typography from "@mui/material/Typography"
 
 const Label = ({ children, required = false }) => {
     return (
         <span style={{ color: colors.error }}>
             {required && "* "}
-            <Text strong style={{ color: colors.blackSecondary }}>
+            <Typography variant="body2" style={{ color: colors.blackSecondary, fontWeight:600 }}>
                 {children}
-            </Text>
+            </Typography>
         </span>
     );
 };

--- a/src/components/Metrics/ReviewStats.tsx
+++ b/src/components/Metrics/ReviewStats.tsx
@@ -37,7 +37,7 @@ const ReviewStats = (props) => {
                             type={ButtonType.blue}
                             onClick={() => setShowAllReviews(true)}
                         >
-                            <AletheiaTitle level={4}>
+                            <AletheiaTitle variant="h4">
                                 {t(`personality:seeAllMetricsOverviews`)}
                             </AletheiaTitle>
                             <ArrowDownwardOutlined
@@ -54,7 +54,7 @@ const ReviewStats = (props) => {
                             type={ButtonType.blue}
                             onClick={() => setShowAllReviews(false)}
                         >
-                            <AletheiaTitle level={4}>
+                            <AletheiaTitle variant="h4">
                                 {t(`personality:seeLessMetricsOverviews`)}
                             </AletheiaTitle>
                             <ArrowUpwardOutlined

--- a/src/components/Personality/MorePersonalities.tsx
+++ b/src/components/Personality/MorePersonalities.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Row, Col } from "antd";
+import Grid from "@mui/material/Grid"
 import SocialMediaShare from "../SocialMediaShare";
 import { useTranslation } from "next-i18next";
 import SectionTitle from "../SectionTitle";
@@ -15,23 +15,23 @@ const MorePersonalities = ({ personalities, href, title }) => {
     const [isLoggedIn] = useAtom(isUserLoggedIn);
 
     return (
-        <Row
+        <Grid container
             style={{
                 width: "100%",
                 paddingTop: "32px",
                 justifyContent: "center",
             }}
         >
-            <Col span={isLoggedIn || vw?.md ? 18 : 12}>
+            <Grid item xs={isLoggedIn || vw?.md ? 9 : 6}>
                 <PersonalitiesGrid
                     personalities={personalities}
                     title={title}
                 />
-            </Col>
+            </Grid>
 
-            <Col
-                span={isLoggedIn || vw?.md ? 24 : 6}
-                style={{ paddingLeft: vw?.md ? 0 : 20 }}
+            <Grid item
+                xs={isLoggedIn || vw?.md ? 12 : 3}
+                style={{    paddingLeft: vw?.md ? 0 : 20}} 
             >
                 {!isLoggedIn && (
                     <>
@@ -41,14 +41,14 @@ const MorePersonalities = ({ personalities, href, title }) => {
                             </SectionTitle>
                         )}
 
-                        <Row id="create_account">
+                        <Grid container id="create_account">
                             <CTARegistration />
-                        </Row>
+                        </Grid>
                     </>
                 )}
                 <SocialMediaShare href={href} />
-            </Col>
-        </Row>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/Personality/MorePersonalities.tsx
+++ b/src/components/Personality/MorePersonalities.tsx
@@ -22,7 +22,7 @@ const MorePersonalities = ({ personalities, href, title }) => {
                 justifyContent: "center",
             }}
         >
-            <Grid item xs={isLoggedIn || vw?.md ? 9 : 6}>
+            <Grid item xs={isLoggedIn || vw?.lg ? 9 : 6}>
                 <PersonalitiesGrid
                     personalities={personalities}
                     title={title}
@@ -30,8 +30,8 @@ const MorePersonalities = ({ personalities, href, title }) => {
             </Grid>
 
             <Grid item
-                xs={isLoggedIn || vw?.md ? 12 : 3}
-                style={{    paddingLeft: vw?.md ? 0 : 20}} 
+                xs={isLoggedIn || vw?.lg ? 11 : 3}
+                style={{    paddingLeft: vw?.lg ? 0 : 20}} 
             >
                 {!isLoggedIn && (
                     <>

--- a/src/components/Personality/PersonalityView.tsx
+++ b/src/components/Personality/PersonalityView.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from "antd";
+import Grid from "@mui/material/Grid"
 import { useTranslation } from "next-i18next";
 
 import ClaimList from "../Claim/ClaimList";
@@ -25,20 +25,20 @@ const PersonalityView = ({ personality, href, personalities }) => {
                     url: href,
                 }}
             />
-            <Row justify="center">
-                <Col sm={22} md={22} lg={18}>
+            <Grid container justifyContent="center">
+                <Grid item sm={11} md={11} lg={9}>
                     <PersonalityCard personality={personality} header={true} />
-                </Col>
-            </Row>
+                </Grid>
+            </Grid>
 
-            <Row justify="center" style={{ marginTop: "64px" }}>
-                <Col sm={22} md={14} lg={12}>
+            <Grid container justifyContent="center"style={{ marginTop: "64px" }}>
+                <Grid item sm={11} md={7} lg={6}>
                     <ClaimList personality={personality} />
-                </Col>
-                <Col sm={22} md={8} lg={6} style={{ width: "100%" }}>
+                </Grid>
+                <Grid item sm={11} md={4} lg={3} style={{ width: "100%" }}>
                     <MetricsOverview stats={personality.stats} />
-                </Col>
-            </Row>
+                </Grid>
+            </Grid>
 
             <MorePersonalities
                 personalities={personalities}

--- a/src/components/SectionTitle.tsx
+++ b/src/components/SectionTitle.tsx
@@ -1,23 +1,22 @@
 import React from "react";
 import colors from "../styles/colors";
-import { Typography } from "antd";
-
-const { Title } = Typography;
+import Typography from "@mui/material/Typography"
 
 const SectionTitle = (props) => {
     return (
-        <Title
-            level={2}
+        <Typography 
+            variant="h2"
             style={{
-                fontSize: "22px",
+                fontFamily:"initial",
+                fontSize: "24px",
                 lineHeight: "32px",
                 margin: "0 0 16px 0",
-                fontWeight: 400,
+                fontWeight: 500,
                 color: colors.neutral,
             }}
         >
             {props.children}
-        </Title>
+        </Typography >
     );
 };
 

--- a/src/components/SocialMediaShare.tsx
+++ b/src/components/SocialMediaShare.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Typography } from "antd";
+import Typography from "@mui/material/Typography"
 import {
     FacebookShareButton,
     FacebookIcon,
@@ -18,8 +18,6 @@ import { useAtom } from "jotai";
 import { isUserLoggedIn } from "../atoms/currentUser";
 import { NameSpaceEnum } from "../types/Namespace";
 import { currentNameSpace } from "../atoms/namespace";
-
-const { Title } = Typography;
 
 const SocialMediaShare = ({ quote = null, href = "", claim = null }) => {
     const { t } = useTranslation();
@@ -53,20 +51,21 @@ const SocialMediaShare = ({ quote = null, href = "", claim = null }) => {
                 marginTop: "20px",
             }}
         >
-            <Title
-                level={3}
+            <Typography
+                variant="h3"
                 style={{
+                    fontFamily:"initial",
                     width: "auto",
                     textAlign: "center",
                     marginBottom: 0,
-                    fontSize: "26px",
+                    fontSize: "28px",
                     lineHeight: "39px",
-                    fontWeight: 400,
+                    fontWeight: 500,
                     color: colors.blackSecondary,
                 }}
             >
                 {t("share:title")}
-            </Title>
+            </Typography>
             <nav className="social-media-container">
                 <ul
                     className="social-media-list"

--- a/src/components/Subtitle.tsx
+++ b/src/components/Subtitle.tsx
@@ -1,21 +1,19 @@
 import React from 'react'
-import { Typography } from "antd";
-
-const { Title } = Typography;
+import  Typography  from "@mui/material/Typography";
 
 const Subtitle = (props) => {
     return(
-        <Title
-            level={2} 
+        <Typography
+            variant="h2"
             style={{
-                fontWeight: 600,
+                fontWeight: 700,
                 fontSize: 24,
                 lineHeight: 1.35,
                 ...props.style
             }}
         >
             {props.children}
-        </Title>
+        </Typography>
     )
 }
 


### PR DESCRIPTION
# Description
*In this PR, I replaced all Ant Design Typography components with MUI, and where necessary, I replaced Ant Design's Col, Row, Affix, and Comment components with their respective MUI equivalents.*

# Testing 
*I only replaced the typographs, but in some components, I also adjusted the responsiveness since I was already working on them.*

*Each component*
- [ ] #1481
- [ ] #1514
- [ ] #1685
- [ ] #1684
- [ ] #1519
- [ ] #1522
- [ ] #1523
- [ ] #1532
- [ ] #1533
- [ ] #1534
- [ ] #1554
- [ ] #1538
- [ ] #1552
- [ ] #1573

*A visual document outlining which visual parts of the site are intended to facilitate testing:*
[teste-typograph1.pdf](https://github.com/user-attachments/files/18223211/teste-typograph1.pdf)

closes #1481, #1514, #1685, #1684, #1519, #1522, #1523, #1532, #1533, #1534, #1554, #1538, #1552, #1573
