### PR TITLE
Migrate antd to mui Layout component

### DIFF
--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -1,26 +1,6 @@
-import { Layout, Row } from "antd";
+import { Box, Grid } from "@mui/material";
 import { useRouter } from "next/router";
-import styled from "styled-components";
-
-import colors from "../styles/colors";
-import { queries } from "../styles/mediaQueries";
 import BackButton from "./BackButton";
-
-const { Content } = Layout;
-
-const StyledContent = styled(Content)`
-    padding: 0;
-
-    ${({ layout }: { layout: string }) =>
-        layout === "mobile" &&
-        `
-        padding: 0 30%;
-
-        @media ${queries.sm} {
-            padding: 0 15px;
-        }
-    `}
-`;
 
 const ContentWrapper = ({ children }) => {
     const router = useRouter();
@@ -45,21 +25,31 @@ const ContentWrapper = ({ children }) => {
         : "desktop";
 
     return (
-        <StyledContent layout={layout}>
+        <Box
+            sx={{
+                padding: layout === "mobile" ? "0 30%" : "0",
+                "@media (max-width: 600px)": {
+                    padding: layout === "mobile" ? "0 15px" : "0",
+                },
+            }}
+        >
             {layout === "mobile" && (
-                <Row
-                    style={{
+                <Grid
+                    container
+                    item
+                    xs={12}
+                    sx={{
                         padding: "10px 30px",
-                        background: colors.white,
+                        backgroundColor: "white",
                         boxShadow: "0px 2px 3px rgba(0, 0, 0, 0.15)",
-                        margin: "0px",
+                        margin: 0,
                     }}
                 >
                     <BackButton />
-                </Row>
+                </Grid>
             )}
             {children}
-        </StyledContent>
+        </Box>
     );
 };
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
-import { Col, Layout, Row } from "antd";
+import { Box, Grid, Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import React, { useLayoutEffect, useState } from "react";
-
 import { useAppSelector } from "../../store/store";
 import colors from "../../styles/colors";
 import AletheiaSocialMediaFooter from "./AletheiaSocialMediaFooter";
@@ -20,35 +19,33 @@ const Footer = () => {
 
     useLayoutEffect(() => {
         setBackgroundColor(
-            nameSpace === NameSpaceEnum.Main
-                ? colors.primary
-                : colors.secondary
+            nameSpace === NameSpaceEnum.Main ? colors.primary : colors.secondary
         );
     }, [nameSpace]);
 
     return (
-        <Layout.Footer
-            style={{
+        <Box
+            component="footer"
+            sx={{
                 textAlign: "center",
                 background: backgroundColor,
                 color: colors.white,
                 padding: "32px",
             }}
         >
-            <Row gutter={24} justify="center">
-                <Col lg={8} md={10} sm={24}>
+            <Grid container spacing={3} justifyContent="center">
+                <Grid item lg={4} md={5} sm={12}>
                     <AletheiaSocialMediaFooter />
-
-                    <Row
-                        style={{
-                            marginTop: "10px",
-                            width: "100%",
+                    <Box
+                        sx={{
+                            mt: 1,
                             textAlign: "center",
+                            display: "flex",
                             flexDirection: "column",
-                            marginBottom: vw?.sm ? "32px" : "0",
+                            mb: vw?.sm ? 4 : 0,
                         }}
                     >
-                        <Col style={{ marginBottom: "16px" }}>
+                        <Box sx={{ mb: 2 }}>
                             <a
                                 rel="license noreferrer"
                                 href="https://creativecommons.org/licenses/by-sa/4.0/"
@@ -61,7 +58,7 @@ const Footer = () => {
                                     src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"
                                 />
                             </a>
-                        </Col>
+                        </Box>
 
                         {t("footer:creativeCommons")}
                         <a
@@ -77,49 +74,41 @@ const Footer = () => {
                             Creative Commons Attribution-ShareAlike 4.0
                             International License
                         </a>
-                    </Row>
-                </Col>
-                <Col
-                    lg={8}
-                    md={10}
-                    sm={24}
-                    style={{
+                    </Box>
+                </Grid>
+                <Grid
+                    item
+                    lg={4}
+                    md={5}
+                    sm={12}
+                    sx={{
                         display: "flex",
-                        justifyContent: "space-between",
                         flexDirection: "column",
+                        justifyContent: "space-between",
                     }}
                 >
                     <FooterInfo />
-                    <Row>
-                        <h3
-                            style={{
-                                width: "100%",
+                    <Box sx={{ mt: vw?.sm ? 8 : 0 }}>
+                        <Typography
+                            variant="h6"
+                            sx={{
                                 fontSize: "23px",
                                 color: colors.white,
-                                marginBottom: 0,
-                                marginTop: vw?.sm ? "64px" : "0",
+                                mb: 0,
                                 textAlign: "center",
                             }}
                         >
                             {t("footer:copyright", {
                                 date: new Date().getFullYear(),
                             })}
-                        </h3>
-                    </Row>
-                </Col>
-                <Col
-                    lg={8}
-                    md={10}
-                    sm={24}
-                    style={{
-                        display: "flex",
-                        flexDirection: "column",
-                    }}
-                >
+                        </Typography>
+                    </Box>
+                </Grid>
+                <Grid item lg={4} md={5} sm={12}>
                     <AletheiaInfo />
-                </Col>
-            </Row>
-        </Layout.Footer>
+                </Grid>
+            </Grid>
+        </Box>
     );
 };
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useState } from "react";
-import { Layout } from "antd";
+import { AppBar } from "@mui/material";
 import HeaderContent from "./HeaderContent";
 import colors from "../../styles/colors";
 import { useAtom } from "jotai";
@@ -13,14 +13,12 @@ const AletheiaHeader = () => {
     );
     useLayoutEffect(() => {
         setHeaderBackgroundColor(
-            nameSpace === NameSpaceEnum.Main
-                ? colors.primary
-                : colors.secondary
+            nameSpace === NameSpaceEnum.Main ? colors.primary : colors.secondary
         );
     }, [nameSpace]);
 
     return (
-        <Layout.Header
+        <AppBar
             style={{
                 position: "sticky",
                 top: 0,
@@ -34,7 +32,7 @@ const AletheiaHeader = () => {
             }}
         >
             <HeaderContent />
-        </Layout.Header>
+        </AppBar>
     );
 };
 

--- a/src/components/MainApp.tsx
+++ b/src/components/MainApp.tsx
@@ -1,4 +1,4 @@
-import { Layout } from "antd";
+import { Box } from "@mui/material";
 import React from "react";
 
 import { useMediaQueryBreakpoints } from "../hooks/useMediaQueryBreakpoints";
@@ -31,9 +31,14 @@ const MainApp = ({ children }) => {
     // Setup to provide breakpoints object on redux
     useMediaQueryBreakpoints();
 
+    const renderCTAButton = () =>
+        localConfig.home.affixCTA ? (
+            <AffixCTAButton copilotDrawerWidth={copilotDrawerWidth} />
+        ) : null;
+
     return (
-        <Layout
-            style={{
+        <Box
+            sx={{
                 minHeight: "100vh",
                 width:
                     copilotDrawerCollapsed || vw?.md
@@ -42,18 +47,16 @@ const MainApp = ({ children }) => {
             }}
         >
             <Sidebar />
-            <Layout style={{ background: colors.white }}>
+            <Box sx={{ background: colors.white }}>
                 <Header />
                 <DonationBanner />
-                {localConfig.home.affixCTA ? (
-                    <AffixCTAButton copilotDrawerWidth={copilotDrawerWidth} />
-                ) : null}
+                {renderCTAButton()}
                 <ContentWrapper>{children}</ContentWrapper>
                 <Footer />
                 {enableOverlay && <OverlaySearchResults />}
-            </Layout>
+            </Box>
             <ClaimReviewDrawer />
-        </Layout>
+        </Box>
     );
 };
 


### PR DESCRIPTION
# Description
*I replaced the Layout component from the library Ant Design for Material UI library, using the following components:*
*°Box*
*ºAppBar*
*ºGrid*
*In the MainApp arquive, i change the logic of rendering  CTA Button for better lecture and organization*

# Testing
*1 - Open the Aletheia on your local and go to the main page, look at the Header (just change the Layout for AppBar)* 
*2 - then go all the way down on the same page and look at the content down the Header (change Layout for Box)*
*3 - Look the personalities and in the same page (change Layout and Row for Box and Grid)*
*4 - In the same page go all the way down and look the Footer (change Layout, Row and Col for Grid, Box and Typhograpy)*

*Just the layout component*

- [x] #1517
- [x] #1590

*Layout and another component*

- [x] #1507
- [x] #1581