### PR TITLE
Migrate verification request page to mui material

### DIFF
--- a/public/locales/en/verificationRequest.json
+++ b/public/locales/en/verificationRequest.json
@@ -50,5 +50,6 @@
     "topicsFilterOption": "Topics",
     "contentFilterOption": "Content",
     "filterByContentLabel": "Filter by Content",
-    "applyButtonLabel": "Apply"
+    "applyButtonLabel": "Apply",
+    "showText": "Show"
 }

--- a/public/locales/pt/verificationRequest.json
+++ b/public/locales/pt/verificationRequest.json
@@ -50,5 +50,6 @@
     "topicsFilterOption": "Tópicos",
     "contentFilterOption": "Conteudo",
     "filterByContentLabel": "Filtrar por Conteudo",
-    "applyButtonLabel": "Aplicar"
+    "applyButtonLabel": "Aplicar",
+    "showText": "Mostrar"
 }

--- a/src/components/VerificationRequest/CreateVerificationRequest/CreateVerificationRequestView.tsx
+++ b/src/components/VerificationRequest/CreateVerificationRequest/CreateVerificationRequestView.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { Col, Row } from "antd";
+import { Grid } from "@mui/material";
 import colors from "../../../styles/colors";
 import DynamicVerificationRequestForm from "./DynamicVerificationRequestForm";
 
 const CreateVerificationRequestView = () => {
     return (
-        <Row justify="center" style={{ background: colors.lightNeutral }}>
-            <Col span={18}>
+        <Grid container justifyContent="center" style={{ background: colors.lightNeutral }}>
+            <Grid item xs={9}>
                 <DynamicVerificationRequestForm />
-            </Col>
-        </Row>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/VerificationRequest/VerificationRequestAlert.tsx
+++ b/src/components/VerificationRequest/VerificationRequestAlert.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from "react";
-import { Col } from "antd";
+import { Grid } from "@mui/material";
 import AletheiaButton from "../Button";
 import { useTranslation } from "next-i18next";
 import AletheiaAlert from "../AletheiaAlert";
@@ -88,9 +88,9 @@ const VerificationRequestAlert = ({ targetId, verificationRequestId }) => {
     }
 
     return (
-        <Col span={24}>
+        <Grid item xs={12}>
             <AletheiaAlert {...alertContent} />
-        </Col>
+        </Grid>
     );
 };
 

--- a/src/components/VerificationRequest/VerificationRequestCard.tsx
+++ b/src/components/VerificationRequest/VerificationRequestCard.tsx
@@ -1,5 +1,5 @@
-import { Grid, Chip, Typography } from "@mui/material";
-import React from "react";
+import { Grid, Chip, Typography, Button } from "@mui/material";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import CardBase from "../CardBase";
 import Link from "next/link";
@@ -62,9 +62,25 @@ const truncateUrl = (url) => {
 const VerificationRequestCard = ({
     verificationRequest,
     actions = [],
+    expandable = true,
     t,
     style = {},
 }) => {
+    const [visible, setVisible] = useState(false);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const textRef = useRef(null);
+
+    const handleToggle = () => {
+        setVisible(true);
+    };
+
+    useEffect(() => {
+        if (textRef.current) {
+            const isOverflow = textRef.current.scrollHeight > textRef.current.clientHeight;
+            setIsOverflowing(isOverflow);
+        }
+    }, [verificationRequest.content]);
+
     const getTags = (verificationRequest) => {
         const tags = [];
         if (verificationRequest.publicationDate) {
@@ -156,15 +172,31 @@ const VerificationRequestCard = ({
         <CardBase style={{ padding: 32, ...style }}>
             <ContentWrapper>
                 <Typography
+                    ref={textRef}
                     variant="body1"
                     style={{
                         color: colors.black,
                         margin: 0,
                         lineHeight: 1.6,
+                        display: "-webkit-box",
+                        WebkitBoxOrient: "vertical",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        WebkitLineClamp: visible ? "none" : 3,
                     }}
+
                 >
                     {verificationRequest.content}
                 </Typography>
+                {expandable && !visible && isOverflowing && (
+                    <Button
+                        variant="text"
+                        style={{ marginLeft: "auto", color: colors.lightPrimary, textDecoration: 'underline', padding: 0 }}
+                        onClick={handleToggle}
+                    >
+                        {t("verificationRequest:showText")}
+                    </Button>
+                )}
                 <TagContainer>{getTags(verificationRequest)}</TagContainer>
             </ContentWrapper>
 

--- a/src/components/VerificationRequest/VerificationRequestCard.tsx
+++ b/src/components/VerificationRequest/VerificationRequestCard.tsx
@@ -1,4 +1,4 @@
-import { Col, Tag, Typography } from "antd";
+import { Grid, Chip, Typography } from "@mui/material";
 import React from "react";
 import styled from "styled-components";
 import CardBase from "../CardBase";
@@ -6,7 +6,7 @@ import Link from "next/link";
 import colors from "../../styles/colors";
 import LocalizedDate from "../LocalizedDate";
 
-const CustomTag = styled(Tag)`
+const CustomTag = styled(Chip)`
     border-radius: 4px;
     font-size: 10px;
     margin-bottom: 4px;
@@ -62,7 +62,6 @@ const truncateUrl = (url) => {
 const VerificationRequestCard = ({
     verificationRequest,
     actions = [],
-    expandable = true,
     t,
     style = {},
 }) => {
@@ -77,65 +76,77 @@ const VerificationRequestCard = ({
 
             tags.push(
                 <CustomTag
-                    color={colors.secondary}
+                    style={{ backgroundColor: colors.secondary, color: colors.white }}
                     key={`${verificationRequest._id}|publicationDate`}
-                >
-                    <strong>
-                        {t(
-                            "verificationRequest:verificationRequestTagPublicationDate"
-                        )}
-                        :
-                    </strong>{" "}
-                    {isValidDate ? (
-                        <LocalizedDate date={publicationDate} />
-                    ) : (
-                        verificationRequest.publicationDate
-                    )}
-                </CustomTag>
+                    label={
+                        <div>
+                            <strong>
+                                {t(
+                                    "verificationRequest:verificationRequestTagPublicationDate"
+                                )}
+                                :
+                            </strong>{" "}
+                            {isValidDate ? (
+                                <LocalizedDate date={publicationDate} />
+                            ) : (
+                                verificationRequest.publicationDate
+                            )}
+                        </div>
+                    }
+                />
             );
         }
         if (verificationRequest.date) {
             tags.push(
                 <CustomTag
-                    color={colors.neutralSecondary}
+                    style={{ backgroundColor: colors.neutralSecondary, color: colors.white }}
                     key={`${verificationRequest._id}|date`}
-                >
-                    <strong>
-                        {t("verificationRequest:verificationRequestTagDate")}:
-                    </strong>{" "}
-                    <LocalizedDate date={verificationRequest.date} />
-                </CustomTag>
+                    label={
+                        <div>
+                            <strong>
+                                {t("verificationRequest:verificationRequestTagDate")}:
+                            </strong>{" "}
+                            <LocalizedDate date={verificationRequest.date} />
+                        </div>
+                    }
+                />
             );
         }
         if (verificationRequest.heardFrom) {
             tags.push(
                 <CustomTag
-                    color={colors.tertiary}
+                    style={{ backgroundColor: colors.tertiary, color: colors.white }}
                     key={`${verificationRequest._id}|heardFrom`}
-                >
-                    <strong>
-                        {t(
-                            "verificationRequest:verificationRequestTagHeardFrom"
-                        )}
-                        :
-                    </strong>{" "}
-                    {verificationRequest.heardFrom}
-                </CustomTag>
+                    label={
+                        <div>
+                            <strong>
+                                {t(
+                                    "verificationRequest:verificationRequestTagHeardFrom"
+                                )}
+                                :
+                            </strong>{" "}
+                            {verificationRequest.heardFrom}
+                        </div>
+                    }
+                />
             );
         }
         if (verificationRequest.source) {
             tags.push(
                 <CustomTag
-                    color={colors.lightPrimary}
+                    style={{ backgroundColor: colors.lightPrimary, color: colors.white }}
                     key={`${verificationRequest._id}|source`}
-                >
-                    <strong>
-                        {t("verificationRequest:verificationRequestTagSource")}:
-                    </strong>
-                    <Link href={verificationRequest.source.href} passHref>
-                        <a>{truncateUrl(verificationRequest.source.href)}</a>
-                    </Link>
-                </CustomTag>
+                    label={
+                        <div>
+                            <strong>
+                                {t("verificationRequest:verificationRequestTagSource")}:
+                            </strong>
+                            <Link href={verificationRequest.source.href} passHref>
+                                <a>{truncateUrl(verificationRequest.source.href)}</a>
+                            </Link>
+                        </div>
+                    }
+                />
             );
         }
         return tags;
@@ -144,21 +155,20 @@ const VerificationRequestCard = ({
     return (
         <CardBase style={{ padding: 32, ...style }}>
             <ContentWrapper>
-                <Typography.Paragraph
+                <Typography
+                    variant="body1"
                     style={{
-                        marginBottom: 0,
                         color: colors.black,
                         margin: 0,
                         lineHeight: 1.6,
                     }}
-                    ellipsis={{ rows: 4, expandable }}
                 >
                     {verificationRequest.content}
-                </Typography.Paragraph>
+                </Typography>
                 <TagContainer>{getTags(verificationRequest)}</TagContainer>
             </ContentWrapper>
 
-            <Col
+            <Grid item
                 style={{
                     marginTop: 16,
                     display: "flex",
@@ -170,7 +180,7 @@ const VerificationRequestCard = ({
                 }}
             >
                 {actions ? actions.map((action) => action) : <></>}
-            </Col>
+            </Grid>
         </CardBase>
     );
 };

--- a/src/components/VerificationRequest/VerificationRequestDisplay.style.tsx
+++ b/src/components/VerificationRequest/VerificationRequestDisplay.style.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 import { queries } from "../../styles/mediaQueries";
-import { Row } from "antd";
+import { Grid } from "@mui/material";
 
-const VerificationRequestDisplayStyle = styled(Row)`
+const VerificationRequestDisplayStyle = styled(Grid)`
     display: flex;
     gap: 16px;
 

--- a/src/components/VerificationRequest/VerificationRequestDisplay.tsx
+++ b/src/components/VerificationRequest/VerificationRequestDisplay.tsx
@@ -28,7 +28,7 @@ const VerificationRequestDisplay = ({ content }) => {
     };
 
     return (
-        <VerificationRequestDisplayStyle>
+        <VerificationRequestDisplayStyle container>
             <VerificationRequestAlert
                 targetId={content?.group?.targetId}
                 verificationRequestId={content._id}

--- a/src/components/VerificationRequest/VerificationRequestMainContent.tsx
+++ b/src/components/VerificationRequest/VerificationRequestMainContent.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "antd";
+import { Typography } from "@mui/material";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import VerificationRequestCard from "./VerificationRequestCard";
@@ -19,9 +19,9 @@ const VerificationRequestMainContent = ({
 
     return (
         <main style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <Typography.Title level={3}>
+            <Typography style={{ fontFamily: "serif", fontWeight: 600, fontSize: 26, lineHeight: 1.35 }} variant="h3">
                 {t("verificationRequest:verificationRequestTitle")}
-            </Typography.Title>
+            </Typography>
             <VerificationRequestCard verificationRequest={content} t={t} />
             {!vw.xs &&
                 role !== Roles.Regular &&

--- a/src/components/VerificationRequest/VerificationRequestRecommendations.tsx
+++ b/src/components/VerificationRequest/VerificationRequestRecommendations.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Typography } from "antd";
+import { Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import { VerificationRequestContext } from "./VerificationRequestProvider";
 import VerificationRequestResultList from "./VerificationRequestResultList";
@@ -12,9 +12,9 @@ const VerificationRequestRecommendations = () => {
         <>
             {recommendations?.length > 0 && (
                 <section style={{ width: "100%" }}>
-                    <Typography.Title level={4}>
+                    <Typography style={{ fontFamily: "serif", fontWeight: 600, fontSize: 26, lineHeight: 1.35 }} variant="h4">
                         {t("verificationRequest:recommendationTitle")}
-                    </Typography.Title>
+                    </Typography>
                     <VerificationRequestResultList results={recommendations} />
                 </section>
             )}

--- a/src/components/VerificationRequest/VerificationRequestResultList.tsx
+++ b/src/components/VerificationRequest/VerificationRequestResultList.tsx
@@ -1,4 +1,4 @@
-import { Col } from "antd";
+import { Grid } from "@mui/material";
 import React, { useContext, useState } from "react";
 import VerificationRequestCard from "./VerificationRequestCard";
 import AletheiaButton from "../Button";
@@ -27,13 +27,12 @@ const VerificationRequestResultList = ({ results }) => {
         <VerificationRequestResultListStyled>
             {results?.length > 0 &&
                 results.map((verificationRequest) => (
-                    <Col
+                    <Grid item
                         style={{ width: "300px" }}
                         key={verificationRequest._id}
                     >
                         <VerificationRequestCard
                             verificationRequest={verificationRequest}
-                            expandable={false}
                             t={t}
                             style={{ minHeight: "100%" }}
                             actions={[
@@ -61,7 +60,7 @@ const VerificationRequestResultList = ({ results }) => {
                                 </AletheiaButton>,
                             ]}
                         />
-                    </Col>
+                    </Grid>
                 ))}
         </VerificationRequestResultListStyled>
     );

--- a/src/components/VerificationRequest/VerificationRequestResultList.tsx
+++ b/src/components/VerificationRequest/VerificationRequestResultList.tsx
@@ -33,6 +33,7 @@ const VerificationRequestResultList = ({ results }) => {
                     >
                         <VerificationRequestCard
                             verificationRequest={verificationRequest}
+                            expandable={false}
                             t={t}
                             style={{ minHeight: "100%" }}
                             actions={[


### PR DESCRIPTION
# Description
*In this PR, I replaced some `Col`, `Row`, `Tag`, `Typography` in the page for creating `verification requests` and in the "verification request" page as well, following the patterns of previous changes. However, this was the first `Tag` I replaced, and the most accessible in the MUI library, which is the `Chip`. I adapted how to use them and kept the old design.*

## Functionality to manually expand text  
*Basically, it was done with state management and DOM manipulation. First, I added ellipses via CSS to hide the rest of the text when it exceeds 3 lines if the condition is false. Then, I added the button with a function that would make the condition true, and in that way, set the line limit to 'none', displaying the full text.* 

  *After that, I used a 'useEffect' with an 'if' statement and 'useRef' to check if the total content value was greater than the visible part. If it was, it would mean the text was being truncated, so the "show" button would appear; otherwise, it would not.*

  *I kept the functionality where the button doesn't appear in recommendations and in search.*

![Screenshot from 2025-01-18 16-26-05](https://github.com/user-attachments/assets/df2cc2cf-7716-4be5-832c-70217750b213)
![Screenshot from 2025-01-18 16-06-59](https://github.com/user-attachments/assets/2137d939-92c2-4cbd-a8df-4b4a89b59754)
![Screenshot from 2025-01-18 16-07-18](https://github.com/user-attachments/assets/b4823cdb-6467-4f16-aee9-f62a46f1b2f4)


# Testing
*In this PR, I managed to separate the pages as we discussed. The `Col` and `Row` were replaced by `Grid`, and in relation to this, the site's responsiveness needs to be tested. The `Tag` was replaced by the `Chip`, which are basically those colored cards inside the report. All the `Typography` from Ant Design was also replaced, so it’s necessary to check if there is any text that’s out of the pattern or breaking the design.*

**Components:**
- [ ] #1715 
- [ ] #1718 
- [ ] #1726 
- [ ] #1727 
- [ ] #1739 
- [ ] #1740 
- [ ] #1745 

A visual document outlining which visual parts of the site need to be tested:  
[Guia visual testes 1.pdf](https://github.com/user-attachments/files/18464300/Guia.visual.testes.1.pdf)
*This guide was created while I was making the changes. You’ll be able to use it in the following PRs as well.*


closes #1715, closes #1718, closes #1726, closes #1727, closes #1739, closes #1740, closes #1745