### PR TITLE
Migrate kanban and home header page to mui material 

### DIFF
--- a/src/components/Home/HomeHeader/HomeHeader.style.tsx
+++ b/src/components/Home/HomeHeader/HomeHeader.style.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import { queries } from "../../../styles/mediaQueries";
 import colors from "../../../styles/colors";
-import { Col } from "antd";
+import Grid from "@mui/material/Grid";
 
-const HomeHeaderStyle = styled(Col)`
+const HomeHeaderStyle = styled(Grid)`
     display: flex;
     background-color: ${colors.blackTertiary};
     align-items: center;

--- a/src/components/Home/HomeHeader/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader/HomeHeader.tsx
@@ -1,4 +1,4 @@
-import { Col } from "antd";
+import Grid from "@mui/material/Grid";
 import React from "react";
 import CTASection from "../CTA/CTASection";
 import HomeHeaderStyle from "./HomeHeader.style";
@@ -8,17 +8,17 @@ import HomeHeaderSearch from "./HomeHeaderSearch";
 
 const HomeHeader = ({ stats }) => {
     return (
-        <HomeHeaderStyle>
-            <Col
-                xxl={12}
-                lg={16}
-                sm={18}
-                xs={24}
+        <HomeHeaderStyle container>
+            <Grid item
+                xl={6}
+                lg={8}
+                sm={9}
+                xs={12}
                 className="home-header-content"
             >
                 <HomeHeaderTitle />
                 <CTASection />
-            </Col>
+            </Grid>
             <HomeStats stats={stats} />
 
             <HomeHeaderSearch />

--- a/src/components/Home/HomeHeader/HomeHeaderSearch.style.tsx
+++ b/src/components/Home/HomeHeader/HomeHeaderSearch.style.tsx
@@ -1,9 +1,9 @@
-import { Col } from "antd";
+import Grid from "@mui/material/Grid";
 import styled from "styled-components";
 import { queries } from "../../../styles/mediaQueries";
 import colors from "../../../styles/colors";
 
-const HomeHeaderSearchStyled = styled(Col)`
+const HomeHeaderSearchStyled = styled(Grid)`
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/components/Home/HomeHeader/HomeHeaderSearch.tsx
+++ b/src/components/Home/HomeHeader/HomeHeaderSearch.tsx
@@ -41,7 +41,7 @@ const HomeHeaderSearch = () => {
     };
 
     return (
-        <HomeHeaderSearchStyled xxl={12} lg={16} sm={18} xs={24}>
+        <HomeHeaderSearchStyled container item xl={6} lg={8} sm={9} xs={12}>
             <h2 className="title">{t("home:homeHeaderSearchTitle")}</h2>
 
             <InputSearch

--- a/src/components/Home/HomeHeader/HomeHeaderTitle.tsx
+++ b/src/components/Home/HomeHeader/HomeHeaderTitle.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { Col } from "antd";
+import Grid from "@mui/material/Grid";
 import { useTranslation } from "next-i18next";
 
 const HomeHeaderTitle = () => {
     const { t } = useTranslation();
     return (
-        <Col className="home-header-title">
+        <Grid item className="home-header-title">
             <h1>{t("home:title")}</h1>
-        </Col>
+        </Grid>
     );
 };
 

--- a/src/components/Kanban/EmptyKanbanGrid.tsx
+++ b/src/components/Kanban/EmptyKanbanGrid.tsx
@@ -1,8 +1,8 @@
-import { Divider } from "antd";
+import { Divider } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import React from "react";
 
-const EmptyKanbanCol = ({ title }) => {
+const EmptyKanbanGrid = ({ title }) => {
     const { t } = useTranslation();
     return (
         <div
@@ -16,9 +16,9 @@ const EmptyKanbanCol = ({ title }) => {
             <span style={{ fontSize: 24 }}>{title}</span>
 
             <span>{t("list:totalItems", { total: 0 })}</span>
-            <Divider style={{ marginTop: 12 }} />
+            <Divider flexItem variant="middle" style={{ marginTop: 12 }} />
         </div>
     );
 };
 
-export default EmptyKanbanCol;
+export default EmptyKanbanGrid;

--- a/src/components/Kanban/KanbanGrid.tsx
+++ b/src/components/Kanban/KanbanGrid.tsx
@@ -6,7 +6,7 @@ import { ReviewTaskStates } from "../../machines/reviewTask/enums";
 import KanbanSkeleton from "../Skeleton/KanbanSkeleton";
 import colors from "../../styles/colors";
 import BaseList from "../List/BaseList";
-import EmptyKanbanCol from "./EmptyKanbanCol";
+import EmptyKanbanGrid from "./EmptyKanbanGrid";
 import KanbanCard from "./KanbanCard";
 import styled from "styled-components";
 
@@ -32,7 +32,7 @@ interface KanbanColProps {
     };
 }
 
-const KanbanCol = ({
+const KanbanGrid = ({
     nameSpace,
     state,
     filterUser,
@@ -58,7 +58,7 @@ const KanbanCol = ({
                     />
                 )}
                 emptyFallback={
-                    <EmptyKanbanCol title={t(`reviewTask:${state}`)} />
+                    <EmptyKanbanGrid title={t(`reviewTask:${state}`)} />
                 }
                 showDividers={false}
                 skeleton={<KanbanSkeleton />}
@@ -68,4 +68,4 @@ const KanbanCol = ({
     );
 };
 
-export default KanbanCol;
+export default KanbanGrid;

--- a/src/components/Kanban/KanbanToolbar.tsx
+++ b/src/components/Kanban/KanbanToolbar.tsx
@@ -1,4 +1,4 @@
-import { Col } from "antd";
+import { Grid } from "@mui/material";
 import React from "react";
 import { useTranslation } from "next-i18next";
 
@@ -18,7 +18,7 @@ const KanbanToolbar = ({ filterUserTasks, setFilterUserTasks }) => {
     };
 
     return (
-        <Col span={24} className="kanban-toolbar">
+        <Grid item xs={12} className="kanban-toolbar">
             {Object.keys(filterUserTasks).map((task) => (
                 <FormControlLabel
                     key={task}
@@ -35,7 +35,7 @@ const KanbanToolbar = ({ filterUserTasks, setFilterUserTasks }) => {
                     )}
                 />
             ))}
-        </Col>
+        </Grid>
     );
 };
 

--- a/src/components/Kanban/KanbanToolbar.tsx
+++ b/src/components/Kanban/KanbanToolbar.tsx
@@ -1,8 +1,7 @@
-import { Grid } from "@mui/material";
 import React from "react";
 import { useTranslation } from "next-i18next";
 
-import { FormControlLabel, Switch } from "@mui/material";
+import { FormControlLabel, Switch, Grid } from "@mui/material";
 
 const KanbanToolbar = ({ filterUserTasks, setFilterUserTasks }) => {
     const { t } = useTranslation();

--- a/src/components/Kanban/KanbanView.tsx
+++ b/src/components/Kanban/KanbanView.tsx
@@ -1,5 +1,5 @@
-import { Col } from "antd";
-import React, { useMemo, useState } from "react";
+import { Grid } from "@mui/material";
+import React, { useState } from "react";
 
 import {
     KanbanClaimState,
@@ -8,7 +8,7 @@ import {
     ReviewTaskStates,
     ReviewTaskTypeEnum,
 } from "../../machines/reviewTask/enums";
-import KanbanCol from "./KanbanCol";
+import KanbanGrid from "./KanbanGrid";
 import { useAtom } from "jotai";
 import { currentNameSpace } from "../../atoms/namespace";
 import KanbanViewStyled from "./KanbanView.style";
@@ -36,9 +36,9 @@ const KanbanView = ({ reviewTaskType }) => {
                 filterUserTasks={filterUserTasks}
                 setFilterUserTasks={setFilterUserTasks}
             />
-            <Col span={23} className="kanban-board">
+            <Grid container xs={11.5} justifyContent="center" className="kanban-board">
                 {states.map((state) => (
-                    <KanbanCol
+                    <KanbanGrid
                         key={state}
                         nameSpace={nameSpace}
                         state={ReviewTaskStates[state]}
@@ -46,7 +46,7 @@ const KanbanView = ({ reviewTaskType }) => {
                         reviewTaskType={reviewTaskType}
                     />
                 ))}
-            </Col>
+            </Grid>
         </KanbanViewStyled>
     );
 };

--- a/src/components/Kanban/KanbanView.tsx
+++ b/src/components/Kanban/KanbanView.tsx
@@ -36,7 +36,7 @@ const KanbanView = ({ reviewTaskType }) => {
                 filterUserTasks={filterUserTasks}
                 setFilterUserTasks={setFilterUserTasks}
             />
-            <Grid container xs={11.5} justifyContent="center" className="kanban-board">
+            <Grid container item xs={11.5} justifyContent="center" className="kanban-board">
                 {states.map((state) => (
                     <KanbanGrid
                         key={state}


### PR DESCRIPTION
# Description
*In this PR, I migrated the Kanban page and the HomeHeader to MUI Material. This mostly involved replacing `Col` with `Grid` and adapting the `Divider` from Ant Design to MUI.*

# Testing
*In this PR, I managed to separate the pages as we discussed. The `Col` were replaced by `Grid`, and in relation to this, the site's responsiveness needs to be tested. The `divider` is a very subtle element used to separate items on the website. It looks like a line, and to test it, you just need to check if its design is correct and if it doesn’t break anything.*

**Components:**
- [ ] #1748  
- [ ] #1736 
- [ ] #1735 
- [ ] #1731 
- [ ] #1732  
- [ ] #1733  
- [ ] #1734  


**A visual document outlining which visual parts of the site need to be tested:**
[Guia visual testes 1.pdf](https://github.com/user-attachments/files/18464300/Guia.visual.testes.1.pdf)
*This guide was created while I was making the changes. You’ll be able to use it in the following PRs as well.*


closes #1748, closes #1736 , closes #1735 , closes #1731 , closes #1732 , closes #1733, closes #1734