### PR TITLE
Migrate sentence report page

### DIFF
--- a/src/components/SentenceReport/ClaimSummaryDisplay.tsx
+++ b/src/components/SentenceReport/ClaimSummaryDisplay.tsx
@@ -2,14 +2,11 @@ import React from "react";
 import { ContentModelEnum } from "../../types/enums";
 import SentenceReportSummary from "./SentenceReportSummary";
 import { generateSentenceContentPath } from "../../utils/GetSentenceContentHref";
-import { Typography } from "antd";
 import ClaimInfo from "../Claim/ClaimInfo";
 import { useAtom } from "jotai";
 import { currentNameSpace } from "../../atoms/namespace";
 import { useTranslation } from "next-i18next";
 import ReviewContent from "../ClaimReview/ReviewContent";
-
-const { Paragraph } = Typography;
 
 const ClaimSummaryDisplay = ({
     claim,
@@ -76,7 +73,7 @@ const ClaimSummaryDisplay = ({
 
     return (
         <>
-            <SentenceReportSummary className={personality ? "after" : ""}>
+            <SentenceReportSummary container className={personality ? "after" : ""}>
                 <ReviewContent
                     title={isImage ? claim?.title : title}
                     content={content?.content}

--- a/src/components/SentenceReport/SentenceReportCard.style.tsx
+++ b/src/components/SentenceReport/SentenceReportCard.style.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import colors from "../../styles/colors";
 import { queries } from "../../styles/mediaQueries";
-import { Row } from "antd";
+import { Grid } from "@mui/material";
 
-const SentenceReportCardStyle = styled(Row)`
+const SentenceReportCardStyle = styled(Grid)`
     padding-top: 32px;
 
     .sentence-card {

--- a/src/components/SentenceReport/SentenceReportCard.tsx
+++ b/src/components/SentenceReport/SentenceReportCard.tsx
@@ -1,4 +1,4 @@
-import { Col, Typography } from "antd";
+import { Grid, Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import React, { useContext } from "react";
 
@@ -12,8 +12,6 @@ import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMa
 import ClaimSummaryDisplay from "./ClaimSummaryDisplay";
 import SourceSummaryDisplay from "./SourceSummaryDisplay";
 import VerificationRequestDisplay from "../VerificationRequest/VerificationRequestDisplay";
-
-const { Title } = Typography;
 
 const SentenceReportCard = ({
     target,
@@ -39,24 +37,23 @@ const SentenceReportCard = ({
         reviewTaskType === ReviewTaskTypeEnum.VerificationRequest;
 
     return (
-        <SentenceReportCardStyle>
+        <SentenceReportCardStyle container>
             {personality && (
-                <Col md={6} sm={24}>
+                <Grid item md={3} sm={12}>
                     <PersonalityMinimalCard
                         personality={personality}
                         avatarSize={80}
                     />
-                </Col>
+                </Grid>
             )}
-            <Col
-                lg={personality ? 18 : 24}
-                md={personality ? (md && !sm ? 17 : 18) : 24}
-                offset={personality && md && !sm ? 1 : 0}
-                sm={24}
+            <Grid item
+                lg={personality ? 9 : 12}
+                md={personality ? (md && !sm ? 8.5 : 9) : 12}
+                sm={12}
                 className="sentence-card"
             >
                 {classification && (
-                    <Title className="classification" level={1}>
+                    <Typography variant="h1" className="classification">
                         <ReviewClassification
                             // TODO: Create a more meaningful h1 for this page
                             label={t(
@@ -64,7 +61,7 @@ const SentenceReportCard = ({
                             )}
                             classification={classification}
                         />
-                    </Title>
+                    </Typography>
                 )}
                 {isClaim && (
                     <ClaimSummaryDisplay
@@ -86,7 +83,7 @@ const SentenceReportCard = ({
                         style={{ padding: "10px" }}
                     />
                 )}
-            </Col>
+            </Grid>
         </SentenceReportCardStyle>
     );
 };

--- a/src/components/SentenceReport/SentenceReportContent.style.tsx
+++ b/src/components/SentenceReport/SentenceReportContent.style.tsx
@@ -2,12 +2,16 @@ import styled from "styled-components";
 
 const SentenceReportContentStyle = styled.div`
     margin: 10px 0;
-    word-break: break-word;
+    .report-Divider{
+      margin: 24px 0;
+
+    }
 
     .title {
         font-size: 16px;
         font-weight: 700;
         text-transform: uppercase;
+        margin-bottom: 16px;
     }
 
     .paragraph {

--- a/src/components/SentenceReport/SentenceReportContent.tsx
+++ b/src/components/SentenceReport/SentenceReportContent.tsx
@@ -1,4 +1,4 @@
-import { Col, Divider, Typography } from "antd";
+import { Grid, Divider, Typography } from "@mui/material";
 
 import React, { useContext } from "react";
 import SentenceReportContentStyle from "./SentenceReportContent.style";
@@ -10,7 +10,6 @@ import { useSelector } from "@xstate/react";
 import { publishedSelector } from "../../machines/reviewTask/selectors";
 import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMachineProvider";
 
-const { Paragraph } = Typography;
 const SentenceReportContent = ({
     context,
     classification,
@@ -32,36 +31,35 @@ const SentenceReportContent = ({
     return (
         <SentenceReportContentStyle>
             {showClassification && classification && (
-                <Col span={24}>
-                    <Paragraph className="title">
+                <Grid item xs={12}>
+                    <Typography variant="body1" className="title">
                         {t(`claimReview:title${reviewTaskType}Review`)}
-                    </Paragraph>
-                    <Paragraph className="paragraph">
+                    </Typography>
+                    <Typography variant="body1" className="paragraph">
                         <ClassificationText classification={classification} />
-                    </Paragraph>
-                    <Divider />
-                </Col>
+                    </Typography>
+                    <Divider className="report-Divider" />
+                </Grid>
             )}
             {summary && (
-                <Col span={24}>
-                    <Paragraph className="title">
+                <Grid item xs={12}>
+                    <Typography variant="body1" className="title">
                         {t("claimReview:summarySectionTitle")}
-                    </Paragraph>
-                    <Paragraph className="paragraph">
-                        <p
-                            dangerouslySetInnerHTML={{
-                                __html: sanitizer(summary),
-                            }}
-                        />
-                    </Paragraph>
-                    <Divider />
-                </Col>
+                    </Typography>
+                    <p
+                        dangerouslySetInnerHTML={{
+                            __html: sanitizer(summary),
+                        }}
+                        className="paragraph"
+                    />
+                    <Divider className="report-Divider" />
+                </Grid>
             )}
             {questions && questions.length > 0 && (
-                <Col span={24}>
-                    <Paragraph className="title">
+                <Grid item xs={12}>
+                    <Typography variant="body1" className="title">
                         {t("claimReview:questionsSectionTitle")}
-                    </Paragraph>
+                    </Typography>
                     {questions.map((item) => {
                         return (
                             <li
@@ -73,41 +71,41 @@ const SentenceReportContent = ({
                             />
                         );
                     })}
-                    <Divider />
-                </Col>
+                    <Divider className="report-Divider" />
+                </Grid>
             )}
             {report && (
-                <Col span={24}>
-                    <Paragraph className="title">
+                <Grid item xs={12}>
+                    <Typography variant="body1" className="title">
                         {t("claimReview:verificationSectionTitle")}
-                    </Paragraph>
+                    </Typography>
                     <p
                         dangerouslySetInnerHTML={{ __html: sanitizer(report) }}
                         className="paragraph"
                     />
-                    <Divider />
-                </Col>
+                    <Divider className="report-Divider" />
+                </Grid>
             )}
             {verification && (
-                <Col span={24}>
-                    <Paragraph className="title">
+                <Grid item xs={12}>
+                    <Typography variant="body1" className="title">
                         {t("claimReview:howSectionTitle")}
-                    </Paragraph>
+                    </Typography>
                     <p
                         dangerouslySetInnerHTML={{
                             __html: sanitizer(verification),
                         }}
                         className="paragraph"
                     />
-                    <Divider />
-                </Col>
+                    <Divider className="report-Divider" />
+                </Grid>
             )}
-            <Col span={24}>
+            <Grid item xs={12}>
                 {sources && sources?.length > 0 && (
                     <>
-                        <Typography.Title level={4}>
+                        <Typography className="title" variant="h4">
                             {t("claim:sourceSectionTitle")}
-                        </Typography.Title>
+                        </Typography>
                         <ClaimSourceList
                             sources={sortedSources}
                             seeMoreHref={`${href}/sources`}
@@ -115,7 +113,7 @@ const SentenceReportContent = ({
                         />
                     </>
                 )}
-            </Col>
+            </Grid>
         </SentenceReportContentStyle>
     );
 };

--- a/src/components/SentenceReport/SentenceReportPreview.tsx
+++ b/src/components/SentenceReport/SentenceReportPreview.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import CTARegistration from "../Home/CTARegistration";
-import { Col } from "antd";
+import { Grid } from "@mui/material";
 import SentenceReportComments from "./SentenceReportComments";
 import SentenceReportContent from "./SentenceReportContent";
 import { isUserLoggedIn } from "../../atoms/currentUser";
@@ -14,7 +14,7 @@ const SentenceReportPreview = ({
 }) => {
     const [isLoggedIn] = useAtom(isUserLoggedIn);
     return (
-        <Col span={componentStyle.span} offset={componentStyle.offset}>
+        <Grid item xs={componentStyle.span}>
             {canShowReportPreview && (
                 <SentenceReportComments context={context} />
             )}
@@ -25,7 +25,7 @@ const SentenceReportPreview = ({
                 href={href}
             />
             {!isLoggedIn && <CTARegistration />}
-        </Col>
+        </Grid>
     );
 };
 

--- a/src/components/SentenceReport/SentenceReportPreviewView.tsx
+++ b/src/components/SentenceReport/SentenceReportPreviewView.tsx
@@ -94,9 +94,9 @@ const SentenceReportPreviewView = ({
             <Grid container
                 justifyContent="center"
                 style={
-                    (isCrossChecking || isReport || isReviewing) && {
-                        backgroundColor: colors.lightNeutral,
-                    }
+                    (isCrossChecking || isReport || isReviewing)
+                        ? { backgroundColor: colors.error }
+                        : undefined
                 }
             >
                 {canShowReport && (

--- a/src/components/SentenceReport/SentenceReportSummary.tsx
+++ b/src/components/SentenceReport/SentenceReportSummary.tsx
@@ -1,9 +1,9 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material";
 import colors from "../../styles/colors";
 import styled from "styled-components";
 import { queries } from "../../styles/mediaQueries";
 
-const SentenceReportSummary = styled(Row)`
+const SentenceReportSummary = styled(Grid)`
     position: relative;
     margin: 8px 0 16px 4px;
     padding: 16px 24px;

--- a/src/stories/components/sentenceReport/SentenceReportSummary.stories.tsx
+++ b/src/stories/components/sentenceReport/SentenceReportSummary.stories.tsx
@@ -22,11 +22,11 @@ export default {
 } as ComponentMeta<typeof SentenceReportSummary>;
 
 export const Default = (args) => (
-    <SentenceReportSummary>{args.content}</SentenceReportSummary>
+    <SentenceReportSummary container>{args.content}</SentenceReportSummary>
 );
 
 export const ClaimReview = (args) => (
-    <SentenceReportSummary className="claim-review">
+    <SentenceReportSummary container className="claim-review">
         {args.content}
     </SentenceReportSummary>
 );


### PR DESCRIPTION
# Description
*In this PR, I migrated the sentence report page to MUI Material. This mostly involved replacing `Col` and `Row` with `Grid` and adapting the `Divider` and `Typography` from Ant Design to MUI.*

# Testing
*In this PR, I managed to separate the pages as we discussed. The `Col` and `Row` were replaced by `Grid`, and in relation to this, the site's responsiveness needs to be tested. The `divider` is a very subtle element used to separate items on the website. It looks like a line, and to test it, you just need to check if its design is correct and if it doesn’t break anything. All the Typography from Ant Design was also replaced, so it’s necessary to check if there is any text that’s out of the pattern or breaking the design.*

**Components:**
- [ ] #1746 
- [ ] #1744 
- [ ] #1725  
- [ ] #1722  
- [ ] #1721   
- [ ] #1737   


**A visual document outlining which visual parts of the site need to be tested:**
[Guia visual testes 1.pdf](https://github.com/user-attachments/files/18464300/Guia.visual.testes.1.pdf)
*This guide was created while I was making the changes. You’ll be able to use it in the following PRs as well.*


closes #1746 , closes #1744  , closes #1725 , closes #1722  , closes #1721  , closes #1737