### PR TITLE
Migrating BaseList and its skeletons

### DIFF
--- a/public/locales/en/history.json
+++ b/public/locales/en/history.json
@@ -3,6 +3,8 @@
     "create": "created",
     "update": "updated",
     "delete": "deleted",
+    "hide": "hide",
+    "unhide": "unhide",
     "personality": "profile",
     "claim": "claim",
     "historyItem": "{{username}} {{type}} {{title}} {{targetModel}}"

--- a/public/locales/pt/history.json
+++ b/public/locales/pt/history.json
@@ -3,6 +3,8 @@
     "create": "criou",
     "update": "atualizou",
     "delete": "deletou",
+    "hide": "ocultou",
+    "unhide": "exibiu",
     "personality": "o perfil de",
     "claim": "a afirmação",
     "historyItem": "{{username}} {{type}} {{targetModel}} {{title}}"

--- a/src/components/Claim/ClaimList.tsx
+++ b/src/components/Claim/ClaimList.tsx
@@ -9,7 +9,7 @@ import { currentNameSpace } from "../../atoms/namespace";
 import { useAtom } from "jotai";
 import ClaimListEmptyFallBack from "./ClaimListEmptyFallBack";
 
-const ClaimList = ({ personality, columns = 2 }) => {
+const ClaimList = ({ personality, columns = 6 }) => {
     const { i18n, t } = useTranslation();
     const [nameSpace] = useAtom(currentNameSpace);
 
@@ -21,12 +21,8 @@ const ClaimList = ({ personality, columns = 2 }) => {
             showDividers={false}
             bluePrimary={true}
             grid={{
-                gutter: 20,
-                // sizes not declared will show 1 column (xs and sm)
-                md: columns,
-                lg: columns,
-                xl: columns,
-                xxl: columns,
+                xs: 12,
+                sm: columns,
             }}
             emptyFallback={<ClaimListEmptyFallBack personality={personality} />}
             renderItem={(claim) =>

--- a/src/components/Claim/ClaimListView.tsx
+++ b/src/components/Claim/ClaimListView.tsx
@@ -9,16 +9,16 @@ const ClaimListView = () => {
     return (
         <>
             <Grid container style={{ marginTop: "64px", justifyContent:"center" }}>
-                <Grid item sm={11} md={7} lg={10.5}>
+                <Grid item sm={7} md={7} lg={10.5}>
                     <h1 style={{ fontSize: 32 }}>
                         {t("claim:claimListTitle")}
                     </h1>
                 </Grid>
-                <Grid item sm={11} md={7} lg={6}>
+                <Grid item sm={7} md={7} lg={6}>
                     <SourceList />
                 </Grid>
-                <Grid item style={{margin:"0 20px"}} sm={11} md={7} lg={4}>
-                    <ClaimList columns={1} personality={{ _id: null }} />
+                <Grid item style={{ margin: "0 20px" }} sm={7} md={7} lg={4}>
+                    <ClaimList columns={12} personality={{ _id: null }} />
                 </Grid>
             </Grid>
         </>

--- a/src/components/Claim/ClaimSourceList.tsx
+++ b/src/components/Claim/ClaimSourceList.tsx
@@ -13,6 +13,7 @@ const ClaimSourceList = ({ claimId }) => {
         <BaseList
             apiCall={SourceApi.getByTargetId}
             filter={{ targetId: claimId, i18n }}
+            style={{ fontSize: 14, padding: 5 }}
             renderItem={(source) =>
                 source && (
                     <LinkPreview

--- a/src/components/Dashboard/DashboardView.tsx
+++ b/src/components/Dashboard/DashboardView.tsx
@@ -25,6 +25,7 @@ const DashboardView = () => {
                         i18n,
                         isHidden: true,
                     }}
+                    showDividers={false}
                     emptyFallback={<></>}
                     renderItem={(p) =>
                         p && (
@@ -47,6 +48,7 @@ const DashboardView = () => {
                         i18n,
                         isHidden: true,
                     }}
+                    showDividers={false}
                     emptyFallback={<></>}
                     renderItem={(claim) =>
                         claim && (
@@ -66,6 +68,7 @@ const DashboardView = () => {
                     title={t("admin:dashboardHiddenReviews")}
                     apiCall={claimReviewApi.get}
                     filter={{ isHidden: true }}
+                    showDividers={false}
                     emptyFallback={<></>}
                     renderItem={(review) =>
                         review && (

--- a/src/components/Kanban/KanbanGrid.tsx
+++ b/src/components/Kanban/KanbanGrid.tsx
@@ -62,7 +62,7 @@ const KanbanGrid = ({
                 }
                 showDividers={false}
                 skeleton={<KanbanSkeleton />}
-                style={{ textTransform: "capitalize" }}
+                style={{ textTransform: "capitalize", padding: "4px 0" }}
             />
         </StyledColumn>
     );

--- a/src/components/List/BaseList.tsx
+++ b/src/components/List/BaseList.tsx
@@ -1,5 +1,4 @@
-import { CircularProgress, Button, Grid } from "@mui/material";
-import { List } from "antd";
+import { CircularProgress, Button, Grid, List, ListItem } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import React, { useEffect, useState } from "react";
 import colors from "../../styles/colors";
@@ -103,62 +102,86 @@ const BaseList = ({
 
     const loadMoreButton =
         totalPages > query.page ? (
-            <div
+            <Button
+                variant="outlined"
+                onClick={loadMoreData}
                 style={{
-                    textAlign: "center",
-                    marginTop: 12,
-                    height: 32,
-                    lineHeight: "32px",
+                    color: colors.primary,
+                    fontSize: 14
                 }}
             >
-                <Button onClick={loadMoreData}>
-                    {t("list:loadMoreButton")}
-                </Button>
-            </div>
+                {t("list:loadMoreButton")}
+            </Button>
         ) : null;
 
     if (items && Array.isArray(items) && (items.length > 0 || !emptyFallback)) {
         return (
             <>
-                <List
-                    itemLayout="horizontal"
-                    grid={grid}
-                    split={showDividers}
-                    header={
-                        <Grid container style={{alignContent:"middle", justifyContent:"space-between"}}>
-                            <Grid item>
-                                <h2
-                                    style={{
-                                        fontSize: "24px",
-                                        lineHeight: "32px",
-                                        color: bluePrimary
-                                            ? colors.primary
-                                            : colors.black,
-                                        marginBottom: 0,
-                                    }}
-                                >
-                                    {title}
-                                </h2>
-
-                                {t("list:totalItems", {
-                                    total: totalItems,
-                                })}
-                            </Grid>
-                            <Grid item>
-                                <SortByButton
-                                    refreshListItems={refreshListItems}
-                                />
-                            </Grid>
-                        </Grid>
-                    }
-                    style={style || {}}
-                    loadMore={loadMoreButton}
-                    loading={loading && loadingProps}
-                    dataSource={items}
-                    renderItem={(item) => {
-                        return <List.Item>{renderItem(item)}</List.Item>;
+                <Grid container
+                    style={{
+                        alignContent: "middle",
+                        justifyContent: "space-between",
+                        padding: "12px 0",
+                        borderBottom: "1px solid #eee"
                     }}
-                />
+                >
+                    <Grid item>
+                        <h2
+                            style={{
+                                fontSize: "24px",
+                                lineHeight: "32px",
+                                color: bluePrimary
+                                    ? colors.primary
+                                    : colors.black,
+                                marginBottom: 0,
+                            }}
+                        >
+                            {title}
+                        </h2>
+                        <p
+                            style={{
+                                fontSize: "14px",
+                                marginBottom: 0,
+                            }}
+                        >
+                            {t("list:totalItems", {
+                                total: totalItems,
+                            })}
+                        </p>
+                    </Grid>
+                    <Grid item>
+                        <SortByButton
+                            refreshListItems={refreshListItems}
+                        />
+                    </Grid>
+                </Grid>
+                <List
+                    style={{
+                        display: "flex",
+                        flexDirection: "row",
+                        flexWrap: "wrap",
+                        padding: 0,
+                    }}
+                >
+                    {loading && loadingProps ? (
+                        <Grid container style={{ display: "flex", justifyContent: "center", padding: 2 }}>
+                            {loadingIcon}
+                        </Grid>
+                    ) : (
+                        items.map((item) => (
+                            <Grid container item {...grid}>
+                                <ListItem key={item} style={{ borderBottom: showDividers ? "1px solid #eee" : "none", padding: "0 10px", ...style }}>
+                                    {renderItem(item)}
+                                </ListItem>
+                            </Grid>
+                        ))
+                    )}
+                    {loadMoreButton && (
+                        <Grid item style={{ width: "100%", display: "flex", justifyContent: "center" }}>
+                            {loadMoreButton}
+                        </Grid>
+                    )}
+                </List >
                 <Grid container
                     style={{
                         textAlign: "center",

--- a/src/components/Personality/PersonalityList.tsx
+++ b/src/components/Personality/PersonalityList.tsx
@@ -1,4 +1,4 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import React from "react";
 
@@ -16,7 +16,7 @@ const PersonalityList = () => {
     const { i18n, t } = useTranslation();
     const [nameSpace] = useAtom(currentNameSpace);
     const createPersonalityCTA = (
-        <Row
+        <Grid container
             style={{
                 flexDirection: "column",
                 alignItems: "center",
@@ -30,7 +30,7 @@ const PersonalityList = () => {
                         : "/personality/search"
                 }
             />
-        </Row>
+        </Grid>
     );
     return (
         <>
@@ -44,6 +44,7 @@ const PersonalityList = () => {
                     i18n,
                     nameSpace,
                 }}
+                style={{ paddingTop: 10 }}
                 emptyFallback={createPersonalityCTA}
                 renderItem={(p) =>
                     p && (

--- a/src/components/Skeleton/ClaimSkeleton.tsx
+++ b/src/components/Skeleton/ClaimSkeleton.tsx
@@ -1,35 +1,35 @@
-import { Col, Skeleton } from "antd";
+import { Grid, Skeleton } from "@mui/material";
 import React from "react";
 
 const ClaimSkeleton = () => {
     return (
-        <Col
-            sm={22}
-            md={14}
-            lg={12}
+        <Grid item
+            sm={11}
+            md={7}
+            lg={6}
             style={{
                 marginBottom: "10px",
             }}
         >
-            <Skeleton
-                active
-                paragraph={{ rows: 5 }}
-                round={true}
-                style={{
-                    width: "100%",
-                }}
-            />
-            <Col
+            <Skeleton variant="text" width="30%" animation="wave" />
+            <Skeleton variant="text" width="100%" animation="wave" />
+            <Skeleton variant="text" width="100%" animation="wave" />
+            <Skeleton variant="text" width="100%" animation="wave" />
+            <Skeleton variant="text" width="100%" animation="wave" />
+            <Skeleton variant="text" width="100%" animation="wave" />
+            <Skeleton variant="text" width="60%" animation="wave" />
+
+            <Grid item
                 style={{
                     display: "flex",
-                    justifyContent: "flex-end",
+                    justifyContent: "space-between",
                     padding: "10px 0",
                 }}
             >
-                <Skeleton title={false} paragraph={{ rows: 1 }} />
-                <Skeleton.Button active />
-            </Col>
-        </Col>
+                <Skeleton variant="text" width="50%" animation="wave" />
+                <Skeleton variant="rectangular" width={60} height={30} animation="wave" />
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/Skeleton/HistorySkeleton.tsx
+++ b/src/components/Skeleton/HistorySkeleton.tsx
@@ -1,13 +1,13 @@
-import { Skeleton } from "antd";
+import { Skeleton } from "@mui/material";
 import React from "react";
 
 const HistorySkeleton = () => {
     return (
         <Skeleton
-            style={{ marginTop: 16 }}
-            title={false}
-            paragraph={{ rows: 1, width: "100%" }}
-            active
+            variant="text"
+            width="100%"
+            animation="wave"
+            style={{ marginBottom: 15 }}
         />
     );
 };

--- a/src/components/Skeleton/KanbanSkeleton.tsx
+++ b/src/components/Skeleton/KanbanSkeleton.tsx
@@ -1,24 +1,21 @@
-import { Col, Skeleton } from "antd";
+import { Grid, Skeleton } from "@mui/material";
 import React from "react";
 
 const KanbanSkeleton = () => {
     return (
-        <Col style={{ width: "95%" }}>
-            <Skeleton
-                style={{ marginTop: 16 }}
-                paragraph={{ rows: 1, width: "100%" }}
-                active
-            />
-            <Col
+        <Grid item style={{ width: "95%" }}>
+            <Skeleton variant="text" width="40%" animation="wave" />
+            <Skeleton variant="text" width="100%" animation="wave" />
+            <Grid item
                 style={{
                     display: "flex",
                     justifyContent: "flex-end",
                     padding: "10px 0",
                 }}
             >
-                <Skeleton.Button active style={{ height: 16, width: 150 }} />
-            </Col>
-        </Col>
+                <Skeleton variant="text" width="50%" animation="wave" />
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/components/Skeleton/ReviewCarouselSkeleton.tsx
+++ b/src/components/Skeleton/ReviewCarouselSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "antd";
+import { Skeleton } from "@mui/material";
 import React from "react";
 import CardBase from "../CardBase";
 
@@ -6,15 +6,22 @@ const ReviewCarouselSkeleton = () => {
     return (
         <CardBase style={{ width: "fit-content", minWidth: "100%" }}>
             <div style={{ flex: 1, padding: "24px 32px" }}>
-                <Skeleton active paragraph={{ rows: 5 }} round={true} />
+                <Skeleton variant="text" width="30%" animation="wave" />
+                <Skeleton variant="text" width="100%" animation="wave" />
+                <Skeleton variant="text" width="100%" animation="wave" />
+                <Skeleton variant="text" width="100%" animation="wave" />
+                <Skeleton variant="text" width="100%" animation="wave" />
+                <Skeleton variant="text" width="100%" animation="wave" />
+                <Skeleton variant="text" width="60%" animation="wave" />
                 <div
                     style={{
                         display: "flex",
+                        justifyContent: "space-between",
                         padding: "10px 0",
                     }}
                 >
-                    <Skeleton title={false} paragraph={{ rows: 1 }} />
-                    <Skeleton.Button active />
+                    <Skeleton variant="text" width="50%" animation="wave" />
+                    <Skeleton variant="rectangular" width={60} height={30} animation="wave" />
                 </div>
             </div>
         </CardBase>

--- a/src/components/Skeleton/SkeletonList.tsx
+++ b/src/components/Skeleton/SkeletonList.tsx
@@ -1,13 +1,13 @@
-import { Row } from "antd";
+import { Grid } from "@mui/material";
 import React from "react";
 
 const SkeletonList = ({ listItem, repeat }) => {
     return (
-        <Row gutter={40} style={{ marginTop: 32 }}>
+        <Grid container spacing={5} style={{ marginTop: 32 }}>
             {[...Array(repeat)].map((_item, index) => (
                 <React.Fragment key={index}>{listItem}</React.Fragment>
             ))}
-        </Row>
+        </Grid>
     );
 };
 

--- a/src/components/Skeleton/SourceSkeleton.tsx
+++ b/src/components/Skeleton/SourceSkeleton.tsx
@@ -1,28 +1,31 @@
-import { Row, Col, Skeleton } from "antd";
+import { Grid, Skeleton } from "@mui/material";
 import React from "react";
 import styled from "styled-components";
 
-const SkeletonCol = styled(Col)`
-    .ant-skeleton-element {
-        width: 100%;
-        border-radius: "10px";
-    }
-`;
+const SkeletonGrid = styled(Grid)(() => ({
+    '& .MuiSkeleton-root': {
+        width: "100%",
+        borderRadius: "10px",
+    },
+}));
 
 const SourceSkeleton = () => {
     return (
-        <Row style={{ marginTop: 14, width: "100%" }}>
-            <SkeletonCol span={24}>
-                <Skeleton.Image
+        <Grid container style={{ marginTop: 14, width: "100%" }}>
+            <SkeletonGrid xs={12}>
+                <Skeleton
+                    variant="rectangular"
                     style={{
                         width: "100%",
                         height: "156px",
                         borderRadius: "10px 10px 0 0 ",
                     }}
                 />
-                <Skeleton active paragraph={{ rows: 2 }} />
-            </SkeletonCol>
-        </Row>
+                <Skeleton variant="text" width="30%" animation="wave" />
+                <Skeleton variant="text" width="100%" animation="wave" />
+                <Skeleton variant="text" width="60%" animation="wave" />
+            </SkeletonGrid>
+        </Grid>
     );
 };
 

--- a/src/components/Source/SourceList.tsx
+++ b/src/components/Source/SourceList.tsx
@@ -14,27 +14,24 @@ const SourceList = ({ footer = false }) => {
     const [nameSpace] = useAtom(currentNameSpace);
 
     return (
-        <Grid container justifyContent="center">
-            <Grid item xs={9} sm={12} lg={10}>
-                <BaseList
-                    apiCall={SourceApi.get}
-                    filter={{ nameSpace }}
-                    title={t("sources:sourceListHeader")}
-                    renderItem={(source, index) =>
-                        source && <SourceListItem key={index} source={source} />
-                    }
-                    grid={{
-                        gutter: 20,
-                        md: 2,
-                        lg: 2,
-                        xl: 2,
-                        xxl: 2,
-                    }}
-                    skeleton={<SourceSkeleton />}
-                    emptyFallback={<SourceCreateCTA />}
-                    footer={footer && <SourceCreateCTA />}
-                />
-            </Grid>
+        <Grid container item xs={11} lg={10} justifySelf="center">
+            <BaseList
+                apiCall={SourceApi.get}
+                filter={{ nameSpace }}
+                title={t("sources:sourceListHeader")}
+                renderItem={(source, index) =>
+                    source && <SourceListItem key={index} source={source} />
+                }
+                style={{ alignItems: "flex-start" }}
+                showDividers={false}
+                grid={{
+                    xs: 12,
+                    lg: 6
+                }}
+                skeleton={<SourceSkeleton />}
+                emptyFallback={<SourceCreateCTA />}
+                footer={footer && <SourceCreateCTA />}
+            />
         </Grid>
     );
 };

--- a/src/components/Source/SourceListItem.style.tsx
+++ b/src/components/Source/SourceListItem.style.tsx
@@ -13,7 +13,6 @@ const SourceListItemStyled = styled(Grid)`
         font-weight: 600;
         color: ${colors.primary};
         margin: 0;
-        width: 100%;
     }
 
     .title ::before {

--- a/src/components/Source/SourceListItem.tsx
+++ b/src/components/Source/SourceListItem.tsx
@@ -35,6 +35,7 @@ const SourceListItem = ({ source }) => {
                         WebkitBoxOrient: "vertical",
                         WebkitLineClamp: 4,
                         textOverflow: "ellipsis",
+                        width: "100%"
                     }}
                 >
                     <cite style={{ fontStyle: "normal" }}>

--- a/src/components/history/HistoryListItem.tsx
+++ b/src/components/history/HistoryListItem.tsx
@@ -1,7 +1,7 @@
-import Text from 'antd/lib/typography/Text'
-import { useTranslation } from 'next-i18next'
-import React from 'react'
-import LocalizedDate from '../LocalizedDate'
+import Typography from "@mui/material/Typography"
+import { useTranslation } from "next-i18next"
+import React from "react"
+import LocalizedDate from "../LocalizedDate"
 interface IHistoryListItemProps {
     history: {
         _id: string,
@@ -27,10 +27,14 @@ const HistoryListItem = ({ history }: IHistoryListItemProps) => {
         title = oldTitle
     }
     return (
-        <div>
+        <div style={{ fontSize: 14 }}>
             <LocalizedDate date={history.date} showTime />{` - `}
             {t('history:historyItem', { username, type, targetModel, title })}
-            {oldTitle && oldTitle !== title && <Text>  (<Text delete>{oldTitle}</Text>)</Text>}
+            {oldTitle && oldTitle !== title && (
+                <Typography variant="body1" display="flex">
+                    (<span style={{ textDecoration: "line-through" }}>{oldTitle}</span>)
+                </Typography>
+            )}
         </div>
     )
 }

--- a/src/components/history/HistoryView.tsx
+++ b/src/components/history/HistoryView.tsx
@@ -9,6 +9,7 @@ const HistoryView = ({ targetId, targetModel }) => {
         <BaseList
             apiCall={HistoryApi.getByTargetId}
             filter={{ targetId, targetModel }}
+            style={{ padding: 5 }}
             renderItem={(history) =>
                 history && <HistoryListItem history={history} />
             }


### PR DESCRIPTION
# Description
*In this PR, I replaced the Ant Design `List` component used in `BaseList.tsx`. Since this component is used in several places, I had to make some adjustments where it was called. I preserved the old layout and design. Along the way, I also fixed some issues for smaller screen resolutions. In the documentation, you can see how the pages and their skeletons turned out.*

# Testing
*To test, you would need to visit each of the components listed in the documentation and verify their responsiveness and behavior as a list. In some cases, I replaced Ant Design texts with Material-UI ones, but overall, the focus should be on testing the responsiveness of the listed pages.*

**Components:**
- [ ] #1756  
- [ ] #1755  
- [ ] #1754  
- [ ] #1753  
- [ ] #1752  
- [ ] #1723  
- [ ] #1716 
- [ ] #1675 
- [ ] #1593  

A visual document outlining which visual parts of the site need to be tested:  
[Testar BaseList e Skeletons.pdf](https://github.com/user-attachments/files/18505200/Testar.BaseList.e.Skeletons.pdf)

closes #1756 , closes #1755 , closes #1754 , closes #1753 , closes #1752 , closes #1723 , closes #1716 , closes #1675 , closes #1593 