### PR TITLE
Migrate Drawers to Material UI

### DIFF
--- a/src/components/LargeDrawer.tsx
+++ b/src/components/LargeDrawer.tsx
@@ -1,4 +1,4 @@
-import { Drawer } from "antd";
+import { Drawer } from "@mui/material";
 import React from "react";
 import { useAppSelector } from "../store/store";
 import colors from "../styles/colors";
@@ -14,15 +14,18 @@ const LargeDrawer = ({
         <Drawer
             open={open}
             onClose={onClose}
-            width={vw?.sm ? "100%" : "60%"}
-            height={vw?.sm ? "85%" : "100%"}
-            placement={vw?.sm ? "bottom" : "right"}
-            bodyStyle={{ padding: 0 }}
-            drawerStyle={{
-                backgroundColor,
+            anchor={vw?.sm ? "bottom" : "right"}
+            variant="temporary"
+            keepMounted={false}
+            sx={{
+                "& .MuiDrawer-paper": {
+                    width: vw?.sm ? "100%" : "60%",
+                    height: vw?.sm ? "85%" : "100%",
+                    backgroundColor,
+                    padding: "0",
+
+                }
             }}
-            closable={false}
-            destroyOnClose
         >
             {children}
         </Drawer>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Drawer } from "antd";
+import { Drawer } from "@mui/material";
 import React from "react";
 import { useDispatch } from "react-redux";
 import actions from "../store/actions";
@@ -24,13 +24,15 @@ const Sidebar = () => {
         <Drawer
             open={!menuCollapsed}
             onClose={() => dispatch(actions.closeSideMenu())}
-            width="17rem"
-            placement="left"
-            bodyStyle={{ padding: 0 }}
-            drawerStyle={{
-                backgroundColor: colors.lightNeutral,
+            anchor="left"
+            variant="temporary"
+            sx={{
+                "& .MuiDrawer-paper": {
+                    width: "17rem",
+                    padding: "0",
+                    backgroundColor: colors.lightNeutral,
+                }
             }}
-            closable={false}
         >
             <div
                 style={{


### PR DESCRIPTION
# Description
*The Drawer component has migrated to Material UI, from the files `Sidebar.tsx` and `LargeDrawer.tsx`, replacing the positioning property with anchor, maintaining the same functions, styled with `sx` and removing the closable property, since in MUI the close button can be omitted directly.*

Fixes #1521 #1515 

# Type of change
- [X] New feature (non-breaking change which adds functionality)     

# Testing
*First Test from Sidebar:
1. Open the Aletheia platform;
2. Click on the header button in the top left corner.*

*Second Test from LargeDrawer
1. Open the Aletheia platform;
2. Log in;
3. Create an affirmation or join an existing one;
4. Click on the paragraph that will be reviewed.*

Visual Document 
[Migrate-drawer.pdf](https://github.com/user-attachments/files/18657077/Migrate-drawer.pdf)



# Developer Checklist
## General
- [X] No `console.log` or related logging is added.


## Frontend Changes
- [X] No new styling is added through CSS files (Unless it's a bugfix/hotfix)
- [X] All types are added correctly

### Tests
- [ ] All existing unit and end to end tests pass across all services     
- [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected     

# Merge Request Review Checklist 
- [ ] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)     
- [ ] High risk and core workflows have been tested and verified in a local environment.     
- [ ] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in JIRA issues if not being addressed.     
- [ ] Any dependent changes have been merged and published in downstream modules     
- [ ] Changes to multiple services can be deployed in parallel and independently. If not, changes should be broken out into separate merge requests and deployed in order.