### PR TITLE
Fix Bug Footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -27,12 +27,11 @@ const Footer = () => {
         <Box
             component="footer"
             sx={{
-                position: "absolute",
-                bottom: 0,
                 textAlign: "center",
                 background: backgroundColor,
                 color: colors.white,
                 padding: "32px",
+                alignSelf: "flex-end"
             }}
         >
             <Grid container spacing={3} justifyContent="center">

--- a/src/components/MainApp.tsx
+++ b/src/components/MainApp.tsx
@@ -39,7 +39,6 @@ const MainApp = ({ children }) => {
     return (
         <Box
             sx={{
-                minHeight: "100vh",
                 width:
                     copilotDrawerCollapsed || vw?.md
                         ? "100%"
@@ -47,11 +46,17 @@ const MainApp = ({ children }) => {
             }}
         >
             <Sidebar />
-            <Box sx={{ background: colors.white }}>
-                <Header />
-                <DonationBanner />
-                {renderCTAButton()}
-                <ContentWrapper>{children}</ContentWrapper>
+            <Box sx={{
+                display: "grid",
+                minHeight: "100vh",
+                background: colors.white
+            }}>
+                <Box>
+                    <Header />
+                    <DonationBanner />
+                    {renderCTAButton()}
+                    <ContentWrapper>{children}</ContentWrapper>
+                </Box>
                 <Footer />
                 {enableOverlay && <OverlaySearchResults />}
             </Box>


### PR DESCRIPTION
# Description
*I made a mistake by not testing on scrollable pages and only tested on pages without scroll, not realizing that the footer was breaking. Essentially, it broke the layout on scrollable pages because the footer wasn't following the page's flow correctly.*

*To fix this, I removed the position: absolute from the footer and used alignSelf: "flex-end" to ensure that it always stays at the bottom of the layout. In the parent component, I added display: "grid" and minHeight: "100vh" to ensure that the structure occupies the full height of the screen.*

*Additionally, I wrapped the other components inside a Box, making sure they are treated as a single unit within the grid. This way, the elements stay grouped correctly without being stretched unexpectedly.*

fixes #1809 

before:
![Screenshot from 2025-02-11 22-39-34](https://github.com/user-attachments/assets/2cae3638-0008-4b7f-9d93-f3bbffe36ded)
![Screenshot from 2025-02-11 22-39-21](https://github.com/user-attachments/assets/540f058a-97c8-4e15-9d96-aad7d7b12646)
after:
![Screenshot from 2025-02-11 23-04-38](https://github.com/user-attachments/assets/b2a8c093-2d5d-4c61-bf7c-84648923c464)
![Screenshot from 2025-02-11 22-39-41](https://github.com/user-attachments/assets/a3a754f4-f3f3-4933-9728-b8e3bae94c59)
*I am testing on other pages too*
![Screenshot from 2025-02-11 22-39-53](https://github.com/user-attachments/assets/02aaf580-73fc-43b0-a994-adc72dfa35e5)
![Screenshot from 2025-02-11 23-05-14](https://github.com/user-attachments/assets/bacca6fc-ae9b-4184-b6ae-d10d9d738de9)


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)     

# Testing
*Basically, test both scrollable and non-scrollable pages*