### PR TITLE
Migrate progress antd to MUI

### DIFF
--- a/src/components/Metrics/MetricsOverview.tsx
+++ b/src/components/Metrics/MetricsOverview.tsx
@@ -44,7 +44,7 @@ const MetricsOverview = ({ stats }) => {
                 ) : (
                     t("metrics:empytOverview")
                 )}
-                <ReviewStats stats={stats} countInTitle={true} type="line" />
+                <ReviewStats stats={stats} countInTitle={true} />
             </Col>
         </Row>
     );

--- a/src/components/Metrics/ReviewProgress.tsx
+++ b/src/components/Metrics/ReviewProgress.tsx
@@ -1,30 +1,33 @@
 import React from "react";
-import { Progress, ProgressProps } from "antd";
+import {
+    Grid,
+    LinearProgress,
+    CircularProgress,
+    linearProgressClasses,
+    circularProgressClasses
+} from "@mui/material";
+import styled from "styled-components";
 import ReviewColors from "../../constants/reviewColors";
 import colors from "../../styles/colors";
-import StatsReviewColors from "../../constants/statsReviewColors";
 import { useTranslation } from "next-i18next";
 
 const ReviewProgress = ({ reviews, statsProps }) => {
     const { t } = useTranslation();
-
-    const getStyle = (reviewId) => {
-        const defaultStyle: ProgressProps = {
-            strokeWidth: statsProps.strokeWidth || 18,
-            width: statsProps.width || 80,
-            strokeLinecap: statsProps.type === "circle" ? "square" : "round",
-            trailColor: colors.neutralTertiary,
-        };
-
-        return {
-            ...defaultStyle,
-            strokeColor: StatsReviewColors[reviewId] || colors.black,
-        };
-    };
-
+    
     return reviews.map((review) => {
-        const format =
-            statsProps.format === "count" ? () => review.count : null;
+        const BorderLinearProgress = styled(LinearProgress)(() => ({
+            [`& .${linearProgressClasses.bar}`]: {
+                borderRadius: 10,
+                backgroundColor: ReviewColors[review._id] || colors.black,
+            },
+        }));
+
+        const BorderCircularProgress = styled(CircularProgress)(() => ({
+            [`& .${circularProgressClasses.circle}`]: {
+                color: ReviewColors[review._id] || colors.black,
+            },
+        }));
+
         return (
             <div
                 style={
@@ -52,13 +55,53 @@ const ReviewProgress = ({ reviews, statsProps }) => {
                     {statsProps.countInTitle && `${review.count} `}
                     {t(`claimReviewForm:${review._id}`)}
                 </span>
-                <Progress
-                    percent={review.percentage}
-                    type={statsProps.type}
-                    format={format}
-                    {...getStyle(review._id)}
-                />
-            </div>
+                {statsProps.type === "circle" ?
+                    <Grid container position="relative" display="inline-flex" justifyContent="center"
+                        alignItems="center">
+                        <CircularProgress
+                            variant="determinate"
+                            value={100}
+                            size={statsProps.size}
+                            thickness={8}
+                            sx={{ color: colors.neutralTertiary, position: "absolute" }}
+                        />
+                        <BorderCircularProgress
+                            variant="determinate"
+                            value={review.percentage}
+                            size={statsProps.size}
+                            thickness={8}
+                        />
+                        <p
+                            style={{
+                                fontSize: statsProps.size === 30 ? "10px" : "14px",
+                                position: "absolute",
+                                top: "50%",
+                                left: "50%",
+                                transform: "translate(-50%, -50%)",
+                            }}
+                        >
+                            {review.count}
+                        </p>
+                    </Grid>
+                    :
+                    <Grid container alignItems="center">
+                        <Grid item xs={11}>
+                            <BorderLinearProgress
+                                variant="determinate"
+                                value={review.percentage}
+                                sx={{ height: 18, borderRadius: 10 }}
+                            />
+                        </Grid>
+                        <Grid item xs={1}>
+                            <p
+                                style={{ fontSize: "12px", margin: 0, padding: "0px 10px" }}
+                            >
+                                {review.percentage}%
+                            </p>
+                        </Grid>
+                    </Grid>
+                }
+            </div >
         );
     });
 };

--- a/src/components/Personality/PersonalityCard.tsx
+++ b/src/components/Personality/PersonalityCard.tsx
@@ -208,10 +208,7 @@ const PersonalityCard = ({
                             <ReviewStats
                                 stats={personality.stats}
                                 type="circle"
-                                format="count"
-                                width={summarized && 30}
-                                showInfo={!summarized}
-                                strokeWidth="16"
+                                size={summarized ? 30 : 80}
                             />
                         </Grid>
                     </Grid>


### PR DESCRIPTION
# Description
*In this PR, I replaced the Progress component from Ant Design with MUI. Overall, I had to use a linear gradient for line progress and a circular progress for circles, as MUI does not unify them under a single component like Ant Design. To replicate the light gray background of the circular progress, I had to use two overlapping circles since it was not possible to define that element with CSS in MUI. In general, I managed to simplify some aspects while maintaining the design and responsiveness.*

### OBS:
*You may notice a color change in the progress components. This happens due to the library switch. To keep the previous, more vibrant, and lighter color, we would need to change the hexadecimal values in the constant where we define these colors or set a new constant with updated colors directly in the progress component. I concluded that maintaining the old color is unnecessary since the difference is minimal. Does this make sense?*

before:
![Screenshot from 2025-02-12 23-33-36](https://github.com/user-attachments/assets/3a266552-7ec5-419a-96ec-5109b96d5a56)
after:
![Screenshot from 2025-02-12 23-56-39](https://github.com/user-attachments/assets/4307b273-2423-4151-a004-6ea6bd5b710e)
before:
![Screenshot from 2025-02-12 23-32-03](https://github.com/user-attachments/assets/87c6749e-dcc9-493a-ae69-e7474715fd1d)
after:
![Screenshot from 2025-02-13 00-01-03](https://github.com/user-attachments/assets/a332d22c-37c2-4c03-918b-3982b914345d)
before:
![Screenshot from 2025-02-12 23-31-34](https://github.com/user-attachments/assets/8fa8c0bd-637f-4e31-a3fb-f54eabd06516)
after:
![Screenshot from 2025-02-12 23-31-41](https://github.com/user-attachments/assets/b86ba6d0-74c2-462d-98e7-b078a94330e2)

# Testing
*To test, go to different places where we call the personality card or the metrics overview and check if everything is correct and responsive.*

**Components:**
- [x] #1763 


closes #1763 