### PR TITLE
Centralizing loading

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -17,6 +17,7 @@ const Loading = ({ style = {} }) => {
                 height: "50vh",
                 display: "grid",
                 placeContent: "center",
+                justifyItems: "center",
                 ...style,
             }}
         >


### PR DESCRIPTION
# Description
*Basically, I centered the loading indicator relative to its parent div.*
![Screenshot from 2025-03-12 23-27-50](https://github.com/user-attachments/assets/226fa9d9-952a-46fa-bb2d-ca5ed27b317b)

Fixes #1845