### PR TITLE
Migrating affix to MUI

### DIFF
--- a/src/components/Claim/ClaimView.tsx
+++ b/src/components/Claim/ClaimView.tsx
@@ -1,5 +1,5 @@
-import { Box ,Grid , Typography} from "@mui/material"
-import React, { useEffect, useRef, useState } from "react";
+import { Grid, Typography } from "@mui/material"
+import React, { useEffect, useState } from "react";
 
 import { ContentModelEnum, Roles, TargetModel } from "../../types/enums";
 import MetricsOverview from "../Metrics/MetricsOverview";
@@ -16,10 +16,9 @@ import AdminToolBar from "../Toolbar/AdminToolBar";
 import claimApi from "../../api/claim";
 import { currentUserRole } from "../../atoms/currentUser";
 import { useAtom } from "jotai";
+import AffixAletheiaButton from "../Collaborative/Components/AffixAletheiaButton";
 
 const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
-    const [isAffixed, setIsAffixed] = useState(false);
-    const ref = useRef<HTMLDivElement | null>(null);
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const [role] = useAtom(currentUserRole);
@@ -42,27 +41,6 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
             dispatch(actions.setSelectContent(claimContent));
         }
     }, [claim, claimContent, dispatch, isImage, personality, t]);
-
-    useEffect(() => {
-        if (!ref.current) return;
-        
-        const scrollableSpeech = ref.current.scrollHeight > window.innerHeight;
-        if (scrollableSpeech) {
-            setIsAffixed(true);
-        }
-
-        const handleScroll = () => {
-            const { bottom } = ref.current.getBoundingClientRect();
-            const isFixed = bottom > window.innerHeight;
-
-            if (isFixed) {
-                setIsAffixed(true);
-            } else {
-                setIsAffixed(false);
-            }
-        };
-        window.addEventListener("scroll", handleScroll);
-    }, []);
 
     return (
         <>
@@ -93,7 +71,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                 style={{ paddingBottom: "15px" }}
                                 justifyContent="center"
                             >
-                                <Grid ref={ref} item xs={12} md={11} lg={10}>
+                                <Grid item xs={12} md={11} lg={10}>
                                     <Typography
                                         variant="h1"
                                         style={{
@@ -116,23 +94,18 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                         }
                                     />
                                 </Grid>
-                                <Box
-                                    style={{
-                                        position: isAffixed ? "fixed" : "relative",
-                                        bottom: isAffixed ? 15 : "auto",
-                                        textAlign: "center",
-                                        width: "100%",
-                                    }}
-                                >
-                                    <ToggleSection
-                                        defaultValue={showHighlights}
-                                        onChange={(e) => {
-                                            setShowHighlights(e.target.value);
-                                        }}
-                                        labelTrue={t("claim:showHighlightsButton")}
-                                        labelFalse={t("claim:hideHighlightsButton")}
-                                    />
-                                </Box>
+                                <AffixAletheiaButton
+                                    Children={
+                                        <ToggleSection
+                                            defaultValue={showHighlights}
+                                            onChange={(e) => {
+                                                setShowHighlights(e.target.value);
+                                            }}
+                                            labelTrue={t("claim:showHighlightsButton")}
+                                            labelFalse={t("claim:hideHighlightsButton")}
+                                        />
+                                    }
+                                />
                             </Grid>
                             {sources.length > 0 && (
                                 <>

--- a/src/components/Claim/ClaimView.tsx
+++ b/src/components/Claim/ClaimView.tsx
@@ -16,7 +16,7 @@ import AdminToolBar from "../Toolbar/AdminToolBar";
 import claimApi from "../../api/claim";
 import { currentUserRole } from "../../atoms/currentUser";
 import { useAtom } from "jotai";
-import AffixAletheiaButton from "../Collaborative/Components/AffixAletheiaButton";
+import AffixButtonV2 from "../Collaborative/Components/AffixButtonV2";
 
 const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
     const dispatch = useDispatch();
@@ -75,7 +75,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                     <Typography
                                         variant="h1"
                                         style={{
-                                            fontFamily:"initial",
+                                            fontFamily: "initial",
                                             fontWeight: 700,
                                             margin: "20px 0",
                                             fontSize: 20,
@@ -94,7 +94,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                                         }
                                     />
                                 </Grid>
-                                <AffixAletheiaButton
+                                <AffixButtonV2
                                     Children={
                                         <ToggleSection
                                             defaultValue={showHighlights}
@@ -109,7 +109,7 @@ const ClaimView = ({ personality, claim, href, hideDescriptions }) => {
                             </Grid>
                             {sources.length > 0 && (
                                 <>
-                                    <Typography variant="h4" style={{fontSize: 24, fontFamily:"initial", fontWeight: 700}}>
+                                    <Typography variant="h4" style={{ fontSize: 24, fontFamily: "initial", fontWeight: 700 }}>
                                         {t("claim:sourceSectionTitle")}
                                     </Typography>
                                     <ClaimSourceList

--- a/src/components/Collaborative/Components/AffixAletheiaButton.tsx
+++ b/src/components/Collaborative/Components/AffixAletheiaButton.tsx
@@ -1,0 +1,54 @@
+import { Box } from "@mui/material";
+import React, { useEffect, useRef, useState } from "react";
+
+interface AffixAletheiaButtonProps {
+  Children: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+const AffixAletheiaButton: React.FC<AffixAletheiaButtonProps> = ({ Children, ...style }) => {
+  const [isAffixed, setIsAffixed] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!ref.current) return;
+
+      const { bottom } = ref.current.getBoundingClientRect();
+      const isFixed = bottom > window.innerHeight;
+
+      if (isFixed) {
+        setIsAffixed(true);
+      } else {
+        setIsAffixed(false);
+      }
+    };
+
+    if (ref.current) {
+      const scrollableSpeech = ref.current.scrollHeight > window.innerHeight;
+      if (scrollableSpeech) {
+        setIsAffixed(true);
+      }
+    }
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <>
+      <span ref={ref} />
+      <Box
+        style={{
+          position: isAffixed ? "fixed" : "relative",
+          bottom: isAffixed ? 15 : "auto",
+          ...style,
+        }}
+      >
+        {Children}
+      </Box>
+    </>
+  );
+};
+
+export default AffixAletheiaButton;

--- a/src/components/Collaborative/Components/AffixAletheiaButton.tsx
+++ b/src/components/Collaborative/Components/AffixAletheiaButton.tsx
@@ -11,6 +11,9 @@ const AffixAletheiaButton: React.FC<AffixAletheiaButtonProps> = ({ Children, ...
   const ref = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    const drawer = document.querySelector(".MuiDrawer-paper");
+    const scrollTarget = drawer || window;
+
     const handleScroll = () => {
       if (!ref.current) return;
 
@@ -31,8 +34,8 @@ const AffixAletheiaButton: React.FC<AffixAletheiaButtonProps> = ({ Children, ...
       }
     }
 
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
+    scrollTarget.addEventListener("scroll", handleScroll);
+    return () => scrollTarget.removeEventListener("scroll", handleScroll);
   }, []);
 
   return (

--- a/src/components/Collaborative/Components/AffixButtonV2.tsx
+++ b/src/components/Collaborative/Components/AffixButtonV2.tsx
@@ -6,7 +6,7 @@ interface AffixAletheiaButtonProps {
   style?: React.CSSProperties;
 }
 
-const AffixAletheiaButton: React.FC<AffixAletheiaButtonProps> = ({ Children, ...style }) => {
+const AffixButtonV2: React.FC<AffixAletheiaButtonProps> = ({ Children, ...style }) => {
   const [isAffixed, setIsAffixed] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -54,4 +54,4 @@ const AffixAletheiaButton: React.FC<AffixAletheiaButtonProps> = ({ Children, ...
   );
 };
 
-export default AffixAletheiaButton;
+export default AffixButtonV2;

--- a/src/components/Collaborative/Components/AffixPreviewButton.tsx
+++ b/src/components/Collaborative/Components/AffixPreviewButton.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import AletheiaButton from "../../Button";
-import AffixAletheiaButton from "./AffixAletheiaButton";
+import AffixButtonV2 from "./AffixButtonV2";
 import { ReviewTaskMachineContext } from "../../../machines/reviewTask/ReviewTaskMachineProvider";
 import { ReviewTaskEvents } from "../../../machines/reviewTask/enums";
 import { useTranslation } from "next-i18next";
@@ -30,7 +30,7 @@ const AffixPreviewButton = ({ doc }) => {
                 order: 5,
             }}
         >
-            <AffixAletheiaButton
+            <AffixButtonV2
                 Children={
                     <AletheiaButton
                         style={{ borderRadius: "50px", height: "fit-content" }}

--- a/src/components/Collaborative/Components/AffixPreviewButton.tsx
+++ b/src/components/Collaborative/Components/AffixPreviewButton.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import AletheiaButton from "../../Button";
-import { Affix } from "antd";
+import AffixAletheiaButton from "./AffixAletheiaButton";
 import { ReviewTaskMachineContext } from "../../../machines/reviewTask/ReviewTaskMachineProvider";
 import { ReviewTaskEvents } from "../../../machines/reviewTask/enums";
 import { useTranslation } from "next-i18next";
@@ -22,8 +22,7 @@ const AffixPreviewButton = ({ doc }) => {
     };
 
     return (
-        <Affix
-            offsetBottom={15}
+        <div
             style={{
                 width: "100%",
                 display: "flex",
@@ -31,15 +30,19 @@ const AffixPreviewButton = ({ doc }) => {
                 order: 5,
             }}
         >
-            <AletheiaButton
-                style={{ borderRadius: "50px", height: "fit-content" }}
-                onClick={handleOnClick}
-            >
-                {viewPreview
-                    ? t("claimReviewForm:hidePreview")
-                    : t("claimReviewForm:viewPreview")}
-            </AletheiaButton>
-        </Affix>
+            <AffixAletheiaButton
+                Children={
+                    <AletheiaButton
+                        style={{ borderRadius: "50px", height: "fit-content" }}
+                        onClick={handleOnClick}
+                    >
+                        {viewPreview
+                            ? t("claimReviewForm:hidePreview")
+                            : t("claimReviewForm:viewPreview")}
+                    </AletheiaButton>
+                }
+            />
+        </div>
     );
 };
 


### PR DESCRIPTION
# Description
*In this PR, I migrated the affix used in AffixPreviewButton.tsx and realized it was using the same logic I had already replicated for another affix. Therefore, I encapsulated the entire functionality into a new component and called it in both places.*

# Question 
@thesocialdev 
*I noticed that when the affix is used in the report drawer, the functionality of keeping the affix with a fixed position when the screen is scrollable is not working. Should I create an issue for this?*
*The affix used in the report is behind a feature flag and is currently turned off because it wasn’t working. I will create an issue to resolve this as well.*
*Should I create two separate issues or combine them into one?*

Fixes #1558
 
In the speech:
![Screenshot from 2025-03-15 12-39-16](https://github.com/user-attachments/assets/8c6b381d-8f9e-42d3-9c80-a2cfc80bfbd2)
![Screenshot from 2025-03-15 12-39-11](https://github.com/user-attachments/assets/8a535622-862a-4134-8587-2392036e7fe6)
In the report:
![Screenshot from 2025-03-15 12-38-51](https://github.com/user-attachments/assets/344161c9-f622-4054-bcc1-da567f08dc3d)
![Screenshot from 2025-03-15 12-38-44](https://github.com/user-attachments/assets/90b6213f-d571-45a5-99ba-9a54dd5eebfa)

# Testing
*To test the first affix, go to the claim page and test the component for showing and hiding the speech checks. The second use of the affix would be on the report page for the preview button of the report, but this functionality is currently disabled via a feature flag. In this PR, I only migrated the component and did part of the visual work.*