### PR TITLE
Migrating editorSourceList to MUI

### DIFF
--- a/src/components/Collaborative/Components/Source/EditorSouceList.style.tsx
+++ b/src/components/Collaborative/Components/Source/EditorSouceList.style.tsx
@@ -5,6 +5,8 @@ import { queries } from "../../../../styles/mediaQueries";
 export const EditorSourcesListStyle = styled.div`
     order: 4;
     width: 100%;
+    display: flex;
+    flex-wrap: wrap;
 
     a {
         overflow-wrap: anywhere;
@@ -18,6 +20,7 @@ export const EditorSourcesListStyle = styled.div`
         background: ${colors.white};
         box-shadow: 0px 2px 2px ${colors.shadow};
         border-radius: 8px;
+        width: 100%;
     }
 
     .source-card-header {
@@ -35,6 +38,7 @@ export const EditorSourcesListStyle = styled.div`
         display: flex;
         justify-content: center;
         align-items: center;
+        width: 100%;
     }
 
     .empty-text {

--- a/src/components/Collaborative/Components/Source/EditorSourceList.tsx
+++ b/src/components/Collaborative/Components/Source/EditorSourceList.tsx
@@ -1,4 +1,4 @@
-import { List } from "antd";
+import { Grid } from "@mui/material";
 import React from "react";
 import { EditorSourcesListStyle } from "./EditorSouceList.style";
 import EditorSourceListItem from "./EditorSourceListItem";
@@ -19,33 +19,27 @@ const EditorSourcesList = ({
     return (
         <EditorSourcesListStyle>
             {sources.length > 0 ? (
-                <List
-                    dataSource={sources}
-                    grid={{
-                        xs: 1,
-                        sm: 2,
-                        md: 2,
-                        lg: 2,
-                        xl: 3,
-                        xxl: 3,
-                    }}
-                    renderItem={(source, index) => {
-                        if (typeof source === "object") {
-                            return (
-                                <EditorSourceListItem
-                                    node={node}
-                                    key={index}
-                                    sup={index + 1}
-                                    source={source}
-                                />
-                            );
-                        } else {
-                            return <></>;
-                        }
-                    }}
-                >
+                <>
+                    {sources.map((source, index) => (
+                        <Grid container
+                            direction="row"
+                            position="relative"
+                            key={source._id}
+                            xs={12}
+                            sm={6}
+                            lg={4}
+                        >
+                            <EditorSourceListItem
+                                node={node}
+                                key={source._id}
+                                sup={index + 1}
+                                source={source}
+                            />
+                        </Grid>
+                    ))
+                    }
                     <EditorAddSources nodeFromJSON={nodeFromJSON} doc={node} />
-                </List>
+                </>
             ) : (
                 <EditorAddSources nodeFromJSON={nodeFromJSON} doc={node} />
             )}

--- a/src/components/Collaborative/Components/Source/EditorSourceListItem.tsx
+++ b/src/components/Collaborative/Components/Source/EditorSourceListItem.tsx
@@ -1,6 +1,5 @@
-import { Col, Spin } from "antd";
 import React, { useEffect, useMemo, useState } from "react";
-import { CircularProgress } from "@mui/material";
+import { CircularProgress, Grid } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import EditorSourcePopover from "./EditorSourcePopover";
 import colors from "../../../../styles/colors";
@@ -49,21 +48,9 @@ const EditorSourceListItem = ({ node, sup, source }: EditorSouceListProps) => {
     }, [href, isArchive]);
 
     return (
-        <Spin
-            spinning={isLoading}
-            indicator={
-                <CircularProgress
-                    style={{
-                        color:
-                            nameSpace === NameSpaceEnum.Main
-                                ? colors.primary
-                                : colors.secondary,
-                    }}
-                />
-            }
-        >
-            <Col className="source-card">
-                <Col className="source-card-header">
+        <>
+            <Grid item style={{ opacity: isLoading && "0.4" }} className="source-card">
+                <Grid item className="source-card-header">
                     <h3>
                         {sup}. {title}
                     </h3>
@@ -75,14 +62,38 @@ const EditorSourceListItem = ({ node, sup, source }: EditorSouceListProps) => {
                     >
                         <MoreVertIcon style={{ cursor: "pointer" }} />
                     </EditorSourcePopover>
-                </Col>
-                <Col className="source-card-content">
+                </Grid>
+                <Grid item className="source-card-content">
                     <a href={href} target="_blank" rel="noopener noreferrer">
                         {href}
                     </a>
-                </Col>
-            </Col>
-        </Spin>
+                </Grid>
+            </Grid>
+            {isLoading &&
+                <Grid item
+                    style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                    }}
+                >
+                    <CircularProgress
+                        size={35}
+                        style={{
+                            color:
+                                nameSpace === NameSpaceEnum.Main
+                                    ? colors.primary
+                                    : colors.secondary,
+                        }}
+                    />
+                </Grid >
+            }
+        </>
     );
 };
 


### PR DESCRIPTION
# Description
*In this PR, I migrated the entire source editor used in the report to MUI. I used Grid instead of the List component because it is not very accessible for this type of dynamic list. I also migrated a Spin component from Ant Design, which has no direct equivalent in MUI, so I had to manually replicate it. Overall, I replicated everything exactly as it was before.*

Fixes #1561 #1562 

before:
![e1](https://github.com/user-attachments/assets/bf095410-82bf-4acc-b53f-cda82132865d)
![e2](https://github.com/user-attachments/assets/fbe97101-81fe-4d08-bd63-96ca3514c1bc)
![e3](https://github.com/user-attachments/assets/d9ac4d60-e3a2-43da-9b8f-02ed904fdaba)
![e7](https://github.com/user-attachments/assets/60eae6ae-1039-47ed-be14-a976d1fe777a)

after:
![e4](https://github.com/user-attachments/assets/65a3a4ff-eebd-465d-aaab-65986a9cbecf)
![e5](https://github.com/user-attachments/assets/f499e53e-a6d7-4178-a744-a9de37fbc63a)
![e6](https://github.com/user-attachments/assets/244ade04-1042-4a0d-891b-8b1a9d4d2f18)
![e8](https://github.com/user-attachments/assets/11b2b191-242e-4d81-bde1-b81d937a8fe8)

loading:
before:
[Screencast from 03-15-2025 06:06:18 PM.webm](https://github.com/user-attachments/assets/0a311c69-f779-428c-81c6-336516b59c00)
after:
[Screencast from 03-15-2025 06:05:30 PM.webm](https://github.com/user-attachments/assets/54d91d38-7f89-4c2f-b3c6-cf5269c73295)
