### PR TITLE
Migrating TextArea to MUI

### DIFF
--- a/src/components/Claim/CreateClaim/ClaimCreate.tsx
+++ b/src/components/Claim/CreateClaim/ClaimCreate.tsx
@@ -56,7 +56,7 @@ const ClaimCreate = () => {
                     }}
                 >
                     <TextArea
-                        rows={4}
+                        multiline
                         value={content || ""}
                         onChange={(e) => setContent(e.target.value)}
                         placeholder={t("claimForm:contentFieldPlaceholder")}

--- a/src/components/Form/DynamicInput.tsx
+++ b/src/components/Form/DynamicInput.tsx
@@ -34,7 +34,7 @@ const DynamicInput = (props: DynamicInputProps) => {
         case "textArea":
             return (
                 <TextArea
-                    rows={4}
+                    multiline
                     placeholder={t(props.placeholder)}
                     onChange={(value) => props.onChange(value)}
                     defaultValue={props.defaultValue}

--- a/src/components/Modal/ToolbarActionsModal.tsx
+++ b/src/components/Modal/ToolbarActionsModal.tsx
@@ -81,6 +81,7 @@ const UnhideContentModal = ({
                             style={{ marginBottom: 16 }}
                         >
                             <TextArea
+                                multiline
                                 white="white"
                                 placeholder={t(
                                     "claimReview:descriptionInputPlaceholder"

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -1,14 +1,23 @@
 import styled from "styled-components";
-import { Input } from "antd";
+import { TextField } from "@mui/material";
 import colors from "../styles/colors";
 
-const TextArea = styled(Input.TextArea)`
+const TextArea = styled(TextField)`
     background: ${(props) => (props.white ? colors.white : colors.lightNeutral)};
-    box-shadow: 0px 2px 2px ${colors.shadow};
+    box-shadow: 0px 2px 2px ${colors.shadow}; 
     border-radius: 4px;
     border: none;
-    height: 40px;
+    height: 100px;
     padding: 10px;
+    overflow-y: auto;
+    width: 100%;
+    resize: vertical;  
+    overflow: auto; 
+
+    & .MuiOutlinedInput-notchedOutline {
+        border: none;
+        top: -20px;
+    }
 
     ::placeholder {
         color: ${colors.blackSecondary};


### PR DESCRIPTION
# Description  
*In this PR, I migrated the textarea component from Ant Design (antd) to the MUI TextField. The main changes I made were adding the `multiline` property and setting the default initial style for the textarea in the CSS, including the `resize` property. This library change also resulted in a slight style difference — a line appears over the placeholder. I chose to keep this line because removing it via CSS would also remove the resize icon.*

Fixes #1524  
Speech creation page:  
https://github.com/user-attachments/assets/00faba26-6eba-4fc6-b8d1-fecda8ed3c38  
Crosschecking and hide speech modal:  
https://github.com/user-attachments/assets/37b50fe5-1822-4644-a3fc-fd9e66a27161

# Testing  
*To test it, go to the three places where this component is used: the speech creation page, the modal to hide a speech, and the crosschecker comment. By visiting these three locations, you can find the text areas.*
