### PR TITLE
Migrating forms for create claim to MUI

### DIFF
--- a/src/components/Claim/CreateClaim/BaseClaimForm.tsx
+++ b/src/components/Claim/CreateClaim/BaseClaimForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Checkbox, Form, Row } from "antd";
+import { FormControl, FormLabel, Checkbox, Grid, FormHelperText } from "@mui/material";
 import moment from "moment";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
@@ -18,23 +18,41 @@ interface BaseClaimFormProps {
     isLoading: boolean;
     disclaimer?: string;
     dateExtraText: string;
+    errors?: {
+        content?: string;
+        title?: string;
+        date?: string;
+        sources?: string[];
+      };
+      clearError?: (field: "content" | "title" | "date" | "sources") => void;
+      setRecaptcha: (captchaString: string) => void;
+      setTitle: (title: string) => void;
+      setDate: (date: string) => void;
+      setSources: (sources: string[]) => void;
+      title: string;
+      sources: string[];
+      onFinish: () => void;
 }
 
 const BaseClaimForm = ({
     content,
-    handleSubmit,
     disableFutureDates,
     isLoading,
     disclaimer,
     dateExtraText,
+    errors,
+    clearError,
+    setRecaptcha,
+    setTitle,
+    setDate,
+    setSources,
+    title,
+    sources,
+    onFinish,
 }: BaseClaimFormProps) => {
     const { t } = useTranslation();
     const router = useRouter();
-    const [title, setTitle] = useState("");
-    const [date, setDate] = useState("");
     const [disableSubmit, setDisableSubmit] = useState(true);
-    const [sources, setSources] = useState([""]);
-    const [recaptcha, setRecaptcha] = useState("");
 
     const disabledDate = (current) => {
         return disableFutureDates && current && current > moment().endOf("day");
@@ -46,71 +64,71 @@ const BaseClaimForm = ({
         setDisableSubmit(!hasRecaptcha);
     };
 
-    const onFinish = () => {
-        const values = {
-            title,
-            date,
-            sources,
-            recaptcha,
-        };
-        handleSubmit(values);
-    };
-
     return (
-        <Form
-            layout="vertical"
+        <FormControl
+            fullWidth
             id="createClaim"
-            onFinish={onFinish}
             style={{ padding: "32px 0" }}
         >
-            <Form.Item
-                name="title"
-                label={t("claimForm:titleField")}
-                rules={[
-                    {
-                        required: true,
-                        message: t("claimForm:titleFieldError"),
-                        whitespace: true,
-                    },
-                ]}
-                wrapperCol={{ sm: 24 }}
+            <FormLabel
                 style={{
                     width: "100%",
                 }}
             >
+                <div className="root-label">
+                    <span className="require-label">*</span>
+                    <p className="form-label">
+                        {t("claimForm:titleField")}
+                    </p>
+                </div>
                 <Input
                     value={title || ""}
-                    onChange={(e) => setTitle(e.target.value)}
+                    onChange={(e) => {
+                        setTitle(e.target.value);
+                        clearError("title");
+                    }}
                     placeholder={t("claimForm:titleFieldPlaceholder")}
                     data-cy={"testTitleClaimForm"}
                 />
-            </Form.Item>
+                {errors?.title && (
+                    <FormHelperText className="require-label">
+                        {errors.title}
+                    </FormHelperText>
+                )}
+            </FormLabel>
             {content}
-            <Form.Item
-                name="date"
-                label={t("claimForm:dateField")}
-                rules={[
-                    {
-                        required: true,
-                        message: t("claimForm:dateFieldError"),
-                    },
-                ]}
-                extra={dateExtraText}
-                wrapperCol={{ sm: 24 }}
+            <FormLabel
                 style={{
                     width: "100%",
-                    marginBottom: "24px",
                 }}
             >
+                <div className="root-label">
+                    <span className="require-label">*</span>
+                    <p className="form-label">
+                        {t("claimForm:dateField")}
+                    </p>
+                </div>
                 <DatePickerInput
                     placeholder={t("claimForm:dateFieldPlaceholder")}
-                    onChange={(value) => setDate(value)}
+                    onChange={(value) => {
+                        setDate(value);
+                        clearError("date");
+                    }}
                     data-cy={"testSelectDate"}
                     disabledDate={disabledDate}
                 />
-            </Form.Item>
+                {errors?.date && (
+                    <FormHelperText className="require-label">
+                        {errors.date}
+                    </FormHelperText>
+                )}
+                <p className="extra-label">
+                    {dateExtraText}
+                </p>
+            </FormLabel>
             <SourceInput
-                name="source"
+                errors={errors}
+                clearError={clearError}
                 label={t("sourceForm:label")}
                 onChange={(e, index) => {
                     setSources(
@@ -133,32 +151,23 @@ const BaseClaimForm = ({
                 sources={sources}
             />
             {disclaimer && (
-                <Form.Item
+                <FormLabel
+                    className="form-label"
                     style={{
                         color: colors.error,
                     }}
                 >
                     {disclaimer}
-                </Form.Item>
+                </FormLabel>
             )}
-            <Form.Item
-                name="accept_terms"
-                rules={[
-                    {
-                        required: true,
-                        message: t("claimForm:errorAcceptTerms"),
-                    },
-                ]}
-                valuePropName="checked"
-            >
-                <Checkbox data-cy={"testCheckboxAcceptTerms"}>
-                    {t("claimForm:checkboxAcceptTerms")}
-                </Checkbox>
-            </Form.Item>
-            <Form.Item>
+            <FormLabel style={{ display: "flex", alignItems: "center", marginTop: "20px" }}>
+                <Checkbox data-cy={"testCheckboxAcceptTerms"} />
+                <p className="form-label">{t("claimForm:checkboxAcceptTerms")}</p>
+            </FormLabel>
+            <FormLabel>
                 <AletheiaCaptcha onChange={onChangeCaptcha} />
-            </Form.Item>
-            <Row
+            </FormLabel>
+            <Grid container
                 style={{
                     justifyContent: "space-evenly",
                     marginBottom: "20px",
@@ -168,6 +177,7 @@ const BaseClaimForm = ({
                     {t("claimForm:cancelButton")}
                 </Button>
                 <Button
+                    onClick={onFinish}
                     loading={isLoading}
                     type={ButtonType.blue}
                     htmlType="submit"
@@ -176,8 +186,8 @@ const BaseClaimForm = ({
                 >
                     {t("claimForm:saveButton")}
                 </Button>
-            </Row>
-        </Form>
+            </Grid>
+        </FormControl>
     );
 };
 

--- a/src/components/Claim/CreateClaim/ClaimCreate.style.tsx
+++ b/src/components/Claim/CreateClaim/ClaimCreate.style.tsx
@@ -1,0 +1,30 @@
+import { Grid } from "@mui/material";
+import styled from "styled-components";
+import colors from "../../../styles/colors";
+
+const ClaimCreateStyle = styled(Grid)`
+justify-content: center;
+
+.root-label{
+  display: flex;
+  gap: 5px;
+}
+.require-label{
+  font-size: 14px;
+  color: ${colors.error};
+  margin: 0;
+}
+.form-label{
+  font-size: 14px;
+  color: ${colors.black};
+  margin: 0;
+}
+
+.extra-label{
+  font-size: 14px;
+  color: ${colors.neutralSecondary};
+}
+    
+`;
+
+export default ClaimCreateStyle;

--- a/src/components/Claim/CreateClaim/CreateClaimView.tsx
+++ b/src/components/Claim/CreateClaim/CreateClaimView.tsx
@@ -22,6 +22,7 @@ import verificationRequestApi from "../../../api/verificationRequestApi";
 import { useTranslation } from "next-i18next";
 import VerificationRequestDrawer from "../../VerificationRequest/VerificationRequestDrawer";
 import ManageVerificationRequestGroup from "../../VerificationRequest/ManageVerificationRequestGroup";
+import ClaimCreateStyle from "./ClaimCreate.style";
 
 const CreateClaimView = () => {
     const { t } = useTranslation();
@@ -77,7 +78,7 @@ const CreateClaimView = () => {
     };
 
     return (
-        <Grid container style={{justifyContent:"center"}}>
+        <ClaimCreateStyle container>
             <Grid item xs={9} style={{ marginTop: 32 }}>
                 {!isLoading &&
                     claimData?.group &&
@@ -110,7 +111,7 @@ const CreateClaimView = () => {
                 onCloseDrawer={onCloseDrawer}
                 onRemove={onRemove}
             />
-        </Grid>
+        </ClaimCreateStyle>
     );
 };
 

--- a/src/components/Source/SourceInput.tsx
+++ b/src/components/Source/SourceInput.tsx
@@ -1,53 +1,64 @@
-import { Form } from "antd";
 import React from "react";
 import { DeleteOutlined, AddOutlined } from "@mui/icons-material";
-import { Grid } from "@mui/material";
+import { FormControl, FormHelperText, Grid } from "@mui/material";
+import { URL_PATTERN } from "../../utils/ValidateFloatingLink";
 import { useTranslation } from "next-i18next";
 import Input from "../AletheiaInput";
 import Button from "../Button";
 
-const SourceInput = ({ onChange, addSource, removeSource, placeholder, name, label, sources }) => {
+const SourceInput = ({ onChange, addSource, removeSource, placeholder, label, sources, errors, clearError }) => {
     const { t } = useTranslation();
     return (
         <>
-            {sources && sources.map((source, index) => {
-                const onSourceChange = (e) => {
-                    onChange(e, index);
-                }
-                return (
-                    <Form.Item
-                        key={index}
-                        name={`source-${index}`}
-                        label={index === 0 ? label : null}
-                        extra={index === (sources.length - 1) ? t("sourceForm:extra") : null}
-                        rules={[
-                            {
-                                message: t("sourceForm:errorMessageValidURL"),
-                                type: "url"
-                            },
-                            {
-                                required: true,
-                                message: t("common:requiredFieldError"),
-                            },
-                        ]}
-                    >
-                        <Grid container>
-                            <Grid item xs={index > 0 ? 10 : 12}>
-                                <Input
-                                    key={index}
-                                    value={source || ""}
-                                    onChange={onSourceChange}
-                                    placeholder={placeholder}
-                                    data-cy={'testSource1'}
-                                />
-                            </Grid>
-                            <Grid item xs={2}>
-                                {index > 0 && <Button style={{ width: "100%", height: "40px" }} onClick={() => removeSource(index)}><DeleteOutlined fontSize="small" /></Button>}
-                            </Grid>
+            {sources && sources.map((source, index) => (
+                <FormControl
+                    fullWidth
+                    key={index}
+                >
+                    <Grid container>
+                        {index === 0 ?
+                            <div className="root-label">
+                                <span className="require-label">*</span>
+                                <p className="form-label">{label}</p>
+                            </div>
+                            :
+                            null
+                        }
+                        <Grid item xs={index > 0 ? 10 : 12}>
+                            <Input
+                                key={index}
+                                value={source || ""}
+                                onChange={(e) => {
+                                    onChange(e, index)
+                                    if (URL_PATTERN.test(e.target.value)) {
+                                        clearError("sources");
+                                    }
+                                }}
+                                placeholder={placeholder}
+                                data-cy={'testSource1'}
+                            />
+                            {errors?.sources?.[index] && (
+                                <FormHelperText className="require-label">
+                                    {errors.sources[index]}
+                                </FormHelperText>
+                            )}
+                            <p className="extra-label">
+                                {index === (sources.length - 1) ? t("sourceForm:extra") : null}
+                            </p>
                         </Grid>
-                    </Form.Item>
-                )
-            })
+                        <Grid item xs={2}>
+                            {index > 0 &&
+                                <Button
+                                    style={{ width: "100%", height: "40px" }}
+                                    onClick={() => removeSource(index)}
+                                >
+                                    <DeleteOutlined fontSize="small" />
+                                </Button>
+                            }
+                        </Grid>
+                    </Grid>
+                </FormControl >
+            ))
             }
             <div
                 style={{
@@ -72,4 +83,4 @@ const SourceInput = ({ onChange, addSource, removeSource, placeholder, name, lab
     );
 }
 
-export default SourceInput;
+export default SourceInput; 


### PR DESCRIPTION
# Description
*In this PR, I migrated the form from Ant Design to MUI, and there are some native functionalities in Ant Design that I had to replicate in MUI — for example, form error handling. As a result, I had to use React's useState to manage the state of each form input individually. I believe there are ways to refactor this code, and I already have some ideas, especially when we start migrating the other forms in different components. My intention here is precisely to get feedback on how to refactor and better organize this code in relation to the other forms we'll be working on.*

https://github.com/user-attachments/assets/7741e38f-c62a-4ed2-9a58-3a3ff97d87e1

fixes #1540  , fixes #1541  , fixes #1670 

# Testing
*To test it, you would need to go through the entire claim creation flow using all fields and test different scenarios related to this functionality.*
