### PR TITLE
Migrating AletheiaAlert to MUI

### DIFF
--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -35,30 +35,28 @@ const About = () => {
                 type="info"
                 message={
                     <>
-                        {t("about:alertInfo")}{" "}
-                        <a
-                            style={{ whiteSpace: "pre-wrap" }}
-                            href="https://github.com/AletheiaFact/aletheia"
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            https://github.com/AletheiaFact/aletheia
-                        </a>
+                        <p style={{ fontWeight: 600 }}>
+                            {t("about:alertInfo")}{" "}
+                            <a
+                                style={{ whiteSpace: "pre-wrap" }}
+                                href="https://github.com/AletheiaFact/aletheia"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                https://github.com/AletheiaFact/aletheia
+                            </a>
+                        </p>
                     </>
                 }
                 action={
                     <Button
+                        style={{ display: "flex", justifySelf: "end" }}
                         variant="contained"
                         size="small"
                         startIcon={<DescriptionIcon />}
                         href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/AletheiaFact/miscellaneous/290b19847f0da521963f74e7947d7863bf5d5624/documents/org_legal_register.pdf"
                         target="_blank"
                         rel="noreferrer"
-                        sx={{
-                            position: "absolute",
-                            bottom: "15px",
-                            right: "15px",
-                        }}
                     >
                         {t("about:labelButton")}
                     </Button>

--- a/src/components/AletheiaAlert.tsx
+++ b/src/components/AletheiaAlert.tsx
@@ -1,5 +1,6 @@
-import { Alert } from "antd";
+import { Alert, useTheme, Grid, AlertTitle } from "@mui/material";
 import React from "react";
+import colors from "../styles/colors";
 
 const AletheiaAlert = ({
     type,
@@ -7,21 +8,44 @@ const AletheiaAlert = ({
     description = null,
     action = null,
     showIcon = false,
+    style = {},
     ...props
 }) => {
+    const theme = useTheme();
+    const colorMap = {
+        success: theme.palette.success.main,
+        info: theme.palette.info.main,
+        warning: theme.palette.warning.main,
+        error: theme.palette.error.main,
+    };
+
     return (
         <Alert
-            type={type}
+            severity={type}
+            icon={showIcon && undefined}
             style={{
                 marginBottom: "15px",
-                padding: "50px 25px 50px 25px",
+                padding: "25px",
+                color: colors.blackTertiary,
+                border: `1px solid ${colorMap[type]}`,
+                ...style,
             }}
-            message={message}
-            description={description}
-            action={action}
-            showIcon={showIcon}
             {...props}
-        />
+        >
+            <AlertTitle style={{ fontSize: "14px", ...style }}>
+                {message}
+            </AlertTitle>
+            {description && (
+                <p style={{ fontSize: "12px" }}>
+                    {description}
+                </p>
+            )}
+            {action && (
+                <Grid item xs={12}>
+                    {action}
+                </Grid>
+            )}
+        </Alert>
     );
 };
 

--- a/src/components/Login/OryLoginForm.tsx
+++ b/src/components/Login/OryLoginForm.tsx
@@ -1,4 +1,5 @@
-import { Alert, Form, Row } from "antd";
+import { Form, Row } from "antd";
+import AletheiaAlert from "../AletheiaAlert";
 import { useTranslation } from "next-i18next";
 import React from "react";
 
@@ -18,9 +19,10 @@ const OryLoginForm = ({
 
     return (
         <>
-            {flow.refresh && (
+            {true && (
                 <Row style={{ paddingBottom: "10px" }}>
-                    <Alert
+                    <AletheiaAlert
+                        style={{ padding: "0 15px", margin: "0px" }}
                         message={t("login:refreshLoginMessage")}
                         type="warning"
                     />

--- a/src/components/Profile/OryProfileView.tsx
+++ b/src/components/Profile/OryProfileView.tsx
@@ -3,7 +3,8 @@ import {
     SettingsFlowState,
     UpdateSettingsFlowWithPasswordMethod as ValuesType,
 } from "@ory/client";
-import { Alert, Form, FormInstance, Typography } from "antd";
+import { Form, FormInstance, Typography } from "antd";
+import AletheiaAlert from "../AletheiaAlert";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import React, { useEffect, useRef, useState } from "react";
@@ -106,13 +107,13 @@ const OryProfileView = ({ user }) => {
                 </Typography.Title>
 
                 {!user.firstPasswordChanged && (
-                    <Alert
-                        style={{ marginBottom: "1rem" }}
+                    <AletheiaAlert
+                        style={{ padding: "0 10px", margin: 0 }}
                         message={t("profile:warningMessage")}
                         type="warning"
                     />
                 )}
-                <Form ref={formRef} onFinish={onFinish}>
+                <Form ref={formRef} onFinish={onFinish} style={{ marginTop: "20px" }}>
                     <Form.Item
                         name="newPassword"
                         label={t("profile:newPasswordLabel")}


### PR DESCRIPTION
# Description
This PR migrates the `AletheiaAlert` component to MUI. I mainly had to adapt some elements that were previously being passed as props in Ant Design to be used as `children` in the MUI version. I also adjusted some styles to match the previous design, and there was a slight color change for the alert `type`.

You can see a full comparison of the alerts before and after the migration in this document:
[alert to MUI(2).pdf](https://github.com/user-attachments/files/19814647/alert.to.MUI.2.pdf)

color change:
before:
<img width="1416" alt="Screenshot 2025-04-18 at 16 18 01" src="https://github.com/user-attachments/assets/6d1aa47e-b0e5-454c-a494-ba1554cdd1e3" />

after:
<img width="1349" alt="Screenshot 2025-04-18 at 18 35 31" src="https://github.com/user-attachments/assets/e7ce735f-ed4f-4422-965e-bcb8f24272f4" />


Fixes #1479

# Testing
To test it, you need to visit all pages where `AletheiaAlert` is used. It's easier to perform the tests by following the documentation provided in the PDF above.
