### PR TITLE
Migrate TOTP form to MUI

### DIFF
--- a/src/components/InputPassword.tsx
+++ b/src/components/InputPassword.tsx
@@ -1,5 +1,5 @@
 import { TextField, IconButton, InputAdornment } from "@mui/material";
-import { useState } from "react";
+import { useState, forwardRef } from "react";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import styled from "styled-components";
 import colors from "../styles/colors";
@@ -36,12 +36,13 @@ const StyledTextField = styled(TextField)`
     }
 `;
 
-const InputPassword = (props) => {
+const InputPassword = forwardRef(({ ...props }, ref) => {
     const [showPassword, setShowPassword] = useState(false);
 
     return (
         <StyledTextField
             {...props}
+            inputRef={ref}
             type={showPassword ? "text" : "password"}
             InputProps={{
                 endAdornment: (
@@ -54,6 +55,6 @@ const InputPassword = (props) => {
             }}
         />
     );
-};
+});
 
 export default InputPassword;

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -4,9 +4,9 @@ import Typography from "@mui/material/Typography"
 
 const Label = ({ children, required = false }) => {
     return (
-        <span style={{ color: colors.error }}>
+        <span style={{ color: colors.error, display: "flex", gap: "4px" }}>
             {required && "* "}
-            <Typography variant="body2" style={{ color: colors.blackSecondary, fontWeight:600 }}>
+            <Typography variant="body2" style={{ color: colors.blackSecondary, fontWeight: 600 }}>
                 {children}
             </Typography>
         </span>

--- a/src/components/Profile/Totp.tsx
+++ b/src/components/Profile/Totp.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @next/next/no-img-element  */
 /* eslint-disable jsx-a11y/anchor-has-content */
 import { UpdateSettingsFlowWithTotpMethod as ValuesType } from "@ory/client";
-import { Form } from "antd";
+import { useForm } from "react-hook-form";
+import Label from "../Label";
 import { MessageManager } from "../Messages";
 import { Grid, Typography } from "@mui/material"
 import { Trans, useTranslation } from "next-i18next";
@@ -21,6 +22,12 @@ export const Totp = ({ flow, setFlow }) => {
     const [isLoading, setIsLoading] = useState(false);
     const { t } = useTranslation();
     const router = useRouter();
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+        reset,
+    } = useForm();
 
     let flowValues: ValuesType = {
         csrf_token: "",
@@ -57,7 +64,8 @@ export const Totp = ({ flow, setFlow }) => {
         } catch {
             setShowForm(false);
         }
-    }, [flow]);
+        reset();
+    }, [flow, reset]);
 
     const onSubmitLink = (values: ValuesType) => {
         orySubmitTotp({ router, flow, setFlow, t, values })
@@ -119,8 +127,11 @@ export const Totp = ({ flow, setFlow }) => {
                 </Typography>
             </Grid>
             {showForm && (
-                <Form onFinish={onFinish} style={{ marginBottom: "20px" }}>
-                    <Form.Item>
+                <form
+                    onSubmit={handleSubmit(onFinish)}
+                    style={{ marginBottom: "20px" }}
+                >
+                    <div style={{ marginBottom: "20px" }}>
                         <p>
                             <Trans
                                 i18nKey={"profile:totpSectionDescription"}
@@ -173,23 +184,29 @@ export const Totp = ({ flow, setFlow }) => {
                         >
                             {textSource}
                         </code>
-                    </Form.Item>
-                    <Form.Item
-                        name="totp"
-                        label={t("profile:totpInputTittle")}
-                        wrapperCol={{ sm: 24 }}
-                        style={{
-                            width: "100%",
-                        }}
-                        rules={[
-                            {
-                                required: true,
-                                message: t("common:requiredFieldError"),
-                            },
-                        ]}
-                    >
-                        <InputPassword />
-                    </Form.Item>
+                    </div>
+                    <div style={{ marginBottom: "20px" }}>
+                        <Label required>
+                            {t("profile:totpInputTittle")}
+                        </Label>
+                        <div>
+                            <InputPassword
+                                {...register("totp", {
+                                    required: t("claimReview:descriptionInputError"),
+                                })}
+                            />
+                            {errors.totp &&
+                                <p
+                                    style={{
+                                        color: colors.error,
+                                        marginTop: 4
+                                    }}
+                                >
+                                    {t("common:requiredFieldError")}
+                                </p>
+                            }
+                        </div>
+                    </div>
                     <AletheiaButton
                         type={ButtonType.blue}
                         htmlType="submit"
@@ -197,10 +214,12 @@ export const Totp = ({ flow, setFlow }) => {
                     >
                         {t("login:submitButton")}
                     </AletheiaButton>
-                </Form>
+                </form>
             )}
             {!showForm && (
-                <Form onFinish={onFinishUnlink}>
+                <form
+                    onSubmit={handleSubmit(onFinishUnlink)}
+                >
                     <AletheiaButton
                         loading={isLoading}
                         htmlType="submit"
@@ -229,7 +248,7 @@ export const Totp = ({ flow, setFlow }) => {
                             {t("profile:totpUnLinkSubmit")}
                         </Typography>
                     </AletheiaButton>
-                </Form>
+                </form>
             )}
         </>
     );


### PR DESCRIPTION
# Description
In this PR, I migrated the TOTP forms to use React Hook Form. To see the full process, I’ve included a video demonstration below:

Video walkthrough:  
https://github.com/user-attachments/assets/81d8c92a-d5d2-4173-ab43-fc1da10ddca6

Fixes #1692

# Testing
To test this, go through the entire authentication flow. First, log in to the platform, navigate to "My Account", and follow the steps to set up or manage TOTP.
