### PR TITLE
Migrating form of login sign to react hook form

### DIFF
--- a/cypress/support/locators.ts
+++ b/cypress/support/locators.ts
@@ -2,8 +2,8 @@ import personality from "../fixtures/personality";
 
 const locators = {
     login: {
-        USER: "#basic_email",
-        PASSWORD: "#basic_password",
+        USER: "[data-cy=emailFormLogin]",
+        PASSWORD: "[data-cy=passwordFormLogin]",
         BTN_LOGIN: "[data-cy=loginButton]",
     },
 

--- a/public/locales/pt/login.json
+++ b/public/locales/pt/login.json
@@ -7,6 +7,7 @@
     "nameLabel": "Nome",
     "submitButton": "Enviar",
     "emailErrorMessage": "Por favor, insira seu e-mail",
+    "invalidEmailErrorMessage": "E-mail inválido",
     "nameErrorMessage": "Por favor, insira seu nome",
     "passwordErrorMessage": "Por favor, insira sua senha",
     "loginFailedMessage": "Erro ao fazer login",

--- a/src/components/InputPassword.tsx
+++ b/src/components/InputPassword.tsx
@@ -8,6 +8,7 @@ const StyledTextField = styled(TextField)`
     background: ${(props) => (props.white ? colors.white : colors.lightNeutral)};
     box-shadow: 0px 2px 2px ${colors.shadow};
     border-radius: 4px;
+    width: 100%;
     
     & .MuiOutlinedInput-root {
         border-radius: 4px;

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -4,7 +4,7 @@ import Typography from "@mui/material/Typography"
 
 const Label = ({ children, required = false }) => {
     return (
-        <span style={{ color: colors.error, display: "flex", gap: "4px" }}>
+        <span style={{ color: colors.error, display: "flex", gap: "4px", width: "100%" }}>
             {required && "* "}
             <Typography variant="body2" style={{ color: colors.blackSecondary, fontWeight: 600 }}>
                 {children}

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -6,7 +6,7 @@ const Label = ({ children, required = false }) => {
     return (
         <span style={{ color: colors.error, display: "flex", gap: "4px", width: "100%" }}>
             {required && "* "}
-            <Typography variant="body2" style={{ color: colors.blackSecondary, fontWeight: 600 }}>
+            <Typography variant="body2" style={{ color: colors.blackSecondary }}>
                 {children}
             </Typography>
         </span>

--- a/src/components/Login/OryLoginForm.tsx
+++ b/src/components/Login/OryLoginForm.tsx
@@ -1,4 +1,3 @@
-import { Form, Row } from "antd";
 import AletheiaAlert from "../AletheiaAlert";
 import { useTranslation } from "next-i18next";
 import React from "react";
@@ -7,6 +6,10 @@ import Input from "../AletheiaInput";
 import Button, { ButtonType } from "../Button";
 import InputPassword from "../InputPassword";
 import ForgotPasswordLink from "./ForgotPasswordLink";
+import { Grid } from "@mui/material";
+import Label from "../Label";
+import colors from "../../styles/colors";
+import { useForm } from "react-hook-form";
 
 const OryLoginForm = ({
     flow,
@@ -16,102 +19,134 @@ const OryLoginForm = ({
     onFinishTotp,
 }) => {
     const { t } = useTranslation();
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm();
 
     return (
         <>
             {flow.refresh && (
-                <Row style={{ paddingBottom: "10px" }}>
+                <Grid container
+                    style={{ paddingBottom: "10px" }}
+                >
                     <AletheiaAlert
                         style={{ padding: "0 15px", margin: "0px" }}
                         message={t("login:refreshLoginMessage")}
                         type="warning"
                     />
-                </Row>
+                </Grid>
             )}
             {flow?.requested_aal !== "aal2" && (
                 <>
-                    <Row className="typo-grey typo-center">
+                    <Grid container className="typo-grey typo-center">
                         <h2>{t("login:formHeader")}</h2>
-                    </Row>
-                    <Form
-                        name="basic"
-                        initialValues={{ remember: true }}
-                        onFinish={onFinish}
-                        onFinishFailed={onFinishFailed}
+                    </Grid>
+                    <form
+                        onSubmit={handleSubmit(onFinish)}
+                        onError={onFinishFailed}
                     >
-                        <Form.Item
-                            label={t("login:emailLabel")}
-                            name="email"
-                            rules={[
-                                {
-                                    required: true,
-                                    message: t("login:emailErrorMessage"),
-                                },
-                            ]}
-                        >
-                            <Input />
-                        </Form.Item>
-
-                        <Form.Item
-                            label={t("login:passwordLabel")}
-                            name="password"
-                            rules={[
-                                {
-                                    required: true,
-                                    message: t("login:passwordErrorMessage"),
-                                },
-                            ]}
-                        >
-                            <div
-                                style={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                }}
-                            >
-                                <InputPassword />
-                                <ForgotPasswordLink t={t} />
-                            </div>
-                        </Form.Item>
-                        <Form.Item>
-                            <div
-                                style={{
-                                    justifyContent: "space-between",
-                                    display: "flex",
-                                }}
-                            >
-                                <Button
-                                    loading={isLoading}
-                                    type={ButtonType.blue}
-                                    htmlType="submit"
-                                    data-cy={"loginButton"}
+                        <Grid container>
+                            <Grid item xs={1}>
+                                <Label required
+                                    children={t("login:emailLabel") + " :"}
+                                />
+                            </Grid>
+                            <Grid item xs={11}>
+                                <Input
+                                    {...register("email", {
+                                        required: true
+                                    })}
+                                />
+                                <p
+                                    style={{
+                                        fontSize: 14,
+                                        color: colors.error,
+                                        visibility: errors.email ? "visible" : "hidden",
+                                    }}
                                 >
-                                    {t("login:submitButton")}
-                                </Button>
-                            </div>
-                        </Form.Item>
-                    </Form>
+                                    {t("login:emailErrorMessage")}
+                                </p>
+                            </Grid>
+                        </Grid>
+                        <Grid container>
+                            <Grid item xs={1}>
+                                <Label required
+                                    children={t("login:passwordLabel") + " :"}
+                                />
+                            </Grid>
+                            <Grid item xs={11}>
+                                <InputPassword
+                                    {...register("password", {
+                                        required: true
+                                    })}
+                                />
+                                <ForgotPasswordLink t={t} />
+                                <p
+                                    style={{
+                                        fontSize: 14,
+                                        color: colors.error,
+                                        visibility: errors.password ? "visible" : "hidden",
+                                    }}
+                                >
+                                    {t("login:passwordErrorMessage")}
+                                </p>
+                            </Grid>
+                        </Grid>
+                        <div
+                            style={{
+                                justifyContent: "space-between",
+                                display: "flex",
+                            }}
+                        >
+                            <Button
+                                loading={isLoading}
+                                type={ButtonType.blue}
+                                htmlType="submit"
+                                data-cy={"loginButton"}
+                            >
+                                {t("login:submitButton")}
+                            </Button>
+                        </div>
+                    </form>
                 </>
             )}
             {flow?.requested_aal === "aal2" && (
                 <>
-                    <Row>
+                    <Grid container
+                        className="typo-grey typo-center"
+                        marginTop={2}
+                    >
                         <h2>{t("totp:formHeader")}</h2>
-                    </Row>
+                    </Grid>
                     <p>{t("totp:totpMessage")}</p>
-                    <Form name="basic" onFinish={onFinishTotp}>
-                        <Form.Item
-                            label={t("totp:inputLabel")}
-                            name="totp"
-                            rules={[
-                                {
-                                    required: true,
-                                    message: t("totp:totpErrorMessage"),
-                                },
-                            ]}
-                        >
-                            <InputPassword />
-                        </Form.Item>
-                        <Form.Item>
+                    <form onSubmit={handleSubmit(onFinishTotp)}>
+                        <Grid container>
+                            <Grid item xs={2.5}>
+                                <Label required
+                                    children={t("totp:inputLabel") + " :"}
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
+                                <InputPassword
+                                    {...register("totp", {
+                                        required: true,
+                                    })}
+                                />
+                                {errors.totp &&
+                                    <p
+                                        style={{
+                                            color: colors.error,
+                                            marginTop: 4,
+                                        }}
+                                    >
+                                        {t("totp:totpErrorMessage")}
+                                    </p>
+                                }
+                            </Grid>
+                        </Grid>
+                        <Grid container>
                             <div
                                 style={{
                                     justifyContent: "space-between",
@@ -126,8 +161,8 @@ const OryLoginForm = ({
                                     {t("totp:submitButton")}
                                 </Button>
                             </div>
-                        </Form.Item>
-                    </Form>
+                        </Grid>
+                    </form>
                 </>
             )}
         </>

--- a/src/components/Login/OryLoginForm.tsx
+++ b/src/components/Login/OryLoginForm.tsx
@@ -8,8 +8,8 @@ import InputPassword from "../InputPassword";
 import ForgotPasswordLink from "./ForgotPasswordLink";
 import { Grid } from "@mui/material";
 import Label from "../Label";
-import colors from "../../styles/colors";
 import { useForm } from "react-hook-form";
+import TextError from "../TextErrorForm";
 
 const OryLoginForm = ({
     flow,
@@ -39,66 +39,51 @@ const OryLoginForm = ({
                 </Grid>
             )}
             {flow?.requested_aal !== "aal2" && (
-                <>
-                    <Grid container className="typo-grey typo-center">
-                        <h2>{t("login:formHeader")}</h2>
-                    </Grid>
+                <Grid container
+                    direction="column"
+                >
+                    <h2>
+                        {t("login:formHeader")}
+                    </h2>
                     <form
                         onSubmit={handleSubmit(onFinish, onFinishFailed)}
                     >
-                        <Grid container>
-                            <Grid item xs={1}>
+                        <Grid container
+                            marginBottom={2}
+                        >
+                            <Grid item xs={12} sm={2.25} lg={1.25}>
                                 <Label required
                                     children={t("login:emailLabel") + " :"}
                                 />
                             </Grid>
-                            <Grid item xs={11}>
+                            <Grid item xs={12} sm={9.75} lg={10.75}>
                                 <Input
                                     {...register("email", {
                                         required: true
                                     })}
                                 />
-                                <p
-                                    style={{
-                                        fontSize: 14,
-                                        color: colors.error,
-                                        visibility: errors.email ? "visible" : "hidden",
-                                    }}
-                                >
-                                    {t("login:emailErrorMessage")}
-                                </p>
+                                <TextError
+                                    stateError={errors.email}
+                                    children={t("login:emailErrorMessage")}
+                                />
                             </Grid>
-                        </Grid>
-                        <Grid container>
-                            <Grid item xs={1}>
+                            <Grid item xs={12} sm={2.25} lg={1.25}>
                                 <Label required
                                     children={t("login:passwordLabel") + " :"}
                                 />
                             </Grid>
-                            <Grid item xs={11}>
+                            <Grid item xs={12} sm={9.75} lg={10.75} >
                                 <InputPassword
                                     {...register("password", {
                                         required: true
                                     })}
                                 />
                                 <ForgotPasswordLink t={t} />
-                                <p
-                                    style={{
-                                        fontSize: 14,
-                                        color: colors.error,
-                                        visibility: errors.password ? "visible" : "hidden",
-                                    }}
-                                >
-                                    {t("login:passwordErrorMessage")}
-                                </p>
+                                <TextError
+                                    stateError={errors.password}
+                                    children={t("login:passwordErrorMessage")}
+                                />
                             </Grid>
-                        </Grid>
-                        <div
-                            style={{
-                                justifyContent: "space-between",
-                                display: "flex",
-                            }}
-                        >
                             <Button
                                 loading={isLoading}
                                 type={ButtonType.blue}
@@ -107,62 +92,50 @@ const OryLoginForm = ({
                             >
                                 {t("login:submitButton")}
                             </Button>
-                        </div>
+                        </Grid>
                     </form>
-                </>
+                </Grid>
             )}
             {flow?.requested_aal === "aal2" && (
-                <>
-                    <Grid container
-                        className="typo-grey typo-center"
-                        marginTop={2}
+                <Grid container direction="column">
+                    <h2>
+                        {t("totp:formHeader")}
+                    </h2>
+                    <p>
+                        {t("totp:totpMessage")}
+                    </p>
+                    <form
+                        onSubmit={handleSubmit(onFinishTotp)}
                     >
-                        <h2>{t("totp:formHeader")}</h2>
-                    </Grid>
-                    <p>{t("totp:totpMessage")}</p>
-                    <form onSubmit={handleSubmit(onFinishTotp)}>
-                        <Grid container>
-                            <Grid item xs={2.5}>
+                        <Grid container display="flex">
+                            <Grid item xs={12} md={5} lg={3}>
                                 <Label required
                                     children={t("totp:inputLabel") + " :"}
                                 />
                             </Grid>
-                            <Grid item xs={4}>
+                            <Grid item xs={8} md={5} lg={3}>
                                 <InputPassword
                                     {...register("totp", {
                                         required: true,
                                     })}
                                 />
-                                {errors.totp &&
-                                    <p
-                                        style={{
-                                            color: colors.error,
-                                            marginTop: 4,
-                                        }}
-                                    >
-                                        {t("totp:totpErrorMessage")}
-                                    </p>
-                                }
+                                <TextError
+                                    stateError={errors.totp}
+                                    children={t("totp:totpErrorMessage")}
+                                />
                             </Grid>
                         </Grid>
                         <Grid container>
-                            <div
-                                style={{
-                                    justifyContent: "space-between",
-                                    display: "flex",
-                                }}
+                            <Button
+                                loading={isLoading}
+                                type={ButtonType.blue}
+                                htmlType="submit"
                             >
-                                <Button
-                                    loading={isLoading}
-                                    type={ButtonType.blue}
-                                    htmlType="submit"
-                                >
-                                    {t("totp:submitButton")}
-                                </Button>
-                            </div>
+                                {t("totp:submitButton")}
+                            </Button>
                         </Grid>
                     </form>
-                </>
+                </Grid>
             )}
         </>
     );

--- a/src/components/Login/OryLoginForm.tsx
+++ b/src/components/Login/OryLoginForm.tsx
@@ -58,6 +58,7 @@ const OryLoginForm = ({
                             </Grid>
                             <Grid item xs={12} sm={9.75} lg={10.75}>
                                 <Input
+                                    data-cy="emailFormLogin"
                                     {...register("email", {
                                         required: true
                                     })}
@@ -74,6 +75,7 @@ const OryLoginForm = ({
                             </Grid>
                             <Grid item xs={12} sm={9.75} lg={10.75} >
                                 <InputPassword
+                                    data-cy="passwordFormLogin"
                                     {...register("password", {
                                         required: true
                                     })}
@@ -115,6 +117,7 @@ const OryLoginForm = ({
                             </Grid>
                             <Grid item xs={8} md={5} lg={3}>
                                 <InputPassword
+                                    data-cy="totpFormLogin"
                                     {...register("totp", {
                                         required: true,
                                     })}
@@ -130,6 +133,7 @@ const OryLoginForm = ({
                                 loading={isLoading}
                                 type={ButtonType.blue}
                                 htmlType="submit"
+                                data-cy="totpSubmitButton"
                             >
                                 {t("totp:submitButton")}
                             </Button>

--- a/src/components/Login/OryLoginForm.tsx
+++ b/src/components/Login/OryLoginForm.tsx
@@ -44,8 +44,7 @@ const OryLoginForm = ({
                         <h2>{t("login:formHeader")}</h2>
                     </Grid>
                     <form
-                        onSubmit={handleSubmit(onFinish)}
-                        onError={onFinishFailed}
+                        onSubmit={handleSubmit(onFinish, onFinishFailed)}
                     >
                         <Grid container>
                             <Grid item xs={1}>

--- a/src/components/Login/SignUpForm.tsx
+++ b/src/components/Login/SignUpForm.tsx
@@ -1,4 +1,3 @@
-import { Form } from "antd";
 import { useTranslation } from "next-i18next";
 import React from "react";
 
@@ -6,9 +5,20 @@ import AletheiaAlert from "../AletheiaAlert";
 import Input from "../AletheiaInput";
 import Button, { ButtonType } from "../Button";
 import InputPassword from "../InputPassword";
+import { Grid } from "@mui/material";
+import { useForm } from "react-hook-form";
+import Label from "../Label";
+import colors from "../../styles/colors";
 
 const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
     const { t } = useTranslation();
+    const {
+        register,
+        handleSubmit,
+        watch,
+        formState: { errors },
+    } = useForm();
+    const senha = watch("password");
 
     return (
         <div>
@@ -27,88 +37,117 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                 }
             />
             <h2>{t("login:signupFormHeader")}</h2>
-            <Form
-                name="signUp"
-                wrapperCol={{ span: 18 }}
-                labelCol={{ span: 6 }}
-                labelAlign="left"
-                labelWrap
-                onFinish={onFinish}
-                onFinishFailed={onFinishFailed}
+            <form
+                onSubmit={handleSubmit(onFinish)}
+                onError={onFinishFailed}
             >
-                <Form.Item
-                    label={t("login:nameLabel")}
-                    name="name"
-                    rules={[
-                        {
-                            required: true,
-                            message: t("login:nameErrorMessage"),
-                        },
-                    ]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item
-                    label={t("login:emailLabel")}
-                    name="email"
-                    rules={[
-                        {
-                            required: true,
-                            message: t("login:emailErrorMessage"),
-                        },
-                        {
-                            type: "email",
-                            message: t("login:emailErrorMessage"),
-                        },
-                    ]}
-                >
-                    <Input />
-                </Form.Item>
-                <Form.Item
-                    label={t("login:passwordLabel")}
-                    name="password"
-                    rules={[
-                        {
-                            required: true,
-                            message: t("login:passwordErrorMessage"),
-                        },
-                    ]}
-                >
-                    <InputPassword sx={{ width: "100%" }} />
-                </Form.Item>
-                <Form.Item
-                    name="repeatPassword"
-                    label={t("login:repeatPasswordLabel")}
-                    rules={[
-                        {
-                            required: true,
-                            message: t("common:requiredFieldError"),
-                        },
-                        ({ getFieldValue }) => ({
-                            validator(_, value) {
-                                if (
-                                    !value ||
-                                    getFieldValue("password") === value
-                                ) {
-                                    return Promise.resolve();
-                                }
-                                return Promise.reject(
-                                    new Error(
-                                        t("profile:passwordMatchErrorMessage")
-                                    )
-                                );
-                            },
-                        }),
-                    ]}
-                    wrapperCol={{ sm: 24 }}
+                <Grid container>
+                    <Grid item xs={3}>
+                        <Label required
+                            children={t("login:nameLabel") + " :"}
+                        />
+                    </Grid>
+                    <Grid item xs={9}>
+                        <Input
+                            {...register("nameDescription", {
+                                required: true
+                            })}
+                        />
+                        <p
+                            style={{
+                                fontSize: 14,
+                                color: colors.error,
+                                visibility: errors.nameDescription ? "visible" : "hidden",
+                            }}>
+                            {t("login:nameErrorMessage")}
+                        </p>
+                    </Grid>
+                </Grid>
+                <Grid container>
+                    <Grid item xs={3}>
+                        <Label required
+                            children={t("login:emailLabel") + " :"}
+                        />
+                    </Grid>
+                    <Grid item xs={9}>
+                        <Input
+                            {...register("email", {
+                                required: true,
+                                pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+                            })}
+                        />
+                        <p
+                            style={{
+                                fontSize: 14,
+                                color: colors.error,
+                                visibility: errors.email ? "visible" : "hidden",
+                            }}
+                        >
+                            {errors.email?.type === "pattern"
+                                ? t("login:invalidEmailErrorMessage")
+                                : t("login:emailErrorMessage")
+                            }
+                        </p>
+                    </Grid>
+                </Grid>
+                <Grid container>
+                    <Grid item xs={3}>
+                        <Label required
+                            children={t("login:passwordLabel") + " :"}
+                        />
+                    </Grid>
+                    <Grid item xs={9}>
+                        <InputPassword
+                            {...register("password", {
+                                required: true
+                            })}
+                        />
+                        <p
+                            style={{
+                                fontSize: 14,
+                                color: colors.error,
+                                visibility: errors.password ? "visible" : "hidden",
+                            }}
+                        >
+                            {t("login:passwordErrorMessage")}
+                        </p>
+                    </Grid>
+                </Grid>
+                <Grid container
                     style={{
                         width: "100%",
                     }}
                 >
-                    <InputPassword sx={{ width: "100%" }} />
-                </Form.Item>
-                <Form.Item>
-                    <div
+                    <Grid item xs={3}>
+                        <Label required
+                            children={t("login:repeatPasswordLabel") + " :"}
+                        />
+                    </Grid>
+                    <Grid item xs={9}>
+                        <InputPassword
+                            {...register("repeatedPassword", {
+                                required: true,
+                                validate: (value) =>
+                                    value === senha
+                            })}
+                        />
+                        {errors.repeatedPassword && (
+                            <p
+                                style={{
+                                    fontSize: 14,
+                                    color: colors.error,
+                                    visibility: "visible",
+                                }}
+                            >
+                                {errors.repeatedPassword.type === "required"
+                                    ? t("common:requiredFieldError")
+                                    : t("profile:passwordMatchErrorMessage")}
+                            </p>
+                        )}
+                    </Grid>
+                </Grid>
+                <Grid item>
+                    <Grid item
                         style={{
                             justifyContent: "space-between",
                             display: "flex",
@@ -122,9 +161,9 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                         >
                             {t("login:submitButton")}
                         </Button>
-                    </div>
-                </Form.Item>
-            </Form>
+                    </Grid>
+                </Grid>
+            </form>
         </div>
     );
 };

--- a/src/components/Login/SignUpForm.tsx
+++ b/src/components/Login/SignUpForm.tsx
@@ -46,6 +46,7 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                     </Grid>
                     <Grid item xs={12} sm={9}>
                         <Input
+                            data-cy="nameInputCreateAccount"
                             {...register("nameDescription", {
                                 required: true
                             })}
@@ -62,6 +63,7 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                     </Grid>
                     <Grid item xs={12} sm={9}>
                         <Input
+                            data-cy="emailInputCreateAccount"
                             {...register("email", {
                                 required: true,
                                 pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
@@ -83,6 +85,7 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                     </Grid>
                     <Grid item xs={12} sm={9}>
                         <InputPassword
+                            data-cy="passwordInputCreateAccount"
                             {...register("password", {
                                 required: true
                             })}
@@ -99,6 +102,7 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                     </Grid>
                     <Grid item xs={12} sm={9}>
                         <InputPassword
+                            data-cy="repeatedPasswordInputCreateAccount"
                             {...register("repeatedPassword", {
                                 required: true,
                                 validate: (value) =>
@@ -119,7 +123,7 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                         loading={isLoading}
                         type={ButtonType.blue}
                         htmlType="submit"
-                        data-cy={"loginButton"}
+                        data-cy="loginButton"
                     >
                         {t("login:submitButton")}
                     </Button>

--- a/src/components/Login/SignUpForm.tsx
+++ b/src/components/Login/SignUpForm.tsx
@@ -38,8 +38,7 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
             />
             <h2>{t("login:signupFormHeader")}</h2>
             <form
-                onSubmit={handleSubmit(onFinish)}
-                onError={onFinishFailed}
+                onSubmit={handleSubmit(onFinish, onFinishFailed)}
             >
                 <Grid container>
                     <Grid item xs={3}>
@@ -136,7 +135,6 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                                 style={{
                                     fontSize: 14,
                                     color: colors.error,
-                                    visibility: "visible",
                                 }}
                             >
                                 {errors.repeatedPassword.type === "required"

--- a/src/components/Login/SignUpForm.tsx
+++ b/src/components/Login/SignUpForm.tsx
@@ -8,7 +8,7 @@ import InputPassword from "../InputPassword";
 import { Grid } from "@mui/material";
 import { useForm } from "react-hook-form";
 import Label from "../Label";
-import colors from "../../styles/colors";
+import TextError from "../TextErrorForm";
 
 const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
     const { t } = useTranslation();
@@ -37,92 +37,67 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                 }
             />
             <h2>{t("login:signupFormHeader")}</h2>
-            <form
-                onSubmit={handleSubmit(onFinish, onFinishFailed)}
-            >
+            <form onSubmit={handleSubmit(onFinish, onFinishFailed)}>
                 <Grid container>
-                    <Grid item xs={3}>
+                    <Grid item xs={12} sm={3}>
                         <Label required
                             children={t("login:nameLabel") + " :"}
                         />
                     </Grid>
-                    <Grid item xs={9}>
+                    <Grid item xs={12} sm={9}>
                         <Input
                             {...register("nameDescription", {
                                 required: true
                             })}
                         />
-                        <p
-                            style={{
-                                fontSize: 14,
-                                color: colors.error,
-                                visibility: errors.nameDescription ? "visible" : "hidden",
-                            }}>
-                            {t("login:nameErrorMessage")}
-                        </p>
+                        <TextError
+                            stateError={errors.nameDescription}
+                            children={t("login:nameErrorMessage")}
+                        />
                     </Grid>
-                </Grid>
-                <Grid container>
-                    <Grid item xs={3}>
+                    <Grid item xs={12} sm={3}>
                         <Label required
                             children={t("login:emailLabel") + " :"}
                         />
                     </Grid>
-                    <Grid item xs={9}>
+                    <Grid item xs={12} sm={9}>
                         <Input
                             {...register("email", {
                                 required: true,
                                 pattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
                             })}
                         />
-                        <p
-                            style={{
-                                fontSize: 14,
-                                color: colors.error,
-                                visibility: errors.email ? "visible" : "hidden",
-                            }}
-                        >
-                            {errors.email?.type === "pattern"
-                                ? t("login:invalidEmailErrorMessage")
-                                : t("login:emailErrorMessage")
+                        <TextError
+                            stateError={errors.email}
+                            children={
+                                errors.email?.type === "pattern"
+                                    ? t("login:invalidEmailErrorMessage")
+                                    : t("login:emailErrorMessage")
                             }
-                        </p>
+                        />
                     </Grid>
-                </Grid>
-                <Grid container>
-                    <Grid item xs={3}>
+                    <Grid item xs={12} sm={3}>
                         <Label required
                             children={t("login:passwordLabel") + " :"}
                         />
                     </Grid>
-                    <Grid item xs={9}>
+                    <Grid item xs={12} sm={9}>
                         <InputPassword
                             {...register("password", {
                                 required: true
                             })}
                         />
-                        <p
-                            style={{
-                                fontSize: 14,
-                                color: colors.error,
-                                visibility: errors.password ? "visible" : "hidden",
-                            }}
-                        >
-                            {t("login:passwordErrorMessage")}
-                        </p>
+                        <TextError
+                            stateError={errors.password}
+                            children={t("login:passwordErrorMessage")}
+                        />
                     </Grid>
-                </Grid>
-                <Grid container
-                    style={{
-                        width: "100%",
-                    }}
-                >
-                    <Grid item xs={3}>
+                    <Grid item xs={12} sm={3}>
                         <Label required
                             children={t("login:repeatPasswordLabel") + " :"}
                         />
                     </Grid>
-                    <Grid item xs={9}>
+                    <Grid item xs={12} sm={9}>
                         <InputPassword
                             {...register("repeatedPassword", {
                                 required: true,
@@ -130,36 +105,24 @@ const SignUpForm = ({ onFinish, onFinishFailed, isLoading }) => {
                                     value === senha
                             })}
                         />
-                        {errors.repeatedPassword && (
-                            <p
-                                style={{
-                                    fontSize: 14,
-                                    color: colors.error,
-                                }}
-                            >
-                                {errors.repeatedPassword.type === "required"
+                        <TextError
+                            stateError={errors.repeatedPassword}
+                            children={
+                                errors.repeatedPassword?.type === "required"
                                     ? t("common:requiredFieldError")
                                     : t("profile:passwordMatchErrorMessage")}
-                            </p>
-                        )}
+                        />
                     </Grid>
                 </Grid>
-                <Grid item>
-                    <Grid item
-                        style={{
-                            justifyContent: "space-between",
-                            display: "flex",
-                        }}
+                <Grid container>
+                    <Button
+                        loading={isLoading}
+                        type={ButtonType.blue}
+                        htmlType="submit"
+                        data-cy={"loginButton"}
                     >
-                        <Button
-                            loading={isLoading}
-                            type={ButtonType.blue}
-                            htmlType="submit"
-                            data-cy={"loginButton"}
-                        >
-                            {t("login:submitButton")}
-                        </Button>
-                    </Grid>
+                        {t("login:submitButton")}
+                    </Button>
                 </Grid>
             </form>
         </div>

--- a/src/components/Profile/OryProfileView.style.tsx
+++ b/src/components/Profile/OryProfileView.style.tsx
@@ -1,0 +1,23 @@
+import { Grid } from "@mui/material";
+import styled from "styled-components";
+
+const OryProfileGrid = styled(Grid)`
+    justify-content: center;
+    align-items: stretch;
+
+    .title{
+      font-size: 24px;
+      font-weight: 600;
+      font-family: initial;
+      margin-bottom: 12px;
+    }
+
+    .subtitle{
+      font-size: 20px;
+      font-weight: 600;
+      font-family: initial;
+      margin: 24px 0px 10px;
+    }
+`;
+
+export default OryProfileGrid;

--- a/src/components/Profile/OryProfileView.tsx
+++ b/src/components/Profile/OryProfileView.tsx
@@ -126,6 +126,7 @@ const OryProfileView = ({ user }) => {
                         </Grid>
                         <Grid item xs={12} sm={9} md={10} lg={10.5} xl={10.75}>
                             <InputPassword
+                                data-cy="newPasswordInput"
                                 {...register("newPassword", {
                                     required: true
                                 })}
@@ -140,6 +141,7 @@ const OryProfileView = ({ user }) => {
                         </Grid>
                         <Grid item xs={12} sm={7.5} md={8.75} lg={9.5} xl={10}>
                             <InputPassword
+                                data-cy="repeatedNewPasswordInput"
                                 {...register("repeatedNewPassword", {
                                     required: true,
                                     validate: (value) =>
@@ -160,6 +162,7 @@ const OryProfileView = ({ user }) => {
                         loading={isLoading}
                         type={ButtonType.blue}
                         htmlType="submit"
+                        data-cy="submitChangePasswordButton"
                     >
                         {t("login:submitButton")}
                     </Button>

--- a/src/components/Profile/OryProfileView.tsx
+++ b/src/components/Profile/OryProfileView.tsx
@@ -17,7 +17,8 @@ import Label from "../Label";
 import Loading from "../Loading";
 import { Totp } from "./Totp";
 import { useForm } from "react-hook-form";
-import colors from "../../styles/colors";
+import OryProfileGrid from "./OryProfileView.style";
+import TextError from "../TextErrorForm";
 
 const OryProfileView = ({ user }) => {
     const [flow, setFlow] = useState<SettingsFlowState>();
@@ -73,15 +74,9 @@ const OryProfileView = ({ user }) => {
     }
 
     return (
-        <Grid
-            container
-            justifyContent="center"
-            alignItems="stretch"
-            spacing={1}
-            my={2}
-        >
+        <OryProfileGrid container spacing={2} my={2}>
             <Grid item xs={7}>
-                <Typography variant="h3" fontSize={24} fontWeight={600} fontFamily="initial" marginBottom="12px">
+                <Typography variant="h3" className="title">
                     {t("profile:pageTitle")}
                 </Typography>
 
@@ -89,7 +84,7 @@ const OryProfileView = ({ user }) => {
                     {t("profile:loggedInAs")}: <Label>{user.email}</Label>
                 </Typography>
 
-                <Typography variant="h4" fontSize={20} fontWeight={600} fontFamily="initial" margin="24px 0px 10px">
+                <Typography variant="h4" className="subtitle">
                     {t("profile:badgesTitle")}
                 </Typography>
 
@@ -110,7 +105,7 @@ const OryProfileView = ({ user }) => {
                     </Typography>
                 )}
 
-                <Typography variant="h4" fontSize={20} fontWeight={600} fontFamily="initial" margin="24px 0px 10px">
+                <Typography variant="h4" className="subtitle">
                     {t("profile:changePasswordSectionTitle")}
                 </Typography>
 
@@ -121,33 +116,29 @@ const OryProfileView = ({ user }) => {
                         type="warning"
                     />
                 )}
-                <form onSubmit={handleSubmit(onFinish)} style={{ margin: "20px 0px" }}>
+                <form
+                    onSubmit={handleSubmit(onFinish)}
+                    style={{ margin: "20px 0px" }}
+                >
                     <Grid container>
-                        <Grid item xs={1.5}>
+                        <Grid item xs={12} sm={3} md={2} lg={1.5} xl={1.25}>
                             <Label required children={t("profile:newPasswordLabel") + ":"} />
                         </Grid>
-                        <Grid item xs={10.5}>
+                        <Grid item xs={12} sm={9} md={10} lg={10.5} xl={10.75}>
                             <InputPassword
                                 {...register("newPassword", {
                                     required: true
                                 })}
                             />
-                            <p
-                                style={{
-                                    fontSize: 14,
-                                    color: "red",
-                                    visibility: errors.newPassword ? "visible" : "hidden",
-                                }}
-                            >
-                                {t("common:requiredFieldError")}
-                            </p>
+                            <TextError
+                                stateError={errors.newPassword}
+                                children={t("common:requiredFieldError")}
+                            />
                         </Grid>
-                    </Grid>
-                    <Grid container>
-                        <Grid item xs={2}>
+                        <Grid item xs={12} sm={4.5} md={3.25} lg={2.5} xl={2}>
                             <Label required children={t("profile:repeatedNewPasswordLabel") + ":"} />
                         </Grid>
-                        <Grid item xs={10}>
+                        <Grid item xs={12} sm={7.5} md={8.75} lg={9.5} xl={10}>
                             <InputPassword
                                 {...register("repeatedNewPassword", {
                                     required: true,
@@ -155,18 +146,14 @@ const OryProfileView = ({ user }) => {
                                         value === senha
                                 })}
                             />
-                            {errors.repeatedNewPassword && (
-                                <p
-                                    style={{
-                                        fontSize: 14,
-                                        color: colors.error,
-                                    }}
-                                >
-                                    {errors.repeatedNewPassword.type === "required"
+                            <TextError
+                                stateError={errors.repeatedNewPassword}
+                                children={
+                                    errors.repeatedNewPassword?.type === "required"
                                         ? t("common:requiredFieldError")
-                                        : t("profile:passwordMatchErrorMessage")}
-                                </p>
-                            )}
+                                        : t("profile:passwordMatchErrorMessage")
+                                }
+                            />
                         </Grid>
                     </Grid>
                     <Button
@@ -179,7 +166,7 @@ const OryProfileView = ({ user }) => {
                 </form>
                 <Totp flow={flow} setFlow={setFlow} />
             </Grid>
-        </Grid>
+        </OryProfileGrid>
     );
 };
 

--- a/src/components/Profile/Totp.tsx
+++ b/src/components/Profile/Totp.tsx
@@ -26,7 +26,6 @@ export const Totp = ({ flow, setFlow }) => {
         register,
         handleSubmit,
         formState: { errors },
-        reset,
     } = useForm();
 
     let flowValues: ValuesType = {
@@ -64,8 +63,7 @@ export const Totp = ({ flow, setFlow }) => {
         } catch {
             setShowForm(false);
         }
-        reset();
-    }, [flow, reset]);
+    }, [flow]);
 
     const onSubmitLink = (values: ValuesType) => {
         orySubmitTotp({ router, flow, setFlow, t, values })
@@ -131,7 +129,7 @@ export const Totp = ({ flow, setFlow }) => {
                     onSubmit={handleSubmit(onFinish)}
                     style={{ marginBottom: "20px" }}
                 >
-                    <div style={{ marginBottom: "20px" }}>
+                    <Grid item xs={12} style={{ marginBottom: "20px" }}>
                         <p>
                             <Trans
                                 i18nKey={"profile:totpSectionDescription"}
@@ -184,15 +182,15 @@ export const Totp = ({ flow, setFlow }) => {
                         >
                             {textSource}
                         </code>
-                    </div>
-                    <div style={{ marginBottom: "20px" }}>
+                    </Grid>
+                    <Grid item style={{ marginBottom: "20px" }}>
                         <Label required>
                             {t("profile:totpInputTittle")}
                         </Label>
-                        <div>
+                        <Grid item xs={3}>
                             <InputPassword
                                 {...register("totp", {
-                                    required: t("claimReview:descriptionInputError"),
+                                    required: true
                                 })}
                             />
                             {errors.totp &&
@@ -205,8 +203,8 @@ export const Totp = ({ flow, setFlow }) => {
                                     {t("common:requiredFieldError")}
                                 </p>
                             }
-                        </div>
-                    </div>
+                        </Grid>
+                    </Grid>
                     <AletheiaButton
                         type={ButtonType.blue}
                         htmlType="submit"
@@ -214,42 +212,44 @@ export const Totp = ({ flow, setFlow }) => {
                     >
                         {t("login:submitButton")}
                     </AletheiaButton>
-                </form>
+                </form >
             )}
-            {!showForm && (
-                <form
-                    onSubmit={handleSubmit(onFinishUnlink)}
-                >
-                    <AletheiaButton
-                        loading={isLoading}
-                        htmlType="submit"
-                        style={{
-                            width: "100%",
-                            marginTop: "21px",
-                            marginBottom: "21px",
-                            display: "flex",
-                            justifyContent: "center",
-                            alignItems: "center",
-                            padding: "8px 15px",
-                            height: "max-content",
-                            whiteSpace: "normal",
-                        }}
-                        type={ButtonType.blue}
+            {
+                !showForm && (
+                    <form
+                        onSubmit={handleSubmit(onFinishUnlink)}
                     >
-                        <Typography
-                            variant="h4"
+                        <AletheiaButton
+                            loading={isLoading}
+                            htmlType="submit"
                             style={{
-                                fontSize: 14,
-                                color: colors.white,
-                                fontWeight: 400,
-                                margin: 0,
+                                width: "100%",
+                                marginTop: "21px",
+                                marginBottom: "21px",
+                                display: "flex",
+                                justifyContent: "center",
+                                alignItems: "center",
+                                padding: "8px 15px",
+                                height: "max-content",
+                                whiteSpace: "normal",
                             }}
+                            type={ButtonType.blue}
                         >
-                            {t("profile:totpUnLinkSubmit")}
-                        </Typography>
-                    </AletheiaButton>
-                </form>
-            )}
+                            <Typography
+                                variant="h4"
+                                style={{
+                                    fontSize: 14,
+                                    color: colors.white,
+                                    fontWeight: 400,
+                                    margin: 0,
+                                }}
+                            >
+                                {t("profile:totpUnLinkSubmit")}
+                            </Typography>
+                        </AletheiaButton>
+                    </form>
+                )
+            }
         </>
     );
 };

--- a/src/components/Profile/Totp.tsx
+++ b/src/components/Profile/Totp.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/router";
 import AletheiaButton, { ButtonType } from "../Button";
 import colors from "../../styles/colors";
 import userApi from "../../api/userApi";
+import TextError from "../TextErrorForm";
 
 export const Totp = ({ flow, setFlow }) => {
     const [imgSource, setImgSource] = useState("");
@@ -120,7 +121,7 @@ export const Totp = ({ flow, setFlow }) => {
     return (
         <>
             <Grid container>
-                <Typography variant="h4" fontSize={20} fontWeight={600}>
+                <Typography variant="h4" className="subtitle">
                     {t("profile:totpSectionTittle")}
                 </Typography>
             </Grid>
@@ -187,22 +188,16 @@ export const Totp = ({ flow, setFlow }) => {
                         <Label required>
                             {t("profile:totpInputTittle")}
                         </Label>
-                        <Grid item xs={3}>
+                        <Grid item xs={7} sm={5} md={4} lg={3}>
                             <InputPassword
                                 {...register("totp", {
                                     required: true
                                 })}
                             />
-                            {errors.totp &&
-                                <p
-                                    style={{
-                                        color: colors.error,
-                                        marginTop: 4
-                                    }}
-                                >
-                                    {t("common:requiredFieldError")}
-                                </p>
-                            }
+                            <TextError
+                                stateError={errors.totp}
+                                children={t("common:requiredFieldError")}
+                            />
                         </Grid>
                     </Grid>
                     <AletheiaButton
@@ -214,42 +209,40 @@ export const Totp = ({ flow, setFlow }) => {
                     </AletheiaButton>
                 </form >
             )}
-            {
-                !showForm && (
-                    <form
-                        onSubmit={handleSubmit(onFinishUnlink)}
+            {!showForm && (
+                <form
+                    onSubmit={handleSubmit(onFinishUnlink)}
+                >
+                    <AletheiaButton
+                        loading={isLoading}
+                        htmlType="submit"
+                        style={{
+                            width: "100%",
+                            marginTop: "21px",
+                            marginBottom: "21px",
+                            display: "flex",
+                            justifyContent: "center",
+                            alignItems: "center",
+                            padding: "8px 15px",
+                            height: "max-content",
+                            whiteSpace: "normal",
+                        }}
+                        type={ButtonType.blue}
                     >
-                        <AletheiaButton
-                            loading={isLoading}
-                            htmlType="submit"
+                        <Typography
+                            variant="h4"
                             style={{
-                                width: "100%",
-                                marginTop: "21px",
-                                marginBottom: "21px",
-                                display: "flex",
-                                justifyContent: "center",
-                                alignItems: "center",
-                                padding: "8px 15px",
-                                height: "max-content",
-                                whiteSpace: "normal",
+                                fontSize: 14,
+                                color: colors.white,
+                                fontWeight: 400,
+                                margin: 0,
                             }}
-                            type={ButtonType.blue}
                         >
-                            <Typography
-                                variant="h4"
-                                style={{
-                                    fontSize: 14,
-                                    color: colors.white,
-                                    fontWeight: 400,
-                                    margin: 0,
-                                }}
-                            >
-                                {t("profile:totpUnLinkSubmit")}
-                            </Typography>
-                        </AletheiaButton>
-                    </form>
-                )
-            }
+                            {t("profile:totpUnLinkSubmit")}
+                        </Typography>
+                    </AletheiaButton>
+                </form>
+            )}
         </>
     );
 };

--- a/src/components/TextErrorForm.tsx
+++ b/src/components/TextErrorForm.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import colors from "../styles/colors";
+
+const TextError = ({ children, stateError }) => {
+  return (
+    <p
+      style={{
+        fontSize: 14,
+        color: colors.error,
+        visibility: stateError ? "visible" : "hidden",
+        marginBottom: 4,
+      }}
+    >
+      {children}
+    </p>
+  );
+};
+
+export default TextError;


### PR DESCRIPTION
# Description
*In this PR, I migrated all Ant Design forms on the login, sign-up, and profile pages to React Hook Form. I also fixed some responsiveness issues. You can see more details in the attached Fluxes videos.*

Change password and login:
https://github.com/user-attachments/assets/006856f9-6a43-42d7-9afa-5dfb925060ef

Sign up before:
https://github.com/user-attachments/assets/6e0cb09e-5643-4982-81ff-1ce46085aac9
Sign up after:
https://github.com/user-attachments/assets/65d7dfce-6d36-487d-9e5f-aa37365fc142

Fixes #1689, Fixes #1761, Fixes #1762

# Testing
*To test it properly, you need to go through the following flows on the platform:*

1. **Login flow** – Access the login page, submit correct and incorrect credentials, and check all validation and error messages.
2. **Sign-up flow** – Register a new user, test with valid and invalid inputs, and verify all feedback and validations.
3. **Password update flow** – Log in, go to the profile page, change the password with valid and invalid values, and confirm the success and error messages.

*It's important to validate all text messages, error handling, and edge cases in each flow.*
