### PR TITLE
Fixing some style errors

### DIFF
--- a/src/components/Home/CTA/CTASection.style.tsx
+++ b/src/components/Home/CTA/CTASection.style.tsx
@@ -13,7 +13,7 @@ const CTASectionStyle = styled(Grid)`
         font-size: 16px;
         line-height: 20px;
         color: ${colors.white};
-        margin-bottom: 0;
+        margin: 0;
     }
 
     .CTA-button-container {

--- a/src/components/Home/HomeHeader/HomeHeader.style.tsx
+++ b/src/components/Home/HomeHeader/HomeHeader.style.tsx
@@ -10,7 +10,7 @@ const HomeHeaderStyle = styled(Grid)`
     padding: 64px 0;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 32px;
+    gap: 1px;
 
     .home-header-content {
         display: flex;

--- a/src/components/Home/Stats.tsx
+++ b/src/components/Home/Stats.tsx
@@ -19,7 +19,6 @@ export const Stats = ({ info, title, style = {} }) => {
                 style={{
                     color: colors.lightSecondary,
                     marginRight: vw?.sm ? "5px" : "20px",
-                    marginBottom: 0,
                     fontSize: vw?.sm ? "28px" : "40px",
                 }}
             >

--- a/src/components/Metrics/ReviewProgress.tsx
+++ b/src/components/Metrics/ReviewProgress.tsx
@@ -75,9 +75,6 @@ const ReviewProgress = ({ reviews, statsProps }) => {
                             style={{
                                 fontSize: statsProps.size === 30 ? "10px" : "14px",
                                 position: "absolute",
-                                top: "50%",
-                                left: "50%",
-                                transform: "translate(-50%, -50%)",
                             }}
                         >
                             {review.count}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -127,6 +127,11 @@ h4,
 h5,
 h6 {
     font-family: "Noticia Text", serif;
+    font-weight: 500;
+}
+
+a {
+    text-decoration: none;
 }
 
 


### PR DESCRIPTION
# Description
*After removing Ant Design, some titles and link texts were no longer using the default styles. In this PR, I fixed those style issues and also corrected other broken components.*

Before:  
https://github.com/user-attachments/assets/e6f71701-01fc-4d16-bfc2-35e8db18c35d
After:
https://github.com/user-attachments/assets/7f47ccaf-866e-493c-b6df-b8003b6e8422

Fixes #1919

# Testing
*To test it, check the following:*

1. **Home page** – Test the responsiveness and ensure that all styles follow the platform’s design standards.
2. **Personality page (metrics section)** – Confirm that styles and layout are consistent with the rest of the platform.
3. **Links during the checking process** – Verify that link texts are styled correctly and behave as expected.