### PR TITLE
Redirect about person

### DIFF
--- a/server/view/view.controller.ts
+++ b/server/view/view.controller.ts
@@ -5,6 +5,7 @@ import {
     Req,
     Header,
     Query,
+    Param,
 } from "@nestjs/common";
 import type { Request, Response } from "express";
 import { parse } from "url";
@@ -35,6 +36,21 @@ export class ViewController {
     public async showAboutPage(@Req() req: Request, @Res() res: Response) {
         const parsedUrl = parse(req.url, true);
         await this.viewService.render(req, res, "/about-page", parsedUrl.query);
+    }
+
+    @IsPublic()
+    @ApiTags("pages")
+    @Get("about/:person")
+    @Header("Cache-Control", "max-age=86400")
+    public async showPersonAboutPage(
+        @Param("person") person: string,
+        @Req() req: Request,
+        @Res() res: Response
+    ) {
+        // For now, redirect to the main about page
+        // In the future, this will render person-specific about pages
+        // The person parameter will be used to fetch specific person data
+        res.redirect(302, "/about");
     }
 
     @IsPublic()


### PR DESCRIPTION
# Description
Redirect any `/about/person-name` to `/about` while we don't have the pages ready.

# Type of change
- [ ] New feature (non-breaking change which adds functionality) 

# Testing
Try to access a link like `/about/mateus` see it being redirected to `/about`


# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas     
- [x] Repository documentation has been updated (Readme.md) with additional steps required for a local environment setup.
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY. The exception to this is for new (MVP/Prototype) functionality where the abstraction layer may not be clear (comments should be added to explain the violation of DRY in these scenarios).   
- [x] Documented with TSDoc all library and controller new functions

## Backend Changes
- [x] All endpoints are appropriately secured with Middleware authentication
- [x] All new endpoints have a interface schema defined

### Tests
- [x] All existing unit and end to end tests pass across all services     
- [x] Unit and end to end tests have been added to ensure backend APIs behave as expected

### Test IDs
- [x] Include the test ID when adding new tasks or components.
- [x] Check that test IDs are present in the modified components.
     

# Merge Request Review Checklist 
- [ ] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)     
- [ ] High risk and core workflows have been tested and verified in a local environment.     
- [ ] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in Project do Github issues if not being addressed.     
- [ ] Any dependent changes have been merged and published in downstream modules     
- [ ] Changes to multiple services can be deployed in parallel and independently. If not, changes should be broken out into separate merge requests and deployed in order.