### PR TITLE
Enhancement: Sort verification requests by newest first

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,8 @@
         "braces": "3.0.3",
         "ws": "8.17.1",
         "prosemirror-model": "1.9.1",
-        "glob": "^9.0.0"
+        "glob": "^9.0.0",
+        "tldjs": "2.3.1"
     },
     "packageManager": "yarn@3.6.3"
 }

--- a/src/api/verificationRequestApi.ts
+++ b/src/api/verificationRequestApi.ts
@@ -25,7 +25,7 @@ const createVerificationRequest = (
     return request
         .post("/", verificationRequest)
         .then((response) => {
-            MessageManager.showMessage("success", 
+            MessageManager.showMessage("success",
                 t("verificationRequest:verificationRequestCreateSuccess")
             );
             router.push(
@@ -47,7 +47,7 @@ const get = (options: SearchOptions, dispatch = null) => {
     const params = {
         contentFilters: options.filtersUsed || [],
         page: options.page ? options.page - 1 : 0,
-        order: options.order || "asc",
+        order: options.order || "desc",
         pageSize: options.pageSize ? options.pageSize : 10,
         topics: options.topics || [],
     };
@@ -113,7 +113,7 @@ const updateVerificationRequest = (id, params, t) => {
     return request
         .put(`/${id}`, params)
         .then((response) => {
-            MessageManager.showMessage("success", 
+            MessageManager.showMessage("success",
                 t("verificationRequest:addVerificationRequestSuccess")
             );
             return response.data;
@@ -128,7 +128,7 @@ const removeVerificationRequestFromGroup = (id, params, t) => {
     return request
         .put(`/${id}/group`, params)
         .then((response) => {
-            MessageManager.showMessage("success", 
+            MessageManager.showMessage("success",
                 t("verificationRequest:removeVerificationRequestSuccess")
             );
             return response.data;


### PR DESCRIPTION
# Description

Changed the `GET /verification-request` endpoint to update the default sorting behavior for verification requests.
By default, results are now returned in descending (`desc`) order — meaning the most recent ones appear first.

Fixes #1448 

# Type of change

* [x] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing

* Access the `/verification-request` route
* Verify that the returned data is sorted from the most recent to the oldest

# Developer Checklist

## General

* [x] Code is appropriately commented, particularly in hard-to-understand areas
* [ ] Repository documentation has been updated (Readme.md) with additional steps required for a local environment setup.
* [x] No `console.log` or related logging is added.
* [x] No code is repeated/duplicated in violation of DRY.
* [ ] Documented with TSDoc all library and controller new functions

## Frontend Changes

* [x] N/A (sem alterações no frontend)

## Backend Changes

* [x] All endpoints are appropriately secured with Middleware authentication
* [x] All new endpoints have a interface schema defined

### Tests

* [x] All existing unit and end to end tests pass across all services
* [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected

### Test IDs

* [x] N/A (sem alterações em componentes com test IDs)

# Merge Request Review Checklist

* [x] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)
* [x] High risk and core workflows have been tested and verified in a local environment
* [ ] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in Project do Github issues if not being addressed
* [x] Any dependent changes have been merged and published in downstream modules
* [x] Changes to multiple services can be deployed in parallel and independently