### PR TITLE
Enhancement: Replace MUI Joy components with MUI Material on the sentence page

### DIFF
--- a/src/components/topics/TopicForm.tsx
+++ b/src/components/topics/TopicForm.tsx
@@ -1,7 +1,6 @@
-import { Grid } from "@mui/material";
 import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Autocomplete, FormControl, CircularProgress, TextField } from '@mui/material';
+import { Autocomplete, FormControl, CircularProgress, TextField, Grid } from '@mui/material';
 import AletheiaButton from "../Button";
 import TopicInputErrorMessages from "./TopicInputErrorMessages";
 import { useTranslation } from "next-i18next";

--- a/src/components/topics/TopicForm.tsx
+++ b/src/components/topics/TopicForm.tsx
@@ -1,15 +1,12 @@
 import { Grid } from "@mui/material";
 import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import FormControl from "@mui/joy/FormControl";
-import Autocomplete from "@mui/joy/Autocomplete";
-import CircularProgress from "@mui/joy/CircularProgress";
+import { Autocomplete, FormControl, CircularProgress, TextField } from '@mui/material';
 import AletheiaButton from "../Button";
 import TopicInputErrorMessages from "./TopicInputErrorMessages";
 import { useTranslation } from "next-i18next";
 import TopicsApi from "../../api/topicsApi";
 import { ContentModelEnum } from "../../types/enums";
-import { CssVarsProvider } from "@mui/joy/styles";
 
 interface ITopicForm {
     contentModel: ContentModelEnum;
@@ -102,42 +99,50 @@ const TopicForm = ({
                         validate: validateDuplication,
                     }}
                     render={({ field: { onChange, value } }) => (
-                        <CssVarsProvider>
-                            <FormControl sx={{ width: "100%" }}>
-                                <Autocomplete
-                                    freeSolo
-                                    multiple
-                                    placeholder={t("topics:placeholder")}
-                                    options={options}
-                                    onInputChange={(_, inputValue) =>
-                                        fetchOptions(inputValue)
-                                    }
-                                    onChange={(_, selectedValues) => {
-                                        onChange(selectedValues);
-                                        setInputValue(selectedValues);
-                                    }}
-                                    getOptionLabel={(option) =>
-                                        option.label || ""
-                                    }
-                                    isOptionEqualToValue={(option, value) =>
-                                        option.value === value.value
-                                    }
-                                    loading={isLoading}
-                                    endDecorator={
-                                        isLoading ? (
-                                            <CircularProgress size="sm" />
-                                        ) : null
-                                    }
-                                />
-                            </FormControl>
-                        </CssVarsProvider>
+                        <FormControl sx={{ width: "100%" }}>
+                            <Autocomplete
+                                freeSolo
+                                multiple
+                                size="small"
+                                options={options}
+                                onInputChange={(_, inputValue) =>
+                                    fetchOptions(inputValue)
+                                }
+                                onChange={(_, selectedValues) => {
+                                    onChange(selectedValues);
+                                    setInputValue(selectedValues);
+                                }}
+                                getOptionLabel={(option) =>
+                                    option.label || ""
+                                }
+                                isOptionEqualToValue={(option, value) =>
+                                    option.value === value.value
+                                }
+                                loading={isLoading}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        placeholder={t("topics:placeholder")}
+                                        InputProps={{
+                                            ...params.InputProps,
+                                            endAdornment: (
+                                                <>
+                                                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                                                    {params.InputProps.endAdornment}
+                                                </>
+                                            ),
+                                        }}
+                                    />
+                                )}
+                            />
+                        </FormControl>
                     )}
                 />
                 <AletheiaButton
                     htmlType="submit"
                     loading={isLoading}
                     style={{
-                        height: 35,
+                        height: 40,
                         borderRadius: 4,
                         borderTopRightRadius: 4,
                         borderBottomRightRadius: 4,


### PR DESCRIPTION
# Description
Replaced the `Autocomplete`, `FormControl`, `CircularProgress`, and `TextField` components from **MUI Joy** with their equivalents from **MUI Material** in the Sentence page.  
This change improves design consistency across the application and aligns the UI with the Material Design guidelines used elsewhere in the project.

Fixes #1773

# Type of change
- [x] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing
1. Access the **Sentence** page.  
2. Verify that the replaced components render correctly using MUI Material styling.  
3. Test autocomplete behavior, form control layout, loading indicator, and text input.  
4. Check that all interactions (typing, selecting, submitting) still work as expected.  
5. Confirm that there are no visual regressions or layout issues.

# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas
- [x] Repository documentation has been updated (Readme.md) with additional steps required for a local environment setup.
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY.
- [x] Documented with TSDoc all library and controller new functions

## Frontend Changes
- [x] No new styling is added through CSS files (Unless it's a bugfix/hotfix)
- [x] All types are added correctly

## Backend Changes
- [ ] N/A (no backend changes)

### Tests
- [x] All existing unit and end to end tests pass across all services
- [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected (N/A for this change)

### Test IDs

* [x] N/A (sem alterações em componentes com test IDs)
