### PR TITLE
Fix Docker build timeout issues in CI/CD pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,19 @@ ENV NEW_RELIC_NO_CONFIG_FILE=true
 ENV NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
 ENV NEW_RELIC_LOG=stdout
 
+WORKDIR /app
+
+# Install build dependencies first for better caching
+RUN apk add --no-cache git python3 make g++
+
+# Copy package files first for better Docker layer caching
+COPY ./package.json /app/package.json
+COPY ./yarn.lock /app/yarn.lock
+
+# Install dependencies with optimized settings
+RUN yarn install --production --network-timeout 300000 --network-concurrency 1
+
+# Now copy the rest of the application
 COPY ./.babelrc /app/.babelrc
 COPY config.$ENVIRONMENT.yaml /app/config.yaml
 COPY config.websocket.$ENVIRONMENT.yaml /app/config.websocket.yaml
@@ -22,8 +35,6 @@ COPY ./.eslintignore /app/.eslintignore
 COPY ./.eslintrc.yml /app/.eslintrc.yml
 COPY server/jest.config.json /app/jest.config.json
 COPY ./next.config.js /app/next.config.js
-COPY ./package.json /app/package.json
-COPY ./yarn.lock /app/yarn.lock
 COPY ./scripts /app/scripts
 COPY ./tsconfig.json /app/tsconfig.json
 COPY ./server /app/server
@@ -33,11 +44,7 @@ COPY ./public /app/public
 COPY ./config /app/config
 COPY ./next-i18next.config.js /app/next-i18next.config.js
 
-WORKDIR /app
-
 RUN cp config/localConfig.example.ts config/localConfig.ts
-RUN apk add --no-cache git python3 make g++
-RUN yarn install --production
 RUN NEXT_PUBLIC_UMAMI_SITE_ID=$NEXT_PUBLIC_UMAMI_SITE_ID \
     NEXT_PUBLIC_RECAPTCHA_SITEKEY=$NEXT_PUBLIC_RECAPTCHA_SITEKEY \
     NEXT_PUBLIC_ENVIRONMENT=$NEXT_PUBLIC_ENVIRONMENT \


### PR DESCRIPTION
## Summary
- Optimize Dockerfile to prevent timeout issues during CI/CD builds
- Improve Docker layer caching for faster rebuilds
- Add network configuration to handle slow dependency downloads

## Changes
- Reorder Dockerfile steps to copy package files first (better caching)
- Add `--network-timeout 300000` to extend timeout to 5 minutes
- Add `--network-concurrency 1` to reduce parallel download issues
- Move build dependencies installation before application files

## Test plan
- [x] Docker build tested locally with optimizations
- [ ] CI/CD pipeline should complete without timeout errors
- [ ] Docker layer caching should reduce rebuild times
- [ ] Production deployments should work correctly

## Context
The CI/CD pipeline was failing with Docker build timeouts during `yarn install --production`. This was blocking PRs from passing tests. The optimizations should resolve the timeout issues and improve build performance.

🤖 Generated with [Claude Code](https://claude.ai/code)