### PR TITLE
Fix: Remove trailing paragraph from API response to prevent duplicate nodes

### DIFF
--- a/src/components/Collaborative/VisualEditorProvider.tsx
+++ b/src/components/Collaborative/VisualEditorProvider.tsx
@@ -13,6 +13,7 @@ import { RemirrorContentType } from "remirror";
 import { SourceType } from "../../types/Source";
 import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMachineProvider";
 import { EditorConfig } from "./utils/getEditorConfig";
+import { removeTrailingParagraph } from "./utils/removeTrailingParagraph";
 import {
     crossCheckingSelector,
     addCommentCrossCheckingSelector,
@@ -88,7 +89,7 @@ export const VisualEditorProvider = (props: VisualEditorProviderProps) => {
 
         if (reportModel) {
             fetchEditorContentObject(props.data_hash).then((content) => {
-                setEditorContentObject(content);
+                setEditorContentObject(removeTrailingParagraph(content));
                 setIsFetchingEditor(false);
             });
         }

--- a/src/components/Collaborative/utils/removeTrailingParagraph.ts
+++ b/src/components/Collaborative/utils/removeTrailingParagraph.ts
@@ -1,0 +1,21 @@
+import { RemirrorJSON } from "remirror";
+
+/**
+ * Removes the last paragraph from a Remirror document if it is of type "paragraph"
+ * @param doc - Remirror document in JSON format
+ * @returns Document without the last paragraph, if it exists
+ */
+export function removeTrailingParagraph(
+    doc: RemirrorJSON | null | undefined
+): RemirrorJSON | null | undefined {
+    if (!doc || !Array.isArray(doc.content)) return doc;
+
+    const items = [...doc.content];
+    const last = items[items.length - 1];
+
+    if (last?.type === "paragraph") {
+        items.pop();
+    }
+
+    return { ...doc, content: items };
+}


### PR DESCRIPTION
# Description

This PR fixes an issue where new nodes (e.g., questions) could not be added to the editor due to duplicate trailing paragraphs in the document structure.

The problem occurred because the API was returning editor content with a trailing `<p>` element. When this content was loaded into the editor, it combined with the `TrailingNodeExtension` (fixed in the previous PR #2160), creating duplicate trailing paragraphs in the HTML structure:

```html
<p><p><br class="ProseMirror-trailingBreak"></p><br class="ProseMirror-trailingBreak"></p>
```

This nested structure prevented Remirror from correctly inserting new nodes into the editor, as the editor could not properly identify where to anchor new components.

The implemented solution extracts the `removeTrailingParagraph` utility function that filters out trailing paragraphs from API responses before inserting content into the editor. This ensures:
- Only one trailing paragraph exists (managed by `TrailingNodeExtension`)
- New nodes can be properly inserted at the correct position
- Existing reports with trailing paragraphs are not affected (backward compatible)
- The function is reusable and follows the project's utility organization pattern

This fix complements the previous TrailingNodeExtension instance reuse issue resolution.

Related to #1816

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing

To validate this fix:

1. Go to the Claim page.
2. Click on any sentence to open the drawer.
3. Locate the "Which questions should the verification answer?" field.
4. Try to add a new question node using the question icon.
5. Verify that the new question node is properly inserted at the end of the document.
6. Verify that no duplicate trailing paragraphs are created in the HTML structure.
7. Test with existing reports that already have trailing paragraphs to ensure backward compatibility.
8. Repeat the add/remove cycle multiple times to ensure consistent behavior.

Impacted scenarios:

* Insertion of new question nodes in the editor
* Loading editor content from API responses
* Interaction between API content and TrailingNodeExtension
* Backward compatibility with existing reports

No special build is required beyond the standard environment.

# Developer Checklist

## General

- [x] Code is appropriately commented, particularly in hard-to-understand areas
- [x] Repository documentation does not require changes for environment setup
- [x] No `console.log` or related logging is added
- [x] No duplicated code added
- [x] Relevant new functions documented with TSDoc

## Frontend Changes

- [x] No new styling added through CSS files
- [x] All types are added correctly

## Backend Changes

- [ ] All endpoints are appropriately secured with Middleware authentication
- [ ] All new endpoints have an interface schema defined

### Tests

- [ ] All existing unit and E2E tests pass
- [ ] Additional tests added where necessary

### Test IDs

- [x] Test IDs verified in modified components

# Merge Request Review Checklist

- [x] An issue is linked to this PR and the changes satisfy its requirements
- [x] High-risk and core workflows have been tested locally
- [x] Potential improvements to performance, stability, or readability have been considered
- [x] No dependent changes pending in downstream modules
- [x] Changes are deployable independently

