### PR TITLE
feat: add reCAPTCHA captcha bridge for Hermes extension

### DIFF
--- a/server/captcha/captcha.controller.ts
+++ b/server/captcha/captcha.controller.ts
@@ -1,4 +1,20 @@
-<!DOCTYPE html>
+import { Controller, Get, Header, Res } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Public } from "../auth/decorators/auth.decorator";
+import type { Response } from "express";
+
+@Controller()
+export class CaptchaController {
+    constructor(private configService: ConfigService) {}
+
+    @Public()
+    @Get("api/captcha-bridge")
+    @Header("Content-Type", "text/html")
+    @Header("Cache-Control", "max-age=86400")
+    getCaptchaBridge(@Res() res: Response) {
+        const sitekey = this.configService.get<string>("recaptcha_sitekey");
+
+        res.send(`<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -21,7 +37,7 @@
 <body>
   <div class="captcha-wrapper">
     <div class="g-recaptcha"
-         data-sitekey="6Lc2BtYUAAAAAOUBI-9r1sDJUIfG2nt6C43noOXh"
+         data-sitekey="${sitekey}"
          data-callback="onCaptchaSuccess"
          data-expired-callback="onCaptchaExpired"
          data-error-callback="onCaptchaError">
@@ -30,7 +46,6 @@
 
   <script>
     function postToParent(payload) {
-      // Post to any origin — the extension validates on its end
       window.parent.postMessage(payload, '*');
     }
 
@@ -47,4 +62,6 @@
     }
   </script>
 </body>
-</html>
+</html>`);
+    }
+}

--- a/server/captcha/captcha.module.ts
+++ b/server/captcha/captcha.module.ts
@@ -1,11 +1,13 @@
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { CaptchaController } from "./captcha.controller";
 import { CaptchaService } from "./captcha.service";
 
 @Module({
     imports: [HttpModule, ConfigModule],
     exports: [CaptchaService],
     providers: [CaptchaService],
+    controllers: [CaptchaController],
 })
 export class CaptchaModule {}


### PR DESCRIPTION
## Summary
- Adds a NestJS controller endpoint at `/api/captcha-bridge` that serves a reCAPTCHA v2 checkbox widget
- The sitekey is injected from `ConfigService.get("recaptcha_sitekey")` — no hardcoded keys, stays in the PKL config pipeline
- The Hermes browser extension embeds this page in an iframe to work around Manifest V3 restrictions on remote scripts

## Details
- `CaptchaController` registered in the existing `CaptchaModule` (which already imports `ConfigModule`)
- `@Public()` decorator — no auth required (iframe cannot pass session cookies)
- `Cache-Control: max-age=86400` — sitekey rarely changes, 24h cache
- Follows the same pattern as `RootController.robots()` for serving raw non-Next.js responses
- Removes the static `public/captcha-bridge.html` that had a hardcoded sitekey

## Hermes extension coordination
The Hermes `captcha-frame.ts` component URL needs updating from `/captcha-bridge.html` to `/api/captcha-bridge` (done in the Hermes repo).

## Test plan
- [ ] After deploy, verify `/api/captcha-bridge` returns HTML with the correct sitekey from config
- [ ] Confirm the reCAPTCHA widget renders at that endpoint
- [ ] Test from the Hermes extension side panel — completing the captcha should post the token back

🤖 Generated with [Claude Code](https://claude.com/claude-code)