### PR TITLE
Release/v1.3.3

### DIFF
--- a/src/machines/reviewTask/actions.cy.ts
+++ b/src/machines/reviewTask/actions.cy.ts
@@ -1,0 +1,124 @@
+import { ReviewSourceInput, ReviewSource } from "../../types/Review";
+import { mergeSources } from "./actions";
+
+describe("Unit Test: mergeSources", () => {
+
+    it("should merge two sources correctly using the ID", () => {
+        const base: ReviewSourceInput[] = [
+            { id: "source-1", href: "old-link", field: "summary" }
+        ];
+        const schema: ReviewSourceInput[] = [
+            { id: "source-1", href: "new-link", props: { textRange: [1, 15] } }
+        ];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(1);
+        expect(result[0]).to.deep.equal({
+            id: "source-1",
+            href: "new-link",
+            field: "summary",
+            props: { textRange: [1, 15] }
+        });
+    });
+
+    it("should normalize strings by transforming them into objects with an href property", () => {
+        const base: ReviewSourceInput[] = ["https://google.com"];
+        const schema: ReviewSourceInput[] = [
+            { href: "https://google.com" }
+        ];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(1);
+        expect(result[0]).to.deep.equal({
+            href: "https://google.com"
+        });
+    });
+
+    it("should return an empty array if empty or undefined arrays are provided", () => {
+        expect(mergeSources()).to.deep.equal([]);
+        expect(mergeSources([], [])).to.deep.equal([]);
+    });
+
+    it("should safely ignore null or undefined values within arrays without throwing errors", () => {
+        const base = [null, { id: "1", href: "link1" }, undefined] as unknown as ReviewSourceInput[];
+        const schema = [{ id: "1", field: "process" }, null] as unknown as ReviewSourceInput[];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(1);
+        expect(result[0]).to.deep.equal({
+            id: "1",
+            href: "link1",
+            field: "process"
+        });
+    });
+
+    it("should merge using the composite key (href + field + targetText) when there is no ID", () => {
+        const base: ReviewSourceInput[] = [{
+            href: "https://link.com",
+            field: "question1",
+            props: { targetText: "text" }
+        }];
+        const schema: ReviewSourceInput[] = [{
+            href: "https://link.com",
+            field: "question1",
+            props: { targetText: "text", textRange: "5-10" }
+        }];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(1);
+        expect(result[0].props).to.deep.equal({
+            targetText: "text",
+            textRange: "5-10"
+        });
+    });
+
+    it("should NOT merge if the composite key is different (distinct fields)", () => {
+        const base: ReviewSourceInput[] = [
+            { href: "https://link.com", field: "question1" }
+        ];
+        const schema: ReviewSourceInput[] = [
+            { href: "https://link.com", field: "question2" }
+        ];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(2);
+        expect(result[0].field).to.equal("question1");
+        expect(result[1].field).to.equal("question2");
+    });
+
+    it("should add new sources from the schema that did not previously exist in the base", () => {
+        const base: ReviewSourceInput[] = [
+            { id: "source-A", href: "link-A" }
+        ];
+        const schema: ReviewSourceInput[] = [
+            { id: "source-B", href: "link-B" }
+        ];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(2);
+        const ids = result.map(r => (r as ReviewSource).id);
+        expect(ids).to.include("source-A");
+        expect(ids).to.include("source-B");
+    });
+
+    it("should prioritize schema properties while keeping exclusive base properties", () => {
+        const base: ReviewSourceInput[] = [
+            { id: "123", href: "base-link", field: "summary" }
+        ];
+        const schema: ReviewSourceInput[] = [
+            { id: "123", href: "schema-link" }
+        ];
+
+        const result = mergeSources(base, schema);
+
+        expect(result).to.have.length(1);
+        expect((result[0] as ReviewSource).href).to.equal("schema-link");
+        expect((result[0] as ReviewSource).field).to.equal("summary");
+    });
+});

--- a/src/machines/reviewTask/actions.ts
+++ b/src/machines/reviewTask/actions.ts
@@ -3,6 +3,56 @@ import { ReviewTaskMachineContextType } from "./context";
 import { SaveEvent } from "./events";
 import { EditorParser } from "../../../lib/editor-parser";
 import { ReviewTaskEvents } from "./enums";
+import { ReviewSource, ReviewSourceInput } from "../../types/Review";
+
+const normalizeSource = (source: ReviewSourceInput): ReviewSource => {
+    if (typeof source === "string") {
+        return { href: source };
+    }
+    return source || {};
+};
+
+const getSourceKey = (source: ReviewSourceInput) => {
+    const normalized = normalizeSource(source);
+    const id = normalized?.props?.id || normalized?.id;
+    if (id) {
+        return `id:${id}`;
+    }
+    const href = normalized?.href || "";
+    const field = normalized?.props?.field || normalized?.field || "";
+    const targetText =
+        normalized?.props?.targetText ||
+        normalized?.props?.textRange ||
+        "";
+    return `href:${href}|field:${field}|target:${targetText}`;
+};
+
+const mergeSources = (
+    baseSources: ReviewSourceInput[] = [],
+    schemaSources: ReviewSourceInput[] = []
+) => {
+    const merged = new Map<string, ReviewSource>();
+
+    baseSources.forEach((source) => {
+        if (!source) return;
+        const normalized = normalizeSource(source);
+        merged.set(getSourceKey(normalized), normalized);
+    });
+
+    schemaSources.forEach((source) => {
+        if (!source) return;
+        const normalized = normalizeSource(source);
+        const key = getSourceKey(normalized);
+        if (!key) return;
+        if (merged.has(key)) {
+            merged.set(key, { ...merged.get(key), ...normalized });
+        } else {
+            merged.set(key, normalized);
+        }
+    });
+
+    return Array.from(merged.values());
+};
 
 const saveContext = assign<ReviewTaskMachineContextType, SaveEvent>(
     (context, event) => {
@@ -76,9 +126,16 @@ const saveContext = assign<ReviewTaskMachineContextType, SaveEvent>(
             }
 
             const reviewDataHtml = editorParser.schema2html(schema);
+
+            const mergedSources =
+                "sources" in schema
+                    ? mergeSources(event.reviewData?.sources, schema.sources)
+                    : event.reviewData?.sources;
+
             event.reviewData = {
                 ...event.reviewData,
                 ...schema,
+                ...(mergedSources ? { sources: mergedSources } : {}),
                 visualEditor: cleanedVisualEditor,
                 reviewDataHtml,
             };

--- a/src/machines/reviewTask/actions.ts
+++ b/src/machines/reviewTask/actions.ts
@@ -27,7 +27,7 @@ const getSourceKey = (source: ReviewSourceInput) => {
     return `href:${href}|field:${field}|target:${targetText}`;
 };
 
-const mergeSources = (
+export const mergeSources = (
     baseSources: ReviewSourceInput[] = [],
     schemaSources: ReviewSourceInput[] = []
 ) => {

--- a/src/types/Review.ts
+++ b/src/types/Review.ts
@@ -3,3 +3,19 @@ export interface Review {
     usersId: string;
     isPartialReview: boolean;
 }
+
+export interface SourceProps {
+    id?: string;
+    field?: string | null;
+    targetText?: string | null;
+    textRange?: number[] | string | null;
+};
+
+export interface ReviewSource {
+    id?: string;
+    href?: string;
+    props?: SourceProps;
+    field?: string | null;
+};
+
+export type ReviewSourceInput = ReviewSource | string;


### PR DESCRIPTION
### Description
This hotfix addresses a bug in the Review Task flow where sources added via the editor button were being lost upon saving a draft or report.

**The Issue:**
The `editor2schema` function was only reconstructing sources explicitly present in the editor content. When `saveContext` was triggered, it would overwrite `event.reviewData.sources` with this partial result, dropping any sources that weren't actively mapped in the text.

**The Fix:**
Implemented a robust `mergeSources` utility to combine existing sources from `event.reviewData` with those recalculated by the schema. 

* **ID & Composite Key Matching:** Merges based on `id` or a composite key (`href` + `field` + `targetText`).
* **Data Integrity:** Preserves legacy properties (like `field`) while updating dynamic ones (like `textRange` or `href`).
* **Normalization:** Handles both string-based and object-based source inputs.

---

### 🧪 Testing & Quality

#### Unit Tests (Cypress)
A new test suite for `mergeSources` has been added to cover critical edge cases:
- [x] **Correct Merging:** Confirms data is merged correctly via ID.
- [x] **String Normalization:** Ensures string URLs are converted to valid objects.
- [x] **Composite Key Logic:** Validates merging when IDs are absent using `href`, `field`, and `targetText`.
- [x] **Conflict Handling:** Ensures distinct sources (different fields) are not accidentally merged.
- [x] **Resilience:** Safely handles `null`, `undefined`, or empty arrays without throwing errors.
- [x] **Property Prioritization:** Ensures schema updates take precedence while keeping exclusive base properties.

#### Manual Verification
1. Open a Review Task with existing sources.
2. Add a new source via the editor button.
3. Save draft (`SAVE_DRAFT`).
4. **Result:** Verified that both old and new sources remain intact in the payload and UI.

---

### 🛠 Key Changes
- **Logic:** Added `mergeSources` helper in `actions.ts` to handle reconciliation.
- **Stability:** Fixed payload overwriting in the save flow.
- **Tests:** Created comprehensive unit tests in Cypress for the new utility.

---

### Developer Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] No `console.log` or related logging is added.
- [x] All types are added correctly.
- [x] Unit tests have been added to ensure logic behaves as expected.

**Related Ticket:** #2377