### PR TITLE
fix: adding view only guard after finish report state

### DIFF
--- a/cypress/e2e/tests/event.cy.ts
+++ b/cypress/e2e/tests/event.cy.ts
@@ -130,7 +130,7 @@ describe("Test events infrastructure", () => {
             cy.get("[data-cy=frase1]").click();
             cy.get(locators.claim.BTN_SEE_FULL_REVIEW).should("exist");
 
-            cy.get(".remirror-editor").should("be.visible").and("have.attr", "contenteditable", "true");
+            cy.get(".remirror-editor").should("be.visible");
             cy.get("[data-testid='report - loading - spinner']").should("not.exist");
 
             addTopicFlow(topic.aliases[0], topic.name);

--- a/cypress/e2e/tests/event.cy.ts
+++ b/cypress/e2e/tests/event.cy.ts
@@ -130,7 +130,7 @@ describe("Test events infrastructure", () => {
             cy.get("[data-cy=frase1]").click();
             cy.get(locators.claim.BTN_SEE_FULL_REVIEW).should("exist");
 
-            cy.get(".remirror-editor").should("be.visible");
+            cy.get(".remirror-editor").should("exist");
             cy.get("[data-testid='report - loading - spinner']").should("not.exist");
 
             addTopicFlow(topic.aliases[0], topic.name);

--- a/server/review-task/permissions.spec.ts
+++ b/server/review-task/permissions.spec.ts
@@ -171,13 +171,16 @@ describe("resolvePermissions", () => {
     });
 
     describe("reported state", () => {
-        it("should allow assignee to edit", () => {
+        it("should not allow assignee to edit after finishing report", () => {
             const result = resolvePermissions(
                 buildInput({ state: ReviewTaskStates.reported })
             );
 
-            expect(result.canEditEditor).toBe(true);
-            expect(result.canSaveDraft).toBe(true);
+            expect(result.canEditEditor).toBe(false);
+            expect(result.canSaveDraft).toBe(false);
+            expect(result.editorReadonly).toBe(true);
+            expect(result.formType).toBe("selection");
+            expect(result.canSubmitActions.length).toBeGreaterThan(0);
         });
 
         it("should give non-assignee readonly view", () => {

--- a/src/machines/reviewTask/permissions.ts
+++ b/src/machines/reviewTask/permissions.ts
@@ -252,14 +252,14 @@ function resolveReportedPermissions(
         return {
             canAccessState: true,
             canViewEditor: true,
-            canEditEditor: true,
-            canSaveDraft: true,
+            canEditEditor: false,
+            canSaveDraft: false,
             canSubmitActions: availableEvents,
             canSelectUsers: false,
-            editorReadonly: false,
+            editorReadonly: true,
             showForm: true,
-            showSaveDraftButton: true,
-            formType: "editor",
+            showSaveDraftButton: false,
+            formType: "selection",
         };
     }
 
@@ -449,6 +449,7 @@ function applyAdminOverride(
     // But respect some restrictions (e.g., not editing during selection)
     const restrictedEditStates = [
         ReviewTaskStates.unassigned,
+        ReviewTaskStates.reported,
         ReviewTaskStates.selectReviewer,
         ReviewTaskStates.selectCrossChecker,
         ReviewTaskStates.published,


### PR DESCRIPTION
# Description
This PR resolves an inconsistency where users could still edit report fields during the **"Add Crosschecker"** and **"Reviewer"** stages, despite the absence of a "Save" or "Draft" option. 

By including these stages in the `viewOnlyMode` trigger, we prevent data loss and clarify to the user that the report content is finalized at this point in the workflow.

**Related Ticket:** #2384

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

### Scenario: View-Only Validation
1. Navigate to a report assigned to you.
2. Advance through the workflow until you reach the **"Add Crosschecker"** or **"Add Reviewers"** step.
3. **Expected Result:** All report fields should be disabled (read-only). The user should not be able to modify text or selections, as these stages are dedicated solely to assigning participants.

### Impacted Areas
* Report Detail View
* Workflow Transition Logic (specifically the transition from editing to participant assignment)

# Developer Checklist
## General
- [ ] Code is appropriately commented, particularly in hard-to-understand areas     
- [ ] Repository documentation has been updated (Readme.md) with additional steps required for a local environment setup.
- [ ] No `console.log` or related logging is added.
- [ ] No code is repeated/duplicated in violation of DRY. The exception to this is for new (MVP/Prototype) functionality where the abstraction layer may not be clear (comments should be added to explain the violation of DRY in these scenarios).   
- [ ] Documented with TSDoc all library and controller new functions

## Frontend Changes
- [ ] No new styling is added through CSS files (Unless it's a bugfix/hotfix)
- [ ] All types are added correctly

## Backend Changes
- [ ] All endpoints are appropriately secured with Middleware authentication
- [ ] All new endpoints have a interface schema defined

### Tests
- [ ] All existing unit and end to end tests pass across all services     
- [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected

### Test IDs
- [ ] Include the test ID when adding new tasks or components.
- [ ] Check that test IDs are present in the modified components.
     

# Merge Request Review Checklist 
- [ ] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)     
- [ ] High risk and core workflows have been tested and verified in a local environment.     
- [ ] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in Project do Github issues if not being addressed.     
- [ ] Any dependent changes have been merged and published in downstream modules     
- [ ] Changes to multiple services can be deployed in parallel and independently. If not, changes should be broken out into separate merge requests and deployed in order.