### PR TITLE
Fix: Prevent multiple URLs in floating link input

### DIFF
--- a/src/utils/ValidateFloatingLink.ts
+++ b/src/utils/ValidateFloatingLink.ts
@@ -1,13 +1,16 @@
 export const URL_PATTERN =
-    /^(?!.*\.$)(ftp|http|https):\/\/[^ "]+\.[a-zA-Z]{2,}(\/|\?|#|$)/i;
+    /^(?!.*https?:\/\/.*https?:\/\/)(?!.*\.$)(ftp|http|https):\/\/[^ "]+\.[a-zA-Z]{2,}(\/|\?|#|$)/i;
 
 /**
  * Validates if a string follows a proper URL format for external links.
  */
-export const validateFloatingLink = (href?: string, t?: (key: string) => string) => {
+export const validateFloatingLink = (
+    href?: string,
+    t?: (key: string) => string
+) => {
     if (!href) return;
 
-    if (href?.endsWith('.')) {
+    if (href?.endsWith(".")) {
         throw new Error(t("sourceForm:errorMessageTrailingDot"));
     }
 
@@ -28,7 +31,11 @@ export const sanitizeUrl = (url: string | undefined): string => {
     try {
         const parsed = new URL(trimmedUrl);
         const protocol = parsed.protocol.toLowerCase();
-        if (protocol === "http:" || protocol === "https:" || protocol === "blob:") {
+        if (
+            protocol === "http:" ||
+            protocol === "https:" ||
+            protocol === "blob:"
+        ) {
             return parsed.toString();
         }
 


### PR DESCRIPTION
# Description
*Previously, the floating link input allowed multiple URLs to be inserted, including edge cases such as concatenated URLs (e.g., https://google.comhttps://g1.com). This could lead to invalid links being stored and applied in the editor.*

Related Ticket #2371 

# Type of change
- [X] Bug fix (non-breaking change which fixes an issue)       

# Testing
Steps:
1. Access the Review Claim form from the fact-checking section.
2. Check for the "source" field to appear.
3. Copy Two different links (e.g., https://google.com/ and https://g1.com/) together.
4. Paste both links into the input field (with or without a space between them).
5. An error message should appear asking you to enter a valid link.

<img width="480" height="225" alt="image" src="https://github.com/user-attachments/assets/744a03fd-220c-43d9-a304-d882f448c72a" />


# Developer Checklist
## General
- [X] No `console.log` or related logging is added.
- [X] No code is repeated/duplicated in violation of DRY. The exception to this is for new (MVP/Prototype) functionality where the abstraction layer may not be clear (comments should be added to explain the violation of DRY in these scenarios).   

### Tests
- [ ] All existing unit and end to end tests pass across all services     
- [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected

### Test IDs
- [ ] Include the test ID when adding new tasks or components.
- [ ] Check that test IDs are present in the modified components.
     

# Merge Request Review Checklist 
- [ ] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)     
- [ ] High risk and core workflows have been tested and verified in a local environment.     
- [ ] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in Project do Github issues if not being addressed.     
- [ ] Any dependent changes have been merged and published in downstream modules     
- [ ] Changes to multiple services can be deployed in parallel and independently. If not, changes should be broken out into separate merge requests and deployed in order.