### PR TITLE
refactor: tighten port, export DI token, enforce build-time conformance for swappable persistence

### DIFF
--- a/server/claim/claim.controller.spec.ts
+++ b/server/claim/claim.controller.spec.ts
@@ -22,6 +22,7 @@ import { FeatureFlagService } from "../feature-flag/feature-flag.service";
 import { GroupService } from "../group/group.service";
 import { AbilitiesGuard } from "../auth/ability/abilities.guard";
 import { GetByDataHashDto } from "./dto/get-by-datahash.dto";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 
 describe("ClaimController (Unit)", () => {
     let controller: ClaimController;
@@ -40,7 +41,7 @@ describe("ClaimController (Unit)", () => {
             providers: [
                 { provide: ClaimReviewService, useValue: {} },
                 { provide: ReviewTaskService, useValue: {} },
-                { provide: "PersonalityService", useValue: personalityService },
+                { provide: PERSONALITY_SERVICE, useValue: personalityService },
                 { provide: ClaimService, useValue: claimService },
                 { provide: SentenceService, useValue: {} },
                 { provide: ConfigService, useValue: {} },
@@ -124,10 +125,9 @@ describe("ClaimController (Unit)", () => {
             },
         } as any);
 
-        vi.spyOn(
-            controller as any,
-            "returnClaimReviewPage"
-        ).mockResolvedValue(undefined);
+        vi.spyOn(controller as any, "returnClaimReviewPage").mockResolvedValue(
+            undefined
+        );
 
         await expect(
             controller.getImageClaimReviewPage(req, res)

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -57,23 +57,23 @@ import { UpdateHiddenStatusDTO } from "./dto/update-hidden-status.dto";
 export class ClaimController {
     private readonly logger = new Logger("ClaimController");
     constructor(
-        private claimReviewService: ClaimReviewService,
-        private reviewTaskService: ReviewTaskService,
+        private readonly claimReviewService: ClaimReviewService,
+        private readonly reviewTaskService: ReviewTaskService,
         @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
-        private claimService: ClaimService,
-        private sentenceService: SentenceService,
-        private configService: ConfigService,
-        private viewService: ViewService,
-        private captchaService: CaptchaService,
-        private imageService: ImageService,
-        private debateService: DebateService,
-        private editorService: EditorService,
-        private parserService: ParserService,
-        private historyService: HistoryService,
-        private claimRevisionService: ClaimRevisionService,
-        private featureFlagService: FeatureFlagService,
-        private groupService: GroupService
+        private readonly claimService: ClaimService,
+        private readonly sentenceService: SentenceService,
+        private readonly configService: ConfigService,
+        private readonly viewService: ViewService,
+        private readonly captchaService: CaptchaService,
+        private readonly imageService: ImageService,
+        private readonly debateService: DebateService,
+        private readonly editorService: EditorService,
+        private readonly parserService: ParserService,
+        private readonly historyService: HistoryService,
+        private readonly claimRevisionService: ClaimRevisionService,
+        private readonly featureFlagService: FeatureFlagService,
+        private readonly groupService: GroupService
     ) {}
 
     _verifyInputsQuery(query: GetClaimsDTO) {

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -36,6 +36,7 @@ import { ImageService } from "./types/image/image.service";
 import { ImageDocument } from "./types/image/schemas/image.schema";
 import { CreateDebateClaimDTO } from "./dto/create-debate-claim.dto";
 import { Public, AdminOnly } from "../auth/decorators/auth.decorator";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 import { DebateService } from "./types/debate/debate.service";
 import { EditorService } from "../editor/editor.service";
@@ -58,7 +59,7 @@ export class ClaimController {
     constructor(
         private claimReviewService: ClaimReviewService,
         private reviewTaskService: ReviewTaskService,
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private claimService: ClaimService,
         private sentenceService: SentenceService,
@@ -134,8 +135,8 @@ export class ClaimController {
             claim.personalities[0]
         );
         const path = claim.slug
-            ? `/personality/${personality.slug}/claim/${claim.slug}`
-            : `/personality/${personality.slug}`;
+            ? `/personality/${personality?.slug}/claim/${claim.slug}`
+            : `/personality/${personality?.slug}`;
         return {
             _id: claim._id,
             title: claim.title,

--- a/server/home/home.controller.ts
+++ b/server/home/home.controller.ts
@@ -18,6 +18,7 @@ import { ClaimRevisionService } from "../claim/claim-revision/claim-revision.ser
 import { ApiTags } from "@nestjs/swagger";
 import { ClaimReviewService } from "../claim-review/claim-review.service";
 import { NameSpaceEnum } from "../auth/name-space/schemas/name-space.schema";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 import { EventsService } from "../events/event.service";
 import { EventsStatus } from "../types/enums";
@@ -28,7 +29,7 @@ import { FeatureFlagService } from "../feature-flag/feature-flag.service";
 export class HomeController {
     constructor(
         private viewService: ViewService,
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private statsService: StatsService,
         private debateService: DebateService,
@@ -101,7 +102,7 @@ export class HomeController {
                     debateRevision.personalities.map((personality) => {
                         if (personality) {
                             return this.personalityService.getById(
-                                personality,
+                                String(personality),
                                 {
                                     language: req.language,
                                     nameSpace:

--- a/server/home/home.controller.ts
+++ b/server/home/home.controller.ts
@@ -28,15 +28,15 @@ import { FeatureFlagService } from "../feature-flag/feature-flag.service";
 @Controller("/")
 export class HomeController {
     constructor(
-        private viewService: ViewService,
+        private readonly viewService: ViewService,
         @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
-        private statsService: StatsService,
-        private debateService: DebateService,
-        private claimRevisionService: ClaimRevisionService,
-        private claimReviewService: ClaimReviewService,
+        private readonly statsService: StatsService,
+        private readonly debateService: DebateService,
+        private readonly claimRevisionService: ClaimRevisionService,
+        private readonly claimReviewService: ClaimReviewService,
         private readonly eventsService: EventsService,
-        private featureFlagService: FeatureFlagService
+        private readonly featureFlagService: FeatureFlagService
     ) {}
 
     @ApiTags("pages")

--- a/server/interfaces/personality.interface.ts
+++ b/server/interfaces/personality.interface.ts
@@ -37,3 +37,67 @@ const FindAllResultSchema = z.object({
 });
 
 export type IFindAllResult = z.infer<typeof FindAllResultSchema>;
+
+const PersonalityCreateInputSchema = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    wikidata: z.string().optional(),
+    isHidden: z.boolean().optional(),
+});
+
+export type IPersonalityCreateInput = z.infer<
+    typeof PersonalityCreateInputSchema
+>;
+
+const PersonalityUpdateInputSchema = z.object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    wikidata: z.string().optional(),
+    isHidden: z.boolean().optional(),
+});
+
+export type IPersonalityUpdateInput = z.infer<
+    typeof PersonalityUpdateInputSchema
+>;
+
+const PersonalityListQuerySchema = z.object({
+    page: z.number().int().nonnegative().optional(),
+    pageSize: z.number().int().positive().optional(),
+    order: z.string().optional(),
+    name: z.string().optional(),
+    isHidden: z.boolean().optional(),
+    language: z.string().optional(),
+    withSuggestions: z.boolean().optional(),
+    filter: z.string().optional(),
+    fetchOnly: z.boolean().optional(),
+    nameSpace: z.string().optional(),
+});
+
+export type IPersonalityListQuery = z.infer<typeof PersonalityListQuerySchema>;
+
+const PersonalityGetByIdOptionsSchema = z.object({
+    language: z.string().optional(),
+    nameSpace: z.string().optional(),
+});
+
+export type IPersonalityGetByIdOptions = z.infer<
+    typeof PersonalityGetByIdOptionsSchema
+>;
+
+const PersonalityFindOrCreateInputSchema = z.object({
+    name: z.string(),
+    wikidata: z
+        .object({
+            id: z.string().optional(),
+            label: z.string().optional(),
+            description: z.string().optional(),
+        })
+        .optional(),
+});
+
+export type IPersonalityFindOrCreateInput = z.infer<
+    typeof PersonalityFindOrCreateInputSchema
+>;
+
+export type IPersonalityListResult = ICombinedListResult;
+export type IPersonalityFindAllResult = IFindAllResult;

--- a/server/interfaces/personality.service.interface.ts
+++ b/server/interfaces/personality.service.interface.ts
@@ -1,54 +1,57 @@
-import { LeanDocument } from "mongoose";
-import {
-    ICombinedListResult,
+import type {
     IFindAllOptions,
-    IFindAllResult,
     IPersonality,
+    IPersonalityCreateInput,
+    IPersonalityFindAllResult,
+    IPersonalityFindOrCreateInput,
+    IPersonalityGetByIdOptions,
+    IPersonalityListQuery,
+    IPersonalityListResult,
+    IPersonalityUpdateInput,
 } from "./personality.interface";
 
+export const PERSONALITY_SERVICE = "PersonalityService" as const;
+
 export type IPersonalityService = {
-    getWikidataEntities(regex: string, language: string): Promise<any>;
-    getWikidataList(regex: string, language: string): Promise<string[]>;
-    listAll(
-        page: number,
-        pageSize: number,
-        order: string,
-        query: any,
-        language: string,
-        withSuggestions: boolean,
-        filter?: any
-    ): Promise<IPersonality[]>;
-    create(personality: any): Promise<IPersonality>;
-    getDeletedPersonalityByWikidata(wikidata: string): Promise<any>;
-    findOrCreatePersonality(personalityData: {
-        name: string;
-        wikidata?: {
-            id?: string;
-            label?: string;
-            description?: string;
-        };
-    }): Promise<IPersonality>;
+    listAll(query: IPersonalityListQuery): Promise<IPersonality[]>;
+    combinedListAll(
+        query: IPersonalityListQuery
+    ): Promise<IPersonalityListResult>;
+    findAll(query: IFindAllOptions): Promise<IPersonalityFindAllResult>;
+
     getById(
-        personalityId: string | LeanDocument<IPersonality>,
-        options?: { language?: string; nameSpace?: string }
+        personalityId: string,
+        options?: IPersonalityGetByIdOptions
+    ): Promise<IPersonality | null>;
+
+    getPersonalityBySlug(
+        query: { slug: string; isHidden?: boolean; isDeleted?: boolean },
+        language?: string
     ): Promise<IPersonality>;
-    getPersonalityBySlug(query: any, language?: string): Promise<IPersonality>;
-    getClaimsByPersonalitySlug(query: any, language?: string): Promise<any>;
-    postProcess(personality: any, language?: string): Promise<any>;
-    getReviewStats(_id: string): Promise<any>;
+
+    getClaimsByPersonalitySlug(
+        query: { slug: string; isDeleted?: boolean },
+        language?: string
+    ): Promise<IPersonality & { claims: unknown[] }>;
+
+    create(input: IPersonalityCreateInput): Promise<IPersonality>;
     update(
         personalityId: string,
-        newPersonalityBody: any
+        input: IPersonalityUpdateInput
+    ): Promise<IPersonality | null>;
+    findOrCreatePersonality(
+        input: IPersonalityFindOrCreateInput
     ): Promise<IPersonality>;
     hideOrUnhidePersonality(
         personalityId: string,
         isHidden: boolean,
         description: string
-    ): Promise<any>;
-    delete(personalityId: string): Promise<void>;
-    count(query?: any): Promise<number> | number;
-    extractClaimWithTextSummary(claims: any): any;
-    verifyInputsQuery(query: any): any;
-    combinedListAll(query: any): Promise<ICombinedListResult>;
-    findAll(options: IFindAllOptions): Promise<IFindAllResult>;
+    ): Promise<IPersonality>;
+    delete(personalityId: string): Promise<unknown>;
+
+    count(
+        query?: Partial<IPersonality> & { isDeleted?: boolean }
+    ): Promise<number>;
+    // Review stats payload is owned by ClaimReviewService.
+    getReviewStats(personalityId: string): Promise<unknown>;
 };

--- a/server/management/management.service.spec.ts
+++ b/server/management/management.service.spec.ts
@@ -2,8 +2,16 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ManagementService } from "./management.service";
 import { ClaimService } from "../claim/claim.service";
 import { ClaimReviewService } from "../claim-review/claim-review.service";
-import { NotFoundException, InternalServerErrorException } from "@nestjs/common";
-import { personalityServiceMock, claimServiceMock, claimReviewServiceMock } from "../mocks/managementMock";
+import {
+    NotFoundException,
+    InternalServerErrorException,
+} from "@nestjs/common";
+import {
+    personalityServiceMock,
+    claimServiceMock,
+    claimReviewServiceMock,
+} from "../mocks/managementMock";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 
 describe("ManagementService (Unit)", () => {
     let service: ManagementService;
@@ -15,14 +23,20 @@ describe("ManagementService (Unit)", () => {
         const testingModule: TestingModule = await Test.createTestingModule({
             providers: [
                 ManagementService,
-                { provide: "PersonalityService", useValue: personalityServiceMock, },
-                { provide: ClaimService, useValue: claimServiceMock, },
-                { provide: ClaimReviewService, useValue: claimReviewServiceMock, },
+                {
+                    provide: PERSONALITY_SERVICE,
+                    useValue: personalityServiceMock,
+                },
+                { provide: ClaimService, useValue: claimServiceMock },
+                {
+                    provide: ClaimReviewService,
+                    useValue: claimReviewServiceMock,
+                },
             ],
         }).compile();
 
         service = testingModule.get<ManagementService>(ManagementService);
-        personalityService = testingModule.get("PersonalityService");
+        personalityService = testingModule.get(PERSONALITY_SERVICE);
         claimService = testingModule.get(ClaimService);
         claimReviewService = testingModule.get(ClaimReviewService);
     });
@@ -38,42 +52,61 @@ describe("ManagementService (Unit)", () => {
 
         it("should successfully delete the entire hierarchy (happy path)", async () => {
             claimService.getByPersonalityId.mockResolvedValue(mockClaims);
-            claimReviewService.findAllReviewsForCascadeDelete.mockResolvedValue(mockReviews);
+            claimReviewService.findAllReviewsForCascadeDelete.mockResolvedValue(
+                mockReviews
+            );
             claimReviewService.delete.mockResolvedValue(true);
-            claimService.delete.mockResolvedValue({ _id: "claim-1", isDeleted: true });
+            claimService.delete.mockResolvedValue({
+                _id: "claim-1",
+                isDeleted: true,
+            });
             personalityService.delete.mockResolvedValue(true);
 
-            const result = await service.deletePersonalityHierarchy(personalityId);
+            const result = await service.deletePersonalityHierarchy(
+                personalityId
+            );
 
-            expect(claimService.getByPersonalityId).toHaveBeenCalledWith(personalityId);
-            expect(claimReviewService.findAllReviewsForCascadeDelete).toHaveBeenCalledTimes(2);
+            expect(claimService.getByPersonalityId).toHaveBeenCalledWith(
+                personalityId
+            );
+            expect(
+                claimReviewService.findAllReviewsForCascadeDelete
+            ).toHaveBeenCalledTimes(2);
             expect(claimService.delete).toHaveBeenCalledTimes(2);
-            expect(personalityService.delete).toHaveBeenCalledWith(personalityId);
+            expect(personalityService.delete).toHaveBeenCalledWith(
+                personalityId
+            );
             expect(result).toBe(true);
         });
 
         it("should throw NotFoundException and log warning if personality does not exist", async () => {
-            personalityService.delete.mockRejectedValue(new NotFoundException());
-            const loggerWarnSpy = vi.spyOn(service['logger'], 'warn');
-
-            await expect(service.deletePersonalityHierarchy(personalityId)).rejects.toThrow(
-                NotFoundException
+            personalityService.delete.mockRejectedValue(
+                new NotFoundException()
             );
+            const loggerWarnSpy = vi.spyOn(service["logger"], "warn");
+
+            await expect(
+                service.deletePersonalityHierarchy(personalityId)
+            ).rejects.toThrow(NotFoundException);
             expect(loggerWarnSpy).toHaveBeenCalledWith(
-                expect.stringContaining(`Resource for deletion not found: [personality] ID ${personalityId}`)
+                expect.stringContaining(
+                    `Resource for deletion not found: [personality] ID ${personalityId}`
+                )
             );
         });
 
         it("should handle error and log it when unexpected failure occurs", async () => {
             const unexpectedError = new Error("Database error");
             personalityService.delete.mockRejectedValue(unexpectedError);
-            const loggerErrorSpy = vi.spyOn(service['logger'], 'error');
+            const loggerErrorSpy = vi.spyOn(service["logger"], "error");
 
-            await expect(service.deletePersonalityHierarchy(personalityId)).rejects.toThrow(
-                InternalServerErrorException
-            );
+            await expect(
+                service.deletePersonalityHierarchy(personalityId)
+            ).rejects.toThrow(InternalServerErrorException);
             expect(loggerErrorSpy).toHaveBeenCalledWith(
-                expect.stringContaining(`Failed to execute cascade delete for [personality] ID: ${personalityId}`),
+                expect.stringContaining(
+                    `Failed to execute cascade delete for [personality] ID: ${personalityId}`
+                ),
                 unexpectedError.stack
             );
         });
@@ -84,42 +117,57 @@ describe("ManagementService (Unit)", () => {
         const mockReviews = [{ _id: "review-1" }, { _id: "review-2" }];
 
         it("should delete claim and its reviews successfully", async () => {
-            claimReviewService.findAllReviewsForCascadeDelete.mockResolvedValue(mockReviews);
+            claimReviewService.findAllReviewsForCascadeDelete.mockResolvedValue(
+                mockReviews
+            );
             claimReviewService.delete.mockResolvedValue(true);
-            claimService.delete.mockResolvedValue({ _id: claimId, isDeleted: true });
+            claimService.delete.mockResolvedValue({
+                _id: claimId,
+                isDeleted: true,
+            });
 
             await service.deleteClaimHierarchy(claimId);
 
-            expect(claimReviewService.findAllReviewsForCascadeDelete).toHaveBeenCalledWith(claimId);
+            expect(
+                claimReviewService.findAllReviewsForCascadeDelete
+            ).toHaveBeenCalledWith(claimId);
             expect(claimReviewService.delete).toHaveBeenCalledTimes(2);
             expect(claimService.delete).toHaveBeenCalledWith(claimId);
         });
 
         it("should throw NotFoundException and log warning if claim does not exist", async () => {
-            claimReviewService.findAllReviewsForCascadeDelete.mockResolvedValue([]);
+            claimReviewService.findAllReviewsForCascadeDelete.mockResolvedValue(
+                []
+            );
             claimService.delete.mockRejectedValue(new NotFoundException());
 
-            const loggerWarnSpy = vi.spyOn(service['logger'], 'warn');
+            const loggerWarnSpy = vi.spyOn(service["logger"], "warn");
 
             await expect(service.deleteClaimHierarchy(claimId)).rejects.toThrow(
                 NotFoundException
             );
             expect(loggerWarnSpy).toHaveBeenCalledWith(
-                expect.stringContaining(`Resource for deletion not found: [claim] ID ${claimId}`)
+                expect.stringContaining(
+                    `Resource for deletion not found: [claim] ID ${claimId}`
+                )
             );
         });
 
         it("should handle error and log it when unexpected failure occurs in claim hierarchy", async () => {
             const unexpectedError = new Error("Database connection lost");
-            claimReviewService.findAllReviewsForCascadeDelete.mockRejectedValue(unexpectedError);
+            claimReviewService.findAllReviewsForCascadeDelete.mockRejectedValue(
+                unexpectedError
+            );
 
-            const loggerErrorSpy = vi.spyOn(service['logger'], 'error');
+            const loggerErrorSpy = vi.spyOn(service["logger"], "error");
 
             await expect(service.deleteClaimHierarchy(claimId)).rejects.toThrow(
                 InternalServerErrorException
             );
             expect(loggerErrorSpy).toHaveBeenCalledWith(
-                expect.stringContaining(`Failed to execute cascade delete for [claim] ID: ${claimId}`),
+                expect.stringContaining(
+                    `Failed to execute cascade delete for [claim] ID: ${claimId}`
+                ),
                 unexpectedError.stack
             );
         });

--- a/server/management/management.service.ts
+++ b/server/management/management.service.ts
@@ -1,6 +1,13 @@
-import { Inject, Injectable, InternalServerErrorException, Logger, NotFoundException } from "@nestjs/common";
+import {
+    Inject,
+    Injectable,
+    InternalServerErrorException,
+    Logger,
+    NotFoundException,
+} from "@nestjs/common";
 import { ClaimService } from "../claim/claim.service";
 import { ClaimReviewService } from "../claim-review/claim-review.service";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 
 @Injectable()
@@ -8,10 +15,10 @@ export class ManagementService {
     private readonly logger = new Logger(ManagementService.name);
 
     constructor(
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private readonly claimService: ClaimService,
-        private readonly claimReviewService: ClaimReviewService,
+        private readonly claimReviewService: ClaimReviewService
     ) {}
 
     /**
@@ -19,25 +26,35 @@ export class ManagementService {
      * Path: Personality -> Claims -> ClaimReviews
      * @param personalityId The unique identifier of the personality.
      */
-    async deletePersonalityHierarchy(personalityId: string): Promise<void> {
-        this.logger.log(`Starting global cascade delete for personalityId: ${personalityId}`);
+    async deletePersonalityHierarchy(personalityId: string): Promise<unknown> {
+        this.logger.log(
+            `Starting global cascade delete for personalityId: ${personalityId}`
+        );
         try {
-            const claims = await this.claimService.getByPersonalityId(personalityId);
+            const claims = await this.claimService.getByPersonalityId(
+                personalityId
+            );
 
             if (claims.length > 0) {
-                this.logger.log(`Found ${claims.length} claims for personality ${personalityId}. Starting sub-cascades.`);
+                this.logger.log(
+                    `Found ${claims.length} claims for personality ${personalityId}. Starting sub-cascades.`
+                );
 
                 for (const claim of claims) {
                     await this.deleteClaimHierarchy(claim._id);
                 }
             }
 
-            const deletedPersonality = await this.personalityService.delete(personalityId);
-            this.logger.log(`Full hierarchy for personality ${personalityId} deleted successfully.`);
+            const deletedPersonality = await this.personalityService.delete(
+                personalityId
+            );
+            this.logger.log(
+                `Full hierarchy for personality ${personalityId} deleted successfully.`
+            );
 
-            return deletedPersonality
+            return deletedPersonality;
         } catch (error) {
-            this.handleError(error, personalityId, 'personality');
+            this.handleError(error, personalityId, "personality");
         }
     }
 
@@ -49,21 +66,28 @@ export class ManagementService {
         this.logger.log(`Starting cascade soft delete for claimId: ${claimId}`);
 
         try {
-            const claimReviews = await this.claimReviewService.findAllReviewsForCascadeDelete(claimId);
+            const claimReviews =
+                await this.claimReviewService.findAllReviewsForCascadeDelete(
+                    claimId
+                );
 
             if (claimReviews.length > 0) {
-                this.logger.log(`Found ${claimReviews.length} associated claim reviews to delete for claimId: ${claimId}`);
+                this.logger.log(
+                    `Found ${claimReviews.length} associated claim reviews to delete for claimId: ${claimId}`
+                );
                 for (const review of claimReviews) {
                     await this.claimReviewService.delete(review._id);
                 }
             }
 
             const deletedClaim = await this.claimService.delete(claimId);
-            this.logger.log(`Cascade soft delete completed successfully for claimId: ${claimId}`);
+            this.logger.log(
+                `Cascade soft delete completed successfully for claimId: ${claimId}`
+            );
 
             return deletedClaim;
         } catch (error) {
-            this.handleError(error, claimId, 'claim');
+            this.handleError(error, claimId, "claim");
         }
     }
 
@@ -72,13 +96,15 @@ export class ManagementService {
      */
     private handleError(error: any, id: string, context: string): void {
         if (error instanceof NotFoundException) {
-            this.logger.warn(`Resource for deletion not found: [${context}] ID ${id}`);
+            this.logger.warn(
+                `Resource for deletion not found: [${context}] ID ${id}`
+            );
             throw error;
         }
 
         this.logger.error(
             `Failed to execute cascade delete for [${context}] ID: ${id}`,
-            error.stack,
+            error.stack
         );
 
         throw new InternalServerErrorException(

--- a/server/personality/dto/mappers.ts
+++ b/server/personality/dto/mappers.ts
@@ -1,0 +1,36 @@
+import type {
+    IPersonalityCreateInput,
+    IPersonalityUpdateInput,
+    IPersonalityListQuery,
+} from "../../interfaces/personality.interface";
+import type { CreatePersonalityDTO } from "./create-personality.dto";
+import type { GetPersonalities } from "./get-personalities.dto";
+
+export const toCreatePersonalityInput = (
+    dto: CreatePersonalityDTO
+): IPersonalityCreateInput => ({
+    name: dto.name,
+    description: dto.description,
+    wikidata: dto.wikidata,
+});
+
+export const toUpdatePersonalityInput = (
+    dto: Partial<CreatePersonalityDTO>
+): IPersonalityUpdateInput => ({
+    name: dto.name,
+    description: dto.description,
+    wikidata: dto.wikidata,
+});
+
+export const toListPersonalitiesQuery = (
+    dto: GetPersonalities
+): IPersonalityListQuery => ({
+    page: dto.page,
+    pageSize: dto.pageSize,
+    order: dto.order,
+    name: dto.name,
+    isHidden: typeof dto.isHidden === "boolean" ? dto.isHidden : undefined,
+    language: dto.language,
+    withSuggestions: dto.withSuggestions,
+    nameSpace: dto.nameSpace,
+});

--- a/server/personality/mongo/personality.service.ts
+++ b/server/personality/mongo/personality.service.ts
@@ -15,18 +15,27 @@ import { UtilService } from "../../util";
 import { ClaimReviewService } from "../../claim-review/claim-review.service";
 import { HistoryService } from "../../history/history.service";
 import { HistoryType, TargetModel } from "../../history/schema/history.schema";
-import { ISoftDeletedModel } from "mongoose-softdelete-typescript";
+import {
+    ISoftDeletedDocument,
+    ISoftDeletedModel,
+} from "mongoose-softdelete-typescript";
 import { REQUEST } from "@nestjs/core";
 import type { BaseRequest } from "../../types";
 import { NameSpaceEnum } from "../../auth/name-space/schemas/name-space.schema";
-import {
-    ICombinedListResult,
+import type {
     IFindAllOptions,
-    IFindAllResult,
+    IPersonality,
+    IPersonalityCreateInput,
+    IPersonalityFindAllResult,
+    IPersonalityFindOrCreateInput,
+    IPersonalityGetByIdOptions,
+    IPersonalityListQuery,
+    IPersonalityListResult,
+    IPersonalityUpdateInput,
 } from "../../interfaces/personality.interface";
+import type { IPersonalityService } from "../../interfaces/personality.service.interface";
 import { escapeRegex } from "../../util/regex.util";
 import { toError } from "../../util/error-handling";
-import { CreatePersonalityDTO } from "../dto/create-personality.dto";
 
 @Injectable({ scope: Scope.REQUEST })
 export class MongoPersonalityService {
@@ -47,63 +56,69 @@ export class MongoPersonalityService {
         private readonly util: UtilService
     ) {}
 
-    async getWikidataEntities(regex: string, language: string) {
+    private async getWikidataEntities(regex: string, language: string) {
         return await this.wikidata.queryWikibaseEntities(
             regex,
             language,
             false
         );
     }
-    async getWikidataList(regex: string, language: string) {
+
+    private async getWikidataList(regex: string, language: string) {
         const wbentities = await this.getWikidataEntities(regex, language);
         return wbentities.map((entity) => entity.wikidata);
     }
 
-    async listAll(
-        page: number,
-        pageSize: number,
-        order: string,
-        query: any,
-        filter: any,
-        language: string,
-        withSuggestions = false
-    ) {
-        let personalities;
+    async listAll(query: IPersonalityListQuery): Promise<IPersonality[]> {
+        const {
+            page = 0,
+            pageSize = 10,
+            order = "asc",
+            language = "en",
+            withSuggestions = false,
+            filter,
+        } = query;
+        const mongoQuery = this.verifyInputsQuery(query);
+
+        let personalities: any[];
 
         if (order === "random") {
             personalities = await this.PersonalityModel.aggregate([
                 {
                     $match: {
-                        $and: [query, { _id: { $ne: filter } }],
+                        $and: [mongoQuery, { _id: { $ne: filter } }],
                     },
                 },
                 { $sample: { size: pageSize } },
             ]);
-        } else if (Object.keys(query).length > 0 && query?.name) {
+        } else if (mongoQuery?.name) {
             const wikidataList = await this.getWikidataList(
-                query?.name.$regex,
+                mongoQuery.name.$regex,
                 language
             );
             personalities = await this.PersonalityModel.find({
-                $or: [{ wikidata: { $in: wikidataList } }, { query }],
+                $or: [
+                    { wikidata: { $in: wikidataList } },
+                    { query: mongoQuery },
+                ],
             })
                 .skip(page * pageSize)
                 .limit(pageSize)
                 .sort({ _id: order as any })
                 .lean();
         } else {
-            personalities = await this.PersonalityModel.find(query)
+            personalities = await this.PersonalityModel.find(mongoQuery)
                 .skip(page * pageSize)
                 .limit(pageSize)
                 .sort({ _id: order as any })
                 .lean();
         }
 
-        if (withSuggestions) {
+        if (withSuggestions && mongoQuery?.name) {
             personalities = this.util.mergeObjectsInUnique(
                 [
                     ...(await this.getWikidataEntities(
-                        query?.name.$regex,
+                        mongoQuery.name.$regex,
                         language
                     )),
                     ...personalities,
@@ -131,25 +146,24 @@ export class MongoPersonalityService {
         );
     }
 
-    /**
-     * This function will create a new personality and save it to the dataBase.
-     * Also creates a History Module that tracks creation of personalities.
-     * @param personality PersonalityBody received of the client.
-     * @returns Return a new personality.
-     */
-    async create(personality: CreatePersonalityDTO & { slug?: string }) {
+    async create(input: IPersonalityCreateInput): Promise<IPersonality> {
+        const personality: IPersonalityCreateInput & { slug?: string } = {
+            ...input,
+            description: input.description ?? "",
+        };
         try {
-            const personalityExists =
-                await this.getDeletedPersonalityByWikidata(
-                    personality.wikidata
-                );
+            const personalityExists = personality.wikidata
+                ? await this.getDeletedPersonalityByWikidata(
+                      personality.wikidata
+                  )
+                : null;
 
             if (personalityExists) {
-                return personalityExists.restore();
+                return (await personalityExists.restore()) as unknown as IPersonality;
             } else {
                 personality.slug = slugify(personality.name, {
-                    lower: true, // convert to lower case, defaults to `false`
-                    strict: true, // strip special characters except replacement, defaults to `false`
+                    lower: true,
+                    strict: true,
                 });
                 const newPersonality = new this.PersonalityModel(personality);
                 this.logger.log(
@@ -177,26 +191,20 @@ export class MongoPersonalityService {
         }
     }
 
-    getDeletedPersonalityByWikidata(wikidata: string) {
+    private getDeletedPersonalityByWikidata(
+        wikidata: string
+    ): Promise<(PersonalityDocument & ISoftDeletedDocument) | null> {
         return this.PersonalityModel.findOne({
             isDeleted: true,
             wikidata,
-        });
+        }).exec() as Promise<
+            (PersonalityDocument & ISoftDeletedDocument) | null
+        >;
     }
 
-    /**
-     * Find or create a personality based on AI task result
-     * @param personalityData - Data from AI task processor with name, wikidata info, etc.
-     * @returns The found or created personality document
-     */
-    async findOrCreatePersonality(personalityData: {
-        name: string;
-        wikidata?: {
-            id?: string;
-            label?: string;
-            description?: string;
-        };
-    }): Promise<PersonalityDocument> {
+    async findOrCreatePersonality(
+        personalityData: IPersonalityFindOrCreateInput
+    ): Promise<IPersonality> {
         const wikidataId = personalityData.wikidata?.id || null;
 
         if (wikidataId) {
@@ -252,7 +260,7 @@ export class MongoPersonalityService {
 
     async getById(
         personalityId: string,
-        query: { language?: string; nameSpace?: string } = {
+        options: IPersonalityGetByIdOptions = {
             language: "en",
             nameSpace: NameSpaceEnum.Main,
         }
@@ -270,7 +278,7 @@ export class MongoPersonalityService {
                 match: {
                     isHidden: false,
                     isDeleted: false,
-                    nameSpace: query.nameSpace,
+                    nameSpace: options.nameSpace,
                 },
                 select: "_id title content",
             })
@@ -288,7 +296,7 @@ export class MongoPersonalityService {
         try {
             processed = await this.postProcess(
                 personality.toObject(),
-                query.language
+                options.language
             );
         } catch (error) {
             const err = toError(error);
@@ -311,7 +319,10 @@ export class MongoPersonalityService {
         return processed;
     }
 
-    async getPersonalityBySlug(query: Record<string, any>, language = "pt") {
+    async getPersonalityBySlug(
+        query: { slug: string; isHidden?: boolean; isDeleted?: boolean },
+        language = "pt"
+    ) {
         const queryOptions = this.util.getParamsBasedOnUserRole(
             query,
             this.req
@@ -342,7 +353,7 @@ export class MongoPersonalityService {
     }
 
     async getClaimsByPersonalitySlug(
-        query: Record<string, any>,
+        query: { slug: string; isDeleted?: boolean },
         language = "pt"
     ) {
         const queryOptions = this.util.getParamsBasedOnUserRole(
@@ -414,7 +425,7 @@ export class MongoPersonalityService {
         return processed;
     }
 
-    async postProcess(personality: any, language: string = "en") {
+    private async postProcess(personality: any, language: string = "en") {
         if (!personality) {
             return personality;
         }
@@ -471,25 +482,22 @@ export class MongoPersonalityService {
         return this.util.formatStats(reviews);
     }
 
-    /**
-     * This function overwrites personality data with the new data,
-     * keeping data that has not changed.
-     * Also creates a History Module that tracks updation of personalities.
-     * @param personalityId Personality id which wants updated.
-     * @param newPersonalityBody PersonalityBody received of the client.
-     * @returns Return changed personality.
-     */
-    async update(personalityId: string, newPersonalityBody: any) {
-        // eslint-disable-next-line no-useless-catch
-        if (newPersonalityBody.name) {
-            newPersonalityBody.slug = slugify(newPersonalityBody.name, {
+    async update(
+        personalityId: string,
+        newPersonalityBody: IPersonalityUpdateInput
+    ): Promise<IPersonality | null> {
+        const body: IPersonalityUpdateInput & { slug?: string } = {
+            ...newPersonalityBody,
+        };
+        if (body.name) {
+            body.slug = slugify(body.name, {
                 lower: true,
                 strict: true,
             });
         }
         const personality = await this.getById(personalityId);
         const previousPersonality = { ...personality };
-        const newPersonality = Object.assign(personality, newPersonalityBody);
+        const newPersonality = Object.assign(personality ?? {}, body);
         const personalityUpdate = await this.PersonalityModel.findByIdAndUpdate(
             personalityId,
             newPersonality,
@@ -516,7 +524,7 @@ export class MongoPersonalityService {
         personalityId: string,
         isHidden: boolean,
         description: string
-    ): Promise<PersonalityDocument> {
+    ): Promise<IPersonality> {
         const personality = await this.getById(personalityId);
 
         const newPersonality = {
@@ -542,18 +550,14 @@ export class MongoPersonalityService {
             newPersonality
         ).exec();
         if (!updated) {
-            throw new NotFoundException(`Personality not found: ${personality._id}`);
+            throw new NotFoundException(
+                `Personality not found: ${personality._id}`
+            );
         }
         return updated;
     }
 
-    /**
-     * Executes a soft delete on a specific personality record.
-     * Records the action in the history module for auditing.
-     * * @param {string} personalityId - The ID of the personality to mark as deleted.
-     * @returns {Promise<Personality>} The personality document with isDeleted set to true, or null if not found.
-     */
-    async delete(personalityId: string) {
+    async delete(personalityId: string): Promise<unknown> {
         const user = this.req.user?._id;
         this.logger.log(
             `Initiating soft delete for personalityId: ${personalityId} by user: ${user}`
@@ -596,18 +600,20 @@ export class MongoPersonalityService {
         }
     }
 
-    /**
-     * Don't count hide personalities because of cache
-     */
-    count(query: any = {}) {
-        return this.PersonalityModel.countDocuments().where({
-            ...query,
-            isDeleted: false,
-            isHidden: query.isHidden || false,
-        });
+    // Exclude hidden personalities so the count stays cacheable.
+    count(
+        query: Partial<IPersonality> & { isDeleted?: boolean } = {}
+    ): Promise<number> {
+        return this.PersonalityModel.countDocuments()
+            .where({
+                ...query,
+                isDeleted: false,
+                isHidden: query.isHidden || false,
+            })
+            .exec();
     }
 
-    extractClaimWithTextSummary(claims: any) {
+    private extractClaimWithTextSummary(claims: any) {
         claims = Array.isArray(claims) ? claims : [claims];
         return claims.map((claim: any) => {
             if (!claim.content) {
@@ -617,7 +623,7 @@ export class MongoPersonalityService {
         });
     }
 
-    verifyInputsQuery(query: Record<string, any>) {
+    private verifyInputsQuery(query: Record<string, any>) {
         const queryInputs: any = {};
         if (query.name) {
             (queryInputs as Record<string, unknown>).name = {
@@ -630,26 +636,15 @@ export class MongoPersonalityService {
         return queryInputs;
     }
 
-    combinedListAll(query: Record<string, any>): Promise<ICombinedListResult> {
-        const { page = 0, pageSize = 10, order = "asc" } = query;
+    combinedListAll(
+        query: IPersonalityListQuery
+    ): Promise<IPersonalityListResult> {
+        const { page = 0, pageSize = 10 } = query;
         const queryInputs = this.verifyInputsQuery(query);
 
-        return Promise.all([
-            this.listAll(
-                page,
-                parseInt(pageSize, 10),
-                order,
-                queryInputs,
-                query.filter,
-                query.language,
-                query.withSuggestions
-            ),
-            this.count(queryInputs),
-        ])
+        return Promise.all([this.listAll(query), this.count(queryInputs)])
             .then(([personalities, totalPersonalities]) => {
-                const totalPages = Math.ceil(
-                    totalPersonalities / parseInt(pageSize, 10)
-                );
+                const totalPages = Math.ceil(totalPersonalities / pageSize);
 
                 this.logger.log(
                     `Found ${totalPersonalities} personalities. Page ${page} of ${totalPages}`
@@ -674,7 +669,7 @@ export class MongoPersonalityService {
         pageSize,
         language,
         skippedDocuments,
-    }: IFindAllOptions): Promise<IFindAllResult> {
+    }: IFindAllOptions): Promise<IPersonalityFindAllResult> {
         const personalities = await this.PersonalityModel.aggregate([
             {
                 $search: {
@@ -738,3 +733,8 @@ export class MongoPersonalityService {
         };
     }
 }
+
+// Port conformance: fails build if MongoPersonalityService drifts from IPersonalityService.
+const _assertImplementsPort: IPersonalityService =
+    {} as MongoPersonalityService;
+void _assertImplementsPort;

--- a/server/personality/mongo/personality.service.ts
+++ b/server/personality/mongo/personality.service.ts
@@ -737,4 +737,3 @@ export class MongoPersonalityService {
 // Port conformance: fails build if MongoPersonalityService drifts from IPersonalityService.
 const _assertImplementsPort: IPersonalityService =
     {} as MongoPersonalityService;
-void _assertImplementsPort;

--- a/server/personality/personality.controller.ts
+++ b/server/personality/personality.controller.ts
@@ -40,10 +40,10 @@ export class PersonalityController {
     constructor(
         @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
-        private viewService: ViewService,
-        private configService: ConfigService,
-        private captchaService: CaptchaService,
-        private historyService: HistoryService
+        private readonly viewService: ViewService,
+        private readonly configService: ConfigService,
+        private readonly captchaService: CaptchaService,
+        private readonly historyService: HistoryService
     ) {}
 
     @Public()

--- a/server/personality/personality.controller.ts
+++ b/server/personality/personality.controller.ts
@@ -25,14 +25,20 @@ import { ApiTags } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
 import { CaptchaService } from "../captcha/captcha.service";
 import { HistoryService } from "../history/history.service";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
+import {
+    toCreatePersonalityInput,
+    toListPersonalitiesQuery,
+    toUpdatePersonalityInput,
+} from "./dto/mappers";
 import { toError } from "../util/error-handling";
 
 @Controller(":namespace?")
 export class PersonalityController {
     private readonly logger = new Logger("PersonalityController");
     constructor(
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private viewService: ViewService,
         private configService: ConfigService,
@@ -45,14 +51,18 @@ export class PersonalityController {
     @Get("api/personality")
     @Header("Cache-Control", "max-age=60, must-revalidate")
     async listAll(@Query() getPersonalities: GetPersonalities) {
-        return this.personalityService.combinedListAll(getPersonalities);
+        return this.personalityService.combinedListAll(
+            toListPersonalitiesQuery(getPersonalities)
+        );
     }
 
     @ApiTags("personality")
     @Post("api/personality")
     async create(@Body() createPersonality: CreatePersonalityDTO) {
         try {
-            return await this.personalityService.create(createPersonality);
+            return await this.personalityService.create(
+                toCreatePersonalityInput(createPersonality)
+            );
         } catch (error) {
             const err = toError(error);
             if (
@@ -87,7 +97,10 @@ export class PersonalityController {
         @Param("id") personalityId: string,
         @Body() body: Partial<CreatePersonalityDTO>
     ) {
-        return this.personalityService.update(personalityId, body);
+        return this.personalityService.update(
+            personalityId,
+            toUpdatePersonalityInput(body)
+        );
     }
 
     @AdminOnly()

--- a/server/personality/personality.module.ts
+++ b/server/personality/personality.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module } from "@nestjs/common";
+import { DynamicModule, Module, Provider } from "@nestjs/common";
 import { MongoPersonalityService } from "./mongo/personality.service";
 import { MongooseModule } from "@nestjs/mongoose";
 import {
@@ -17,6 +17,7 @@ import { ConfigModule } from "@nestjs/config";
 import { CaptchaModule } from "../captcha/captcha.module";
 import { AbilityModule } from "../auth/ability/ability.module";
 import { personalityServiceProvider } from "./personality.provider";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import dbConfig from "../config/db.config";
 
 const PersonalityModel = MongooseModule.forFeature([
@@ -29,20 +30,20 @@ const PersonalityModel = MongooseModule.forFeature([
 @Module({})
 export class PersonalityModule {
     static register(): DynamicModule {
-        const imports: any[] = [];
-        const providers: any[] = [personalityServiceProvider];
+        const dbImports: DynamicModule["imports"] = [];
+        const dbProviders: Provider[] = [personalityServiceProvider];
 
         if (dbConfig.type === "mongodb") {
-            imports.push(PersonalityModel);
-            providers.push(MongoPersonalityService);
+            dbImports.push(PersonalityModel);
+            dbProviders.push(MongoPersonalityService);
         } else {
-            throw new Error("Invalid DB_TYPE in configuration");
+            throw new Error(`Unsupported DB_TYPE: ${dbConfig.type}`);
         }
 
         return {
             module: PersonalityModule,
             imports: [
-                ...imports,
+                ...dbImports,
                 WikidataModule,
                 ClaimReviewModule,
                 ClaimRevisionModule,
@@ -52,9 +53,9 @@ export class PersonalityModule {
                 AbilityModule,
                 CaptchaModule,
             ],
-            providers: [...providers, UtilService, WinstonLogger],
+            providers: [...dbProviders, UtilService, WinstonLogger],
             controllers: [PersonalityController],
-            exports: ["PersonalityService"],
+            exports: [PERSONALITY_SERVICE],
         };
     }
 }

--- a/server/personality/personality.provider.ts
+++ b/server/personality/personality.provider.ts
@@ -1,18 +1,18 @@
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 import { Provider } from "@nestjs/common";
 import { MongoPersonalityService } from "./mongo/personality.service";
 import dbConfig from "../config/db.config";
 
 export const personalityServiceProvider: Provider = {
-    provide: "PersonalityService",
+    provide: PERSONALITY_SERVICE,
     useFactory: (
         mongoService: MongoPersonalityService | null
     ): IPersonalityService => {
         if (dbConfig.type === "mongodb" && mongoService) {
-            return mongoService as unknown as IPersonalityService;
-        } else {
-            throw new Error("Invalid DB_TYPE in configuration");
+            return mongoService;
         }
+        throw new Error(`Unsupported DB_TYPE: ${dbConfig.type}`);
     },
     inject: [MongoPersonalityService],
 };

--- a/server/search/search.controller.ts
+++ b/server/search/search.controller.ts
@@ -24,12 +24,12 @@ import type { IPersonalityService } from "../interfaces/personality.service.inte
 export class SearchController {
     private readonly logger = new Logger("SearchController");
     constructor(
-        private viewService: ViewService,
+        private readonly viewService: ViewService,
         @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
-        private sentenceService: SentenceService,
-        private claimRevisionService: ClaimRevisionService,
-        private configService: ConfigService
+        private readonly sentenceService: SentenceService,
+        private readonly claimRevisionService: ClaimRevisionService,
+        private readonly configService: ConfigService
     ) {}
 
     @Public()

--- a/server/search/search.controller.ts
+++ b/server/search/search.controller.ts
@@ -17,6 +17,7 @@ import { parse } from "url";
 import type { Response } from "express";
 import type { BaseRequest } from "../types";
 import { ApiTags } from "@nestjs/swagger";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 
 @Controller()
@@ -24,7 +25,7 @@ export class SearchController {
     private readonly logger = new Logger("SearchController");
     constructor(
         private viewService: ViewService,
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private sentenceService: SentenceService,
         private claimRevisionService: ClaimRevisionService,

--- a/server/sitemap/sitemap.service.ts
+++ b/server/sitemap/sitemap.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger } from "@nestjs/common";
 import { SitemapStream, streamToPromise } from "sitemap";
 import { ClaimService } from "../claim/claim.service";
 import { ClaimReviewService } from "../claim-review/claim-review.service";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 import { toError } from "../util/error-handling";
 const axios = require("axios");
@@ -9,7 +10,7 @@ const axios = require("axios");
 @Injectable()
 export class SitemapService {
     constructor(
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private claimService: ClaimService,
         private claimReviewService: ClaimReviewService
@@ -27,14 +28,13 @@ export class SitemapService {
             { url: "/personality" },
         ];
 
-        const personalities: any[] = await this.personalityService.listAll(
-            0,
-            0,
-            "asc",
-            {},
-            "pt",
-            false
-        );
+        const personalities: any[] = await this.personalityService.listAll({
+            page: 0,
+            pageSize: 0,
+            order: "asc",
+            language: "pt",
+            withSuggestions: false,
+        });
 
         for (const personality of personalities) {
             if (!personality) {
@@ -82,7 +82,8 @@ export class SitemapService {
         } catch (error) {
             const err = toError(error);
             const message =
-                "Error while submitting sitemap to search engine: " + err.message;
+                "Error while submitting sitemap to search engine: " +
+                err.message;
             this.logger.error(message);
             return message;
         }

--- a/server/sitemap/sitemap.service.ts
+++ b/server/sitemap/sitemap.service.ts
@@ -12,8 +12,8 @@ export class SitemapService {
     constructor(
         @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
-        private claimService: ClaimService,
-        private claimReviewService: ClaimReviewService
+        private readonly claimService: ClaimService,
+        private readonly claimReviewService: ClaimReviewService
     ) {}
     private readonly logger = new Logger("SitemapService");
 

--- a/server/stats/stats.service.ts
+++ b/server/stats/stats.service.ts
@@ -4,6 +4,7 @@ import { ClaimService } from "../claim/claim.service";
 import { REQUEST } from "@nestjs/core";
 import type { BaseRequest } from "../types";
 import { NameSpaceEnum } from "../auth/name-space/schemas/name-space.schema";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 
 @Injectable({ scope: Scope.REQUEST })
@@ -11,7 +12,7 @@ export class StatsService {
     constructor(
         @Inject(REQUEST) private req: BaseRequest,
         private claimReviewService: ClaimReviewService,
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
         private claimService: ClaimService
     ) {}
@@ -32,7 +33,7 @@ export class StatsService {
                     isHidden: false,
                     isDeleted: false,
                     nameSpace: this.req.params.namespace || NameSpaceEnum.Main,
-                }
+                },
             }),
         ]).then((values) => {
             return {

--- a/server/stats/stats.service.ts
+++ b/server/stats/stats.service.ts
@@ -10,11 +10,11 @@ import type { IPersonalityService } from "../interfaces/personality.service.inte
 @Injectable({ scope: Scope.REQUEST })
 export class StatsService {
     constructor(
-        @Inject(REQUEST) private req: BaseRequest,
-        private claimReviewService: ClaimReviewService,
+        @Inject(REQUEST) private readonly req: BaseRequest,
+        private readonly claimReviewService: ClaimReviewService,
         @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService,
-        private claimService: ClaimService
+        private readonly claimService: ClaimService
     ) {}
 
     getHomeStats() {

--- a/server/tests/claim.e2e.spec.ts
+++ b/server/tests/claim.e2e.spec.ts
@@ -16,15 +16,14 @@ import { NameSpaceEnum } from "../auth/name-space/schemas/name-space.schema";
 import { AbilitiesGuard } from "../auth/ability/abilities.guard";
 import { AbilitiesGuardMock } from "./mocks/AbilitiesGuardMock";
 import { CaptchaService } from "../captcha/captcha.service";
-import { MongoPersonalityService } from "../personality/mongo/personality.service";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import { HistoryService } from "../history/history.service";
 import { HistoryServiceMock } from "./mocks/HistoryServiceMock";
 import { CleanupDatabase } from "./utils/CleanupDatabase";
 
-
 /**
  * ClaimController E2E Test Suite
- * 
+ *
  * Tests the complete claim lifecycle management including:
  * - Multiple content model types (Speech, Image, Debate) with different validation rules
  * - Claim creation, retrieval, and management across content types
@@ -33,14 +32,14 @@ import { CleanupDatabase } from "./utils/CleanupDatabase";
  * - Soft delete functionality with proper access control
  * - Comprehensive validation for required fields and business rules
  * - Pagination and filtering capabilities
- * 
+ *
  * Business Context:
  * Claims are the core content units in the fact-checking platform. They represent
  * statements made by public figures that need verification. The system supports:
  * - Speech Claims: Text-based statements with source citations
  * - Image Claims: Visual content with metadata and file storage
  * - Debate Claims: Multi-personality discussions requiring 2+ participants
- * 
+ *
  * Technical Features:
  * - Content model polymorphism with type-specific validation
  * - Personality service integration with mock data
@@ -48,7 +47,7 @@ import { CleanupDatabase } from "./utils/CleanupDatabase";
  * - Soft delete pattern with mongoose-softdelete
  * - Path generation with SEO-friendly slugs
  * - Namespace-based content organization
- * 
+ *
  * Data Flow:
  * 1. Empty state validation → claim creation by type → retrieval with population
  * 2. Moderation workflows (hide/unhide) → soft deletion → access validation
@@ -95,7 +94,10 @@ describe("ClaimController (e2e)", () => {
 
         await SeedTestUser(mongoUri);
         const { insertedIds } = await SeedTestPersonality(mongoUri);
-        personalitiesId = [insertedIds["0"].toString(), insertedIds["1"].toString()];
+        personalitiesId = [
+            insertedIds["0"].toString(),
+            insertedIds["1"].toString(),
+        ];
 
         // Update test config with shared MongoDB URI
         const testConfig = {
@@ -119,7 +121,7 @@ describe("ClaimController (e2e)", () => {
             .useValue(AbilitiesGuardMock)
             .overrideProvider(CaptchaService)
             .useValue(captchaService)
-            .overrideProvider("PersonalityService")
+            .overrideProvider(PERSONALITY_SERVICE)
             .useValue(personalityService)
             .overrideProvider(HistoryService)
             .useValue(HistoryServiceMock)
@@ -184,16 +186,18 @@ describe("ClaimController (e2e)", () => {
                 sources: speechSources,
                 recaptcha: "valid_recaptcha_token",
             });
-        
+
         expect(response.status).toBe(201);
         speechClaimId = response.body?._id;
         claimId = speechClaimId; // Set default claimId for dependent tests
-        
+
         // Validate response structure and content
         expect(response.body?.title).toEqual("Speech Claim Title");
         expect(response.body?._id).toBeDefined();
         expect(response.body?.path).toBeDefined();
-        expect(response.body?.path).toContain("/personality/barack-obama/claim/");
+        expect(response.body?.path).toContain(
+            "/personality/barack-obama/claim/"
+        );
         expect(response.body?.path).toContain("speech-claim-title");
     });
 
@@ -209,13 +213,13 @@ describe("ClaimController (e2e)", () => {
      */
     it("/api/claim/:id (GET) - Get by id", async () => {
         expect(claimId).toBeDefined();
-        
+
         const response = await request(app.getHttpServer())
             .get(`/api/claim/${claimId}`)
             .query({ nameSpace: NameSpaceEnum.Main });
-        
+
         expect(response.status).toBe(200);
-        
+
         // Validate personality population works correctly
         const hasBarackObamaPersonality = response.body?.personalities.some(
             (p) => p.name === "Barack Obama"
@@ -223,7 +227,7 @@ describe("ClaimController (e2e)", () => {
         expect(hasBarackObamaPersonality).toBeTruthy();
         expect(response.body?.personalities).toHaveLength(1);
         expect(response.body?.personalities[0]?.slug).toEqual("barack-obama");
-        
+
         // Validate all claim fields are properly returned
         expect(response.body?._id).toEqual(claimId);
         expect(response.body?.title).toEqual("Speech Claim Title");
@@ -265,13 +269,17 @@ describe("ClaimController (e2e)", () => {
                 recaptcha: "valid_recaptcha_token",
             })
             .expect(201);
-        
+
         // Validate response structure and content
         expect(response.status).toBe(201);
-        expect(response.body?.title).toEqual("Image Claim Title With Personality");
+        expect(response.body?.title).toEqual(
+            "Image Claim Title With Personality"
+        );
         expect(response.body?.path).toBeDefined();
-        expect(response.body?.path).toContain("/personality/barack-obama/claim/");
-        
+        expect(response.body?.path).toContain(
+            "/personality/barack-obama/claim/"
+        );
+
         imageClaimId = response.body?._id || response.body?.path;
     });
 
@@ -302,12 +310,13 @@ describe("ClaimController (e2e)", () => {
                 },
                 recaptcha: "valid_recaptcha_token",
             });
-        
-        
+
         expect(response.status).toBe(201);
-        expect(response.body?.title).toEqual("Image Claim Title Without Personality");
+        expect(response.body?.title).toEqual(
+            "Image Claim Title Without Personality"
+        );
         expect(response.body?.path).toBeDefined();
-        
+
         // Validate that path doesn't contain personality slug (since no personality)
         expect(response.body?.path).toContain("/claim/");
         expect(response.body?.path).not.toContain("/personality/");
@@ -341,7 +350,8 @@ describe("ClaimController (e2e)", () => {
 
         // Debate endpoint may return different response formats
         // Accept either _id, path, or just success status
-        debateClaimId = response.body?._id || response.body?.path || "debate-created";
+        debateClaimId =
+            response.body?._id || response.body?.path || "debate-created";
 
         // If the response contains a path, validate it
         if (response.body?.path) {
@@ -386,7 +396,7 @@ describe("ClaimController (e2e)", () => {
      */
     it("/api/claim/hidden/:id (PUT) - Hide claim", async () => {
         expect(claimId).toBeDefined();
-        
+
         // Hide the claim
         await request(app.getHttpServer())
             .put(`/api/claim/hidden/${claimId}`)
@@ -396,7 +406,7 @@ describe("ClaimController (e2e)", () => {
                 recaptcha: "valid_recaptcha_token",
             })
             .expect(200);
-            
+
         // Verify claim no longer appears in public listings
         const response = await request(app.getHttpServer())
             .get("/api/claim")
@@ -409,7 +419,7 @@ describe("ClaimController (e2e)", () => {
                 nameSpace: NameSpaceEnum.Main,
             })
             .expect(200);
-            
+
         expect(response.body?.claims.length).toEqual(3); // Should be 3 instead of 4
     });
 
@@ -424,7 +434,7 @@ describe("ClaimController (e2e)", () => {
      */
     it("/api/claim/hidden/:id (PUT) - Unhide claim", async () => {
         expect(claimId).toBeDefined();
-        
+
         // Unhide the claim
         await request(app.getHttpServer())
             .put(`/api/claim/hidden/${claimId}`)
@@ -434,7 +444,7 @@ describe("ClaimController (e2e)", () => {
                 recaptcha: "valid_recaptcha_token",
             })
             .expect(200);
-            
+
         // Verify claim reappears in public listings
         const response = await request(app.getHttpServer())
             .get("/api/claim")
@@ -447,7 +457,7 @@ describe("ClaimController (e2e)", () => {
                 nameSpace: NameSpaceEnum.Main,
             })
             .expect(200);
-            
+
         expect(response.body?.claims.length).toEqual(4); // Should be back to 4
     });
 

--- a/server/verification-request/verification-request.service.spec.ts
+++ b/server/verification-request/verification-request.service.spec.ts
@@ -10,115 +10,128 @@ import { HistoryService } from "../history/history.service";
 import { AiTaskService } from "../ai-task/ai-task.service";
 import { TopicService } from "../topic/topic.service";
 import {
-  createFakeVerificationRequest,
-  mockQuery,
-  mockVerificationRequestModel,
+    createFakeVerificationRequest,
+    mockQuery,
+    mockVerificationRequestModel,
 } from "../mocks/VerificationRequestMock";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 
 const mockSourceService = {
-  getSourceByHref: vi.fn(),
+    getSourceByHref: vi.fn(),
 };
 
 describe("VerificationRequestService (Unit)", () => {
-  let testingModule: TestingModule;
-  let service: VerificationRequestService;
-  let model: Model<VerificationRequestDocument>;
+    let testingModule: TestingModule;
+    let service: VerificationRequestService;
+    let model: Model<VerificationRequestDocument>;
 
-  beforeAll(async () => {
-    testingModule = await Test.createTestingModule({
-      providers: [
-        VerificationRequestService,
-        {
-          provide: getModelToken("VerificationRequest"),
-          useValue: mockVerificationRequestModel,
-        },
-        {
-          provide: "REQUEST",
-          useValue: { user: { id: "test-user" } },
-        },
-        { provide: VerificationRequestStateMachineService, useValue: {} },
-        { provide: SourceService, useValue: mockSourceService },
-        { provide: GroupService, useValue: {} },
-        { provide: HistoryService, useValue: {} },
-        { provide: AiTaskService, useValue: {} },
-        { provide: TopicService, useValue: {} },
-        { provide: "PersonalityService", useValue: {} },
-      ],
-    }).compile();
+    beforeAll(async () => {
+        testingModule = await Test.createTestingModule({
+            providers: [
+                VerificationRequestService,
+                {
+                    provide: getModelToken("VerificationRequest"),
+                    useValue: mockVerificationRequestModel,
+                },
+                {
+                    provide: "REQUEST",
+                    useValue: { user: { id: "test-user" } },
+                },
+                {
+                    provide: VerificationRequestStateMachineService,
+                    useValue: {},
+                },
+                { provide: SourceService, useValue: mockSourceService },
+                { provide: GroupService, useValue: {} },
+                { provide: HistoryService, useValue: {} },
+                { provide: AiTaskService, useValue: {} },
+                { provide: TopicService, useValue: {} },
+                { provide: PERSONALITY_SERVICE, useValue: {} },
+            ],
+        }).compile();
 
-    model = testingModule.get<Model<VerificationRequestDocument>>(
-      getModelToken("VerificationRequest")
-    );
-  });
-
-  beforeEach(async () => {
-    service = await testingModule.resolve<VerificationRequestService>(
-      VerificationRequestService
-    );
-
-    vi.clearAllMocks();
-  });
-
-  it("should be defined", () => {
-    expect(service).toBeDefined();
-  });
-
-  describe("findBySourceUrl", () => {
-    const fakeSourceId = "507f1f77bcf86cd799439011";
-    const fakeSource = { _id: fakeSourceId, href: "https://example.com/article" };
-
-    it("should return empty array when no matching source exists", async () => {
-      mockSourceService.getSourceByHref.mockResolvedValue(null);
-
-      const result = await service.findBySourceUrl("https://nonexistent.com");
-
-      expect(result).toEqual([]);
-      expect(mockSourceService.getSourceByHref).toHaveBeenCalledWith(
-        "https://nonexistent.com"
-      );
-      expect(mockVerificationRequestModel.find).not.toHaveBeenCalled();
+        model = testingModule.get<Model<VerificationRequestDocument>>(
+            getModelToken("VerificationRequest")
+        );
     });
 
-    it("should return matching verification requests when source is found", async () => {
-      const fakeVRs = [
-        createFakeVerificationRequest({ source: [fakeSourceId] as any }),
-      ];
-      mockSourceService.getSourceByHref.mockResolvedValue(fakeSource);
-      mockQuery.exec.mockResolvedValue(fakeVRs);
+    beforeEach(async () => {
+        service = await testingModule.resolve<VerificationRequestService>(
+            VerificationRequestService
+        );
 
-      const result = await service.findBySourceUrl("https://example.com/article");
-
-      expect(mockSourceService.getSourceByHref).toHaveBeenCalledWith(
-        "https://example.com/article"
-      );
-      expect(mockVerificationRequestModel.find).toHaveBeenCalledWith(
-        { source: fakeSourceId },
-        { embedding: 0 }
-      );
-      expect(mockQuery.sort).toHaveBeenCalledWith({ date: -1 });
-      expect(mockQuery.limit).toHaveBeenCalledWith(10);
-      expect(mockQuery.exec).toHaveBeenCalled();
-      expect(result).toEqual(fakeVRs);
+        vi.clearAllMocks();
     });
 
-    it("should use default pageSize of 10 when not provided", async () => {
-      mockSourceService.getSourceByHref.mockResolvedValue(fakeSource);
-      mockQuery.exec.mockResolvedValue([]);
-
-      await service.findBySourceUrl("https://example.com/article");
-
-      expect(mockQuery.limit).toHaveBeenCalledWith(10);
+    it("should be defined", () => {
+        expect(service).toBeDefined();
     });
 
-    it("should respect custom pageSize option", async () => {
-      mockSourceService.getSourceByHref.mockResolvedValue(fakeSource);
-      mockQuery.exec.mockResolvedValue([]);
+    describe("findBySourceUrl", () => {
+        const fakeSourceId = "507f1f77bcf86cd799439011";
+        const fakeSource = {
+            _id: fakeSourceId,
+            href: "https://example.com/article",
+        };
 
-      await service.findBySourceUrl("https://example.com/article", {
-        pageSize: 5,
-      });
+        it("should return empty array when no matching source exists", async () => {
+            mockSourceService.getSourceByHref.mockResolvedValue(null);
 
-      expect(mockQuery.limit).toHaveBeenCalledWith(5);
+            const result = await service.findBySourceUrl(
+                "https://nonexistent.com"
+            );
+
+            expect(result).toEqual([]);
+            expect(mockSourceService.getSourceByHref).toHaveBeenCalledWith(
+                "https://nonexistent.com"
+            );
+            expect(mockVerificationRequestModel.find).not.toHaveBeenCalled();
+        });
+
+        it("should return matching verification requests when source is found", async () => {
+            const fakeVRs = [
+                createFakeVerificationRequest({
+                    source: [fakeSourceId] as any,
+                }),
+            ];
+            mockSourceService.getSourceByHref.mockResolvedValue(fakeSource);
+            mockQuery.exec.mockResolvedValue(fakeVRs);
+
+            const result = await service.findBySourceUrl(
+                "https://example.com/article"
+            );
+
+            expect(mockSourceService.getSourceByHref).toHaveBeenCalledWith(
+                "https://example.com/article"
+            );
+            expect(mockVerificationRequestModel.find).toHaveBeenCalledWith(
+                { source: fakeSourceId },
+                { embedding: 0 }
+            );
+            expect(mockQuery.sort).toHaveBeenCalledWith({ date: -1 });
+            expect(mockQuery.limit).toHaveBeenCalledWith(10);
+            expect(mockQuery.exec).toHaveBeenCalled();
+            expect(result).toEqual(fakeVRs);
+        });
+
+        it("should use default pageSize of 10 when not provided", async () => {
+            mockSourceService.getSourceByHref.mockResolvedValue(fakeSource);
+            mockQuery.exec.mockResolvedValue([]);
+
+            await service.findBySourceUrl("https://example.com/article");
+
+            expect(mockQuery.limit).toHaveBeenCalledWith(10);
+        });
+
+        it("should respect custom pageSize option", async () => {
+            mockSourceService.getSourceByHref.mockResolvedValue(fakeSource);
+            mockQuery.exec.mockResolvedValue([]);
+
+            await service.findBySourceUrl("https://example.com/article", {
+                pageSize: 5,
+            });
+
+            expect(mockQuery.limit).toHaveBeenCalledWith(5);
+        });
     });
-  });
 });

--- a/server/verification-request/verification-request.service.ts
+++ b/server/verification-request/verification-request.service.ts
@@ -43,6 +43,7 @@ import {
 import * as crypto from "crypto";
 import { TopicService } from "../topic/topic.service";
 import { toError } from "../util/error-handling";
+import { PERSONALITY_SERVICE } from "../interfaces/personality.service.interface";
 import type { IPersonalityService } from "../interfaces/personality.service.interface";
 
 const md5 = require("md5");
@@ -62,7 +63,7 @@ export class VerificationRequestService {
         private readonly historyService: HistoryService,
         private readonly aiTaskService: AiTaskService,
         private readonly topicService: TopicService,
-        @Inject("PersonalityService")
+        @Inject(PERSONALITY_SERVICE)
         private readonly personalityService: IPersonalityService
     ) {}
 
@@ -254,7 +255,10 @@ export class VerificationRequestService {
             return vr;
         } catch (error) {
             const err = toError(error);
-            this.logger.error("Failed to create verification request", err.stack);
+            this.logger.error(
+                "Failed to create verification request",
+                err.stack
+            );
 
             if (err.name === "ValidationError" && err.errors) {
                 const fields = Object.keys(err.errors).join(", ");

--- a/server/verification-request/verification-request.service.ts
+++ b/server/verification-request/verification-request.service.ts
@@ -58,7 +58,7 @@ export class VerificationRequestService {
         private readonly VerificationRequestModel: Model<VerificationRequestDocument>,
         @Inject(forwardRef(() => VerificationRequestStateMachineService))
         private readonly verificationRequestStateService: VerificationRequestStateMachineService,
-        private sourceService: SourceService,
+        private readonly sourceService: SourceService,
         private readonly groupService: GroupService,
         private readonly historyService: HistoryService,
         private readonly aiTaskService: AiTaskService,


### PR DESCRIPTION
# Description

Refactors the `personality` module toward a clean port/adapter shape so the persistence layer can be swapped without touching consumers. No behavior change — pure structural and type tightening.

**Key changes:**

- **DI token** — introduces `PERSONALITY_SERVICE` (`"PersonalityService"`) and replaces the magic string across all 9 consumers (controllers, services, tests). Token value is unchanged, so wiring stays backward compatible.
- **Port tightening** — `IPersonalityService` moves off `any` to Zod-derived input types (`IPersonalityCreateInput`, `IPersonalityUpdateInput`, `IPersonalityListQuery`, `IPersonalityGetByIdOptions`, `IPersonalityFindOrCreateInput`). Dead port methods removed; Wikidata/postProcess/verifyInputsQuery helpers made `private`.
- **Mappers** — new `personality/dto/mappers.ts` converts controller DTOs into port-aligned inputs, keeping the controller boundary explicit.
- **`listAll` signature** — collapses 7 positional args into a single typed query object; callers (`combinedListAll`, `sitemap`) updated accordingly.
- **Build-time conformance** — an assignability assertion at the bottom of `MongoPersonalityService` fails the build if the implementation drifts from `IPersonalityService`.
- **SonarCloud cleanup** — removed the `void` operator flagged as a CRITICAL code smell (S3735) on the conformance assertion.

# Type of change

- [x] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing

No functional change expected. Verify:

- `yarn build-ts` and `yarn lint` pass.
- Personality endpoints behave unchanged: list (`GET /api/personality`), create, update, hide/unhide, delete.
- Home page live debates, sitemap generation, search, and stats still resolve personalities.
- Existing unit and e2e suites pass (personality, claim, management, verification-request).

# Notes / follow-ups

- Zod is currently type-only in this module (schemas define inferred types but are not parsed at runtime). Follow-up: migrate the controller inputs to Zod + `ZodValidationPipe` per project guidance, which would validate at the boundary and let the mappers collapse into pure type maps.
- Pre-existing latent bug preserved intentionally in `listAll` name-search (`$or` branch matches a literal `query` field). Out of scope for this refactor; to be fixed separately.
