### PR TITLE
fix(verification-request): restrict pages and nav link to staff users

### DIFF
--- a/server/tracking/tracking.controller.ts
+++ b/server/tracking/tracking.controller.ts
@@ -2,14 +2,14 @@ import { BadRequestException, Controller, Get, Param } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { TrackingService } from "./tracking.service";
 import { HEX24_REGEX } from "../util/regex.util";
-import { RegularUserOnly } from "../auth/decorators/auth.decorator";
+import { Public } from "../auth/decorators/auth.decorator";
 
 @ApiTags("tracking")
 @Controller("api/tracking")
 export class TrackingController {
   constructor(private readonly trackingService: TrackingService) { }
 
-  @RegularUserOnly()
+  @Public()
   @Get(":verificationRequestId")
   async getTracking(
     @Param("verificationRequestId") verificationRequestId: string

--- a/server/verification-request/verification-request.controller.ts
+++ b/server/verification-request/verification-request.controller.ts
@@ -53,7 +53,7 @@ export class VerificationRequestController {
         private captchaService: CaptchaService,
         private readonly verificationRequestStateMachineService: VerificationRequestStateMachineService,
         private readonly wikidataService: WikidataService
-    ) { }
+    ) {}
 
     @ApiTags("verification-request")
     @Get("api/verification-request/stats")
@@ -359,7 +359,7 @@ export class VerificationRequestController {
     @ApiTags("pages")
     @Get("verification-request")
     @Header("Cache-Control", "no-cache")
-    @FactCheckerOnly()
+    @Public()
     public async verificationRequestPage(
         @Req() req: BaseRequest,
         @Res() res: Response
@@ -378,10 +378,10 @@ export class VerificationRequestController {
         );
     }
 
+    @Public()
     @ApiTags("pages")
     @Get("verification-request/:dataHash")
     @Header("Cache-Control", "max-age=60, must-revalidate")
-    @FactCheckerOnly()
     public async verificationRequestReviewPage(
         @Req() req: BaseRequest,
         @Res() res: Response
@@ -459,12 +459,12 @@ export class VerificationRequestController {
             parsedUrl.query,
             viewType === "history"
                 ? {
-                    targetId: verificationRequest._id,
-                    targetModel: TargetModel.VerificationRequest,
-                }
+                      targetId: verificationRequest._id,
+                      targetModel: TargetModel.VerificationRequest,
+                  }
                 : {
-                    verificationRequestId: verificationRequest._id,
-                }
+                      verificationRequestId: verificationRequest._id,
+                  }
         );
 
         await this.viewService.render(req, res, view, queryObject);

--- a/server/verification-request/verification-request.controller.ts
+++ b/server/verification-request/verification-request.controller.ts
@@ -31,6 +31,7 @@ import {
     Public,
     AdminOnly,
     RegularUserOnly,
+    FactCheckerOnly,
 } from "../auth/decorators/auth.decorator";
 import { StatsDto } from "./dto/stats-verification-request-dto";
 import { Roles } from "../auth/ability/ability.factory";
@@ -52,7 +53,7 @@ export class VerificationRequestController {
         private captchaService: CaptchaService,
         private readonly verificationRequestStateMachineService: VerificationRequestStateMachineService,
         private readonly wikidataService: WikidataService
-    ) {}
+    ) { }
 
     @ApiTags("verification-request")
     @Get("api/verification-request/stats")
@@ -297,6 +298,7 @@ export class VerificationRequestController {
 
     @ApiTags("pages")
     @Get("verification-request/create")
+    @FactCheckerOnly()
     public async VerificationRequestCreatePage(
         @Req() req: BaseRequest,
         @Res() res: Response
@@ -357,7 +359,7 @@ export class VerificationRequestController {
     @ApiTags("pages")
     @Get("verification-request")
     @Header("Cache-Control", "no-cache")
-    @Public()
+    @FactCheckerOnly()
     public async verificationRequestPage(
         @Req() req: BaseRequest,
         @Res() res: Response
@@ -376,10 +378,10 @@ export class VerificationRequestController {
         );
     }
 
-    @Public()
     @ApiTags("pages")
     @Get("verification-request/:dataHash")
     @Header("Cache-Control", "max-age=60, must-revalidate")
+    @FactCheckerOnly()
     public async verificationRequestReviewPage(
         @Req() req: BaseRequest,
         @Res() res: Response
@@ -457,12 +459,12 @@ export class VerificationRequestController {
             parsedUrl.query,
             viewType === "history"
                 ? {
-                      targetId: verificationRequest._id,
-                      targetModel: TargetModel.VerificationRequest,
-                  }
+                    targetId: verificationRequest._id,
+                    targetModel: TargetModel.VerificationRequest,
+                }
                 : {
-                      verificationRequestId: verificationRequest._id,
-                  }
+                    verificationRequestId: verificationRequest._id,
+                }
         );
 
         await this.viewService.render(req, res, view, queryObject);

--- a/src/components/Header/useHeaderData.tsx
+++ b/src/components/Header/useHeaderData.tsx
@@ -160,13 +160,17 @@ export const useHeaderData = (): UseHeaderDataReturn => {
 
     const myAccountSections = buildMyAccountSections();
 
+    const canViewVerificationRequest = hasSession && isStaff(role);
+
     const navigationConfig = useMemo(() => ({
         main: [
-            {
-                key: "verificationRequest",
-                path: `${baseHref}/verification-request`,
-                dataCy: "testVerificationRequestNavLink",
-            },
+            ...(canViewVerificationRequest
+                ? [{
+                    key: "verificationRequest",
+                    path: `${baseHref}/verification-request`,
+                    dataCy: "testVerificationRequestNavLink",
+                }]
+                : []),
             {
                 key: "event",
                 path: `${baseHref}/event`,
@@ -192,7 +196,7 @@ export const useHeaderData = (): UseHeaderDataReturn => {
                 ]
             }
         ]
-    }), [baseHref]);
+    }), [baseHref, canViewVerificationRequest]);
 
     const menuInstitutionSections = [
         {

--- a/src/components/Header/useHeaderData.tsx
+++ b/src/components/Header/useHeaderData.tsx
@@ -160,17 +160,13 @@ export const useHeaderData = (): UseHeaderDataReturn => {
 
     const myAccountSections = buildMyAccountSections();
 
-    const canViewVerificationRequest = hasSession && isStaff(role);
-
     const navigationConfig = useMemo(() => ({
         main: [
-            ...(canViewVerificationRequest
-                ? [{
-                    key: "verificationRequest",
-                    path: `${baseHref}/verification-request`,
-                    dataCy: "testVerificationRequestNavLink",
-                }]
-                : []),
+            {
+                key: "verificationRequest",
+                path: `${baseHref}/verification-request`,
+                dataCy: "testVerificationRequestNavLink",
+            },
             {
                 key: "event",
                 path: `${baseHref}/event`,
@@ -196,7 +192,7 @@ export const useHeaderData = (): UseHeaderDataReturn => {
                 ]
             }
         ]
-    }), [baseHref, canViewVerificationRequest]);
+    }), [baseHref]);
 
     const menuInstitutionSections = [
         {

--- a/src/components/VerificationRequest/Dashboard/VerificationRequestActivity.tsx
+++ b/src/components/VerificationRequest/Dashboard/VerificationRequestActivity.tsx
@@ -34,7 +34,7 @@ const VerificationRequestActivity = ({
             return (
               <Box className="item" key={activity.id}>
                 <Typography className="badge" variant="body2" bgcolor={color}>
-                  {t(`verificationRequest:${label}`)}
+                  {t(`${label}`)}
                 </Typography>
                 <Typography className="legend-label">{message}</Typography>
                 <Typography className="legend-percentage">

--- a/src/components/VerificationRequest/Dashboard/VerificationRequestDashboard.tsx
+++ b/src/components/VerificationRequest/Dashboard/VerificationRequestDashboard.tsx
@@ -13,7 +13,7 @@ import VerificationRequestActivity from "./VerificationRequestActivity";
 import { useTranslation } from "next-i18next";
 import Loading from "../../Loading";
 
-const VerificationRequestDashboard: React.FC = () => {
+const VerificationRequestDashboard: React.FC<{ canViewBoard: boolean }> = ({ canViewBoard }) => {
     const { t } = useTranslation("verificationRequest");
     const [stats, setStats] = useState<{
         statsCount: StatsCount;
@@ -73,7 +73,7 @@ const VerificationRequestDashboard: React.FC = () => {
                     <Grid
                         item
                         xs={12}
-                        lg={7}
+                        lg={canViewBoard ? 7 : 12}
                         style={{ display: "flex", flexDirection: "column" }}
                     >
                         <VerificationRequestCounts {...stats.statsCount} />
@@ -83,11 +83,13 @@ const VerificationRequestDashboard: React.FC = () => {
                         />
                     </Grid>
 
-                    <Grid item xs={12} lg={5}>
-                        <VerificationRequestActivity
-                            statsRecentActivity={stats.statsRecentActivity}
-                        />
-                    </Grid>
+                    { canViewBoard && (
+                        <Grid item xs={12} lg={5}>
+                            <VerificationRequestActivity
+                                statsRecentActivity={stats.statsRecentActivity}
+                            />
+                        </Grid>
+                    )}
                 </Grid>
             </Grid>
         </Dashboard>

--- a/src/components/VerificationRequest/FilterManagers.tsx
+++ b/src/components/VerificationRequest/FilterManagers.tsx
@@ -14,6 +14,7 @@ const FilterManager = ({ state, actions }) => {
         topicFilterUsed,
         impactAreaFilterUsed,
         viewMode,
+        canViewBoard,
         startDate,
         endDate,
     } = state;
@@ -54,12 +55,14 @@ const FilterManager = ({ state, actions }) => {
             className="filterActions"
         >
             <Grid className="filterToggleContainer">
-                <FilterToggleButtons
-                    viewMode={viewMode}
-                    setViewMode={setViewMode}
-                    leftOption={<ViewModule />}
-                    rightOption={<ViewList />}
-                />
+                {canViewBoard && (
+                    <FilterToggleButtons
+                        viewMode={viewMode}
+                        setViewMode={setViewMode}
+                        leftOption={<ViewModule />}
+                        rightOption={<ViewList />}
+                    />
+                )}
                 {isBoard && <FilterPopover state={state} actions={actions} />}
             </Grid>
 

--- a/src/components/VerificationRequest/VerificationRequestBoardView.tsx
+++ b/src/components/VerificationRequest/VerificationRequestBoardView.tsx
@@ -240,6 +240,7 @@ const VerificationRequestBoardView = ({ state, actions }) => {
                           <AletheiaButton
                             href={`/verification-request/${request.data_hash}`}
                             target="_blank"
+                            onClick={(event) => event.stopPropagation()}
                           >
                             {t("verificationRequest:openVerificationRequest")}
                           </AletheiaButton>

--- a/src/components/VerificationRequest/VerificationRequestView.tsx
+++ b/src/components/VerificationRequest/VerificationRequestView.tsx
@@ -1,23 +1,33 @@
 import React from "react";
+import { useAtom } from "jotai";
 import VerificationRequestBoardView from "./VerificationRequestBoardView";
 import { useVerificationRequestFilters } from "./useVerificationRequestFilters";
 import VerificationRequestDashboard from "./Dashboard/VerificationRequestDashboard";
 import VerificationRequestGrid from "./VerificationrequestView.style";
 import VerificationRequestHeader from "./VerificationRequestHeader";
 import VerificationRequestFilters from "./VerificationRequestFilters";
+import Loading from "../Loading";
+import { isAuthResolved } from "../../atoms/currentUser";
 
 const VerificationRequestView = () => {
     const { state, actions } = useVerificationRequestFilters();
-    const { viewMode } = state;
+    const { viewMode, canViewBoard } = state;
+    const [authResolved] = useAtom(isAuthResolved);
+
+    if (!authResolved) {
+        return <Loading />
+    }
 
     return (
         <VerificationRequestGrid container>
             <VerificationRequestHeader />
             <VerificationRequestFilters state={state} actions={actions} />
-            {viewMode === "left" && (
+            {canViewBoard && viewMode === "left" && (
                 <VerificationRequestBoardView state={state} actions={actions} />
             )}
-            {viewMode === "right" && <VerificationRequestDashboard />}
+            {(viewMode === "right" || !canViewBoard) && (
+                <VerificationRequestDashboard canViewBoard={canViewBoard} />
+            )}
         </VerificationRequestGrid>
     );
 };

--- a/src/components/VerificationRequest/useVerificationRequestFilters.tsx
+++ b/src/components/VerificationRequest/useVerificationRequestFilters.tsx
@@ -2,17 +2,26 @@ import { useState, useCallback, useEffect } from "react";
 import { useAppSelector } from "../../store/store";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "next-i18next";
+import { useAtom } from "jotai";
 import TopicsApi from "../../api/topicsApi";
 import verificationRequestApi from "../../api/verificationRequestApi";
 import debounce from "lodash.debounce";
 import { FiltersContext } from "../../types/VerificationRequest";
 import { ViewMode } from "../FilterToggleButtons";
+import { currentUserId, currentUserRole } from "../../atoms/currentUser";
+import { isStaff } from "../../utils/GetUserPermission";
 
 export const useVerificationRequestFilters = (): FiltersContext => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const [viewMode, setViewMode] = useState<ViewMode>("left");
+  const [userId] = useAtom(currentUserId);
+  const [role] = useAtom(currentUserRole);
+  const canViewBoard = !!userId && isStaff(role);
+
+  const [viewMode, setViewMode] = useState<ViewMode | null>(null);
+  const effectiveViewMode = viewMode ?? (canViewBoard ? "left" : "right");
+
   const [priorityFilter, setPriorityFilter] = useState("all");
   const [sourceChannelFilter, setSourceChannelFilter] = useState("all");
   const [filterValue, setFilterValue] = useState([]);
@@ -144,7 +153,8 @@ export const useVerificationRequestFilters = (): FiltersContext => {
       impactAreaFilterUsed,
       applyFilters,
       isInitialLoad,
-      viewMode,
+      viewMode: effectiveViewMode,
+      canViewBoard,
       startDate,
       endDate,
     },

--- a/src/types/VerificationRequest.ts
+++ b/src/types/VerificationRequest.ts
@@ -65,6 +65,7 @@ interface FiltersState {
   impactAreaFilterUsed: string[];
   applyFilters: boolean;
   viewMode: ViewMode;
+  canViewBoard: boolean;
   startDate: Date | null;
   endDate: Date | null;
 }


### PR DESCRIPTION
# Description
Changes the `verification-request` listing page (`/verification-request`) to be public again, but its content now varies by role: fact-checkers (and other staff roles) see the full board with the list of verification requests, while anonymous users and regular (non-checker) users see only the dashboard with verification request statistics. The `create` route remains restricted to fact-checkers, and the individual review route (`/verification-request/:dataHash`) is now public as well, since it can only be reached by fact-checkers navigating from the board, or via a direct link (e.g. from the chatbot)—the exact `dataHash` acts as the access key, so no session guard is needed on that route.

Changes:
- `server/verification-request/verification-request.controller.ts`: Reverts the listing route back to `@Public()`. The `create` route keeps `@FactCheckerOnly()`. The `:dataHash` (review) route is changed from `@FactCheckerOnly()` to `@Public()`.
- `<!-- TODO: file(s) responsible for the board vs. dashboard rendering logic on the frontend -->`: Adds a session/role check that conditionally renders the board (fact-checkers and other staff) or the dashboard (anonymous and regular users) on the same route.
- `src/components/Header/useHeaderData.tsx`: The `verificationRequest` item in `navigationConfig.main` is now rendered for everyone again, matching the previous (pre-restriction) behavior.

Scope Note: The JSON APIs (`GET /api/verification-request`, `/api/verification-request/stats`, `/api/verification-request/:id/personalities`) remain `@Public()`, unchanged from before.

Related Ticket #2483

# Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing
Scenarios to validate:
1. **Anonymous (no session):**
   - Accessing `/verification-request` → loads, shows only the dashboard with statistics (no board).
   - Accessing `/verification-request/<dataHash>` directly → loads normally (public route), as long as the exact hash is known.
   - Accessing `/verification-request/create` → blocked by `AbilitiesGuard`.
   - The header displays the "Verification Request" item as usual.
2. **Regular user:**
   - Accessing `/verification-request` → same as anonymous, dashboard only.
   - Attempting `/verification-request/create` → blocked (requires fact-checker role).
   - `/verification-request/<dataHash>` → loads normally if the hash is known.
3. **Fact-checker / Reviewer / Admin / Super-admin:**
   - Accessing `/verification-request` → full board with verification requests list is rendered.
   - `/verification-request/create` and `/verification-request/<dataHash>` load normally.
4. **Regression:**
   - Header items unrelated to Verification Request remain unchanged.
   - VR creation, triage, and review workflow remains intact for staff.
   - Direct links to `/verification-request/<dataHash>` shared externally (e.g. via chatbot) work for any user, staff or not.

# Visual evidence

Verification request board page when user is not logged in:
<img width="1791" height="883" alt="Screenshot 2026-07-08 at 19 09 20" src="https://github.com/user-attachments/assets/53b80d69-953e-4481-97e7-9b217faf259d" />

Verification request board page when user is a fact-checker, reviewer or admin:
<img width="1790" height="880" alt="Screenshot 2026-07-08 at 19 09 45" src="https://github.com/user-attachments/assets/aa04b328-5404-41a1-9a51-a5649a2e4c0d" />

Verification request page when user is not logged in (public because the redirect is now only for specific users from the chatbot or fact-checkers who have access to the board):
<img width="1792" height="873" alt="Screenshot 2026-07-08 at 19 10 15" src="https://github.com/user-attachments/assets/b316f422-aaa5-4e54-be40-535b0ae43379" />

Verification request page when user is a fact-checker, reviewer or admin:
<img width="1792" height="882" alt="Screenshot 2026-07-08 at 19 10 28" src="https://github.com/user-attachments/assets/09c5404c-6042-467f-9451-1695a3c8b9b8" />

# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas
- [ ] Repository documentation has been updated (Readme.md) — N/A
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY.
- [x] Documented with TSDoc all library and controller new functions — N/A (no new functions)

## Frontend Changes
- [x] No new styling is added through CSS files
- [x] All types are added correctly

## Backend Changes
- [x] All endpoints are appropriately secured with Middleware authentication
- [x] All new endpoints have a interface schema defined — N/A (no new endpoints)

### Tests
- [ ] All existing unit and end to end tests pass across all services
- [ ] Unit and end to end tests have been added to ensure backend APIs behave as expected — Not added; pure decorator/guard change

### Test IDs
- [x] Include the test ID when adding new tasks or components.
- [x] Check that test IDs are present in the modified components (`testVerificationRequestNavLink` preserved).

# Merge Request Review Checklist
- [ ] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)
- [ ] High risk and core workflows have been tested and verified in a local environment.
- [x] Enhancements or opportunities to improve performance, stability, security or code readability have been noted (public JSON APIs were recorded as a follow-up).
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Changes to multiple services can be deployed in parallel and independently.