### PR TITLE
perf(review-task): add compound index for listing aggregation

### DIFF
--- a/migrations/20260702120000-add-listing-index-on-reviewtasks.ts
+++ b/migrations/20260702120000-add-listing-index-on-reviewtasks.ts
@@ -1,0 +1,45 @@
+import { Db } from "mongodb";
+
+/**
+ * The review-task listing aggregation (ReviewTaskService.listAll) starts with:
+ *
+ *   { $match: { "machine.value": <value>, reviewTaskType: <type>, nameSpace: <ns> } }
+ *   ... $lookup x4 ...
+ *   { $sort: { _id: -1 } }, { $skip }, { $limit }
+ *
+ * With no supporting index this runs a COLLSCAN over the whole `reviewtasks`
+ * collection (~494k docs examined to return 10) plus a blocking in-memory sort.
+ *
+ * This compound index follows the ESR rule (Equality → Sort → Range):
+ *  - reviewTaskType / nameSpace: always equality across every listing shape.
+ *  - machine.value: equality for plain states (e.g. "published"), $in for
+ *    "cross-checking"; placed right before the sort key.
+ *  - _id: the sort key (descending), so the index also satisfies the $sort and
+ *    eliminates the blocking sort. Reverse traversal covers the "asc" case too.
+ *
+ * Result: bounded index scan + index-provided sort instead of COLLSCAN + sort.
+ */
+const INDEX_KEY = {
+    reviewTaskType: 1,
+    nameSpace: 1,
+    "machine.value": 1,
+    _id: -1,
+} as const;
+
+const INDEX_NAME = "reviewTaskType_1_nameSpace_1_machine.value_1__id_-1";
+
+export async function up(db: Db) {
+    const collection = db.collection("reviewtasks");
+    await collection.createIndex(INDEX_KEY, { name: INDEX_NAME });
+    console.log(`  - reviewtasks: created index ${INDEX_NAME}`);
+}
+
+export async function down(db: Db) {
+    const collection = db.collection("reviewtasks");
+    try {
+        await collection.dropIndex(INDEX_NAME);
+        console.log(`  - reviewtasks: dropped index ${INDEX_NAME}`);
+    } catch (error) {
+        console.log(`  - reviewtasks: index ${INDEX_NAME} not found, skipping`);
+    }
+}


### PR DESCRIPTION
## Problem

The review-task listing aggregation (`ReviewTaskService.listAll`) is slow in production. A representative query (`machine.value: "published"`, `reviewTaskType: "Claim"`, `nameSpace: "main"`, page size 10) shows:

| Signal | Value |
|---|---|
| `planSummary` | `COLLSCAN` |
| `docsExamined` | `493,892` |
| `nreturned` | `10` |
| `hasSortStage` | `true` (blocking in-memory sort) |
| `durationMillis` | `825` |

The pipeline opens with a `$match` on `{ machine.value, reviewTaskType, nameSpace }` and later `$sort: { _id: -1 }`. The `reviewtasks` collection has no index covering these fields (only `_id` and unique `data_hash`), so Mongo scans the entire collection and sorts survivors in memory.

## Fix

Add a compound index following the ESR rule (Equality → Sort → Range):

```js
{ reviewTaskType: 1, nameSpace: 1, "machine.value": 1, _id: -1 }
```

- `reviewTaskType` + `nameSpace` — always equality in every listing shape → reusable prefix.
- `machine.value` — equality for plain states (`"published"`), `$in` for `"cross-checking"`; sits right before the sort key.
- `_id: -1` — lets the index satisfy the `$sort`, removing the blocking sort. Reverse traversal covers the `order: "asc"` case.

This turns the COLLSCAN + in-memory sort into a bounded, pre-sorted index scan.

## Testing

1. Run `yarn migrate` (MongoDB 8.0 builds the index without a long exclusive lock — safe on the live collection).
2. Re-run the listing aggregation with `.explain("executionStats")` and confirm:
   - `IXSCAN` instead of `COLLSCAN`
   - `totalDocsExamined` near the page size
   - `hasSortStage: false`
3. Rollback available via `yarn migrate down` (drops the index).

## Notes

- The post-lookup `$match` on `isDeleted` prevents pushing `$limit` before the `$lookup`s, but the index fixes the dominant cost (COLLSCAN + sort); docs now stream in `_id` order so the limit short-circuits early.
- The `$exists` query branch (`machine.value.<state>`) targets a different field path and is out of scope for this index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)