### PR TITLE
perf(claim-review): add data_hash index for review-task listing lookup

### DIFF
--- a/migrations/20260704120000-add-data-hash-index-on-claimreviews.ts
+++ b/migrations/20260704120000-add-data-hash-index-on-claimreviews.ts
@@ -1,0 +1,44 @@
+import { Db } from "mongodb";
+
+/**
+ * The review-task "published" listing aggregation (ReviewTaskService.listAll,
+ * via _verifyMachineValueAndAddMatchPipeline) joins each matched review task to
+ * its claim review:
+ *
+ *   { $lookup: {
+ *       from: "claimreviews",
+ *       localField: "data_hash",
+ *       foreignField: "data_hash",
+ *       as: "machine.context.claimReview.claimReview",
+ *   } }
+ *
+ * `claimreviews.data_hash` has no index, so this equality join runs a COLLSCAN
+ * of the whole `claimreviews` collection for every review task in the stream.
+ * With ~396 published tasks matched and ~1.2k claim reviews, that is ~494k docs
+ * examined to return 10 rows (the dominant cost of the ~718ms query), even
+ * though the reviewtasks $match itself is already a bounded index scan.
+ *
+ * A plain (non-unique) index on data_hash turns the per-row COLLSCAN into an
+ * indexed nested-loop join. The field is intentionally non-unique: multiple
+ * claim reviews can share the same data_hash (see ClaimReviewService grouping
+ * by data_hash + classification and getReviewByDataHash lookups).
+ */
+const INDEX_KEY = { data_hash: 1 } as const;
+
+const INDEX_NAME = "data_hash_1";
+
+export async function up(db: Db) {
+    const collection = db.collection("claimreviews");
+    await collection.createIndex(INDEX_KEY, { name: INDEX_NAME });
+    console.log(`  - claimreviews: created index ${INDEX_NAME}`);
+}
+
+export async function down(db: Db) {
+    const collection = db.collection("claimreviews");
+    try {
+        await collection.dropIndex(INDEX_NAME);
+        console.log(`  - claimreviews: dropped index ${INDEX_NAME}`);
+    } catch (error) {
+        console.log(`  - claimreviews: index ${INDEX_NAME} not found, skipping`);
+    }
+}


### PR DESCRIPTION
# Description

Follow-up to #2486. That PR fixed the *initial* stage of the review-task "published" listing (`ReviewTaskService.listAll`), turning the opening COLLSCAN + in-memory sort into a bounded index scan. But the query was still slow — profiling showed **493,614 docs examined to return 10 rows (~718ms)** even though `keysExamined` was only 396.

The remaining cost is the `$lookup` into `claimreviews` on `data_hash` (`server/review-task/review-task.service.ts`):

```js
$lookup {
  from: "claimreviews",
  localField: "data_hash",
  foreignField: "data_hash",
  as: "machine.context.claimReview.claimReview",
}
```

`claimreviews.data_hash` had **no index**, so this equality join ran a full collection scan of `claimreviews` for *every* review task in the stream:

```
~396 matched review tasks × ~1,246 claim reviews ≈ 493,614 docs examined
```

Every other lookup in the pipeline (`users`, `personalities`, `claims`, `claimrevisions`) joins on `_id`, which is already indexed — so this one unindexed join was the entire remaining cost.

This PR adds a plain **non-unique** index `{ data_hash: 1 }` on `claimreviews`, turning the per-row COLLSCAN into an indexed nested-loop join. Non-unique is intentional: multiple claim reviews can share the same `data_hash` (`ClaimReviewService` groups by `data_hash` + classification).

**Expected impact:** `docsExamined` drops from ~494k to roughly the number of matched tasks (a few hundred); query time should fall from ~718ms to the low tens of ms.

Related Ticket # (issue): _n/a_

# Type of change

- [x] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing

- Run `yarn migrate` to create the index, then `yarn migrate:status` to confirm it applied.
- Re-run the `reviewtasks` "published" listing (Claim, `main` namespace) and confirm via `explain`/profiler that `docsExamined` is now in the hundreds rather than ~494k, and the `claimreviews` lookup uses the new index.
- `yarn migrate:down` cleanly drops the index (`data_hash_1`).

Migration only — no application code or API changes.

# Notes for reviewer

- Purely additive index migration (`migrations/20260704120000-add-data-hash-index-on-claimreviews.ts`); mirrors the structure of the #2486 migration.
- Follow-up opportunity (not in scope here): the pipeline still hydrates all matched tasks through the lookups before `$skip`/`$limit`. That is cheap at a few hundred rows, but if published Claim tasks grow into the tens of thousands, moving `$sort`/`$skip`/`$limit` ahead of the lookups (complicated by the post-lookup `isDeleted` filters) would be the next optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)