### PR TITLE
feat(copilot): disclose partial search failures deterministically

### DIFF
--- a/docs/superpowers/plans/2026-07-04-copilot-partial-failure-disclosure.md
+++ b/docs/superpowers/plans/2026-07-04-copilot-partial-failure-disclosure.md
@@ -1,0 +1,503 @@
+# Copilot Partial-Failure Disclosure (Gap A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee the copilot discloses when one of multiple requested fact-check searches (online / gazettes) fails, instead of silently presenting only the surviving search.
+
+**Architecture:** A new pure, dependency-free util module (`copilot-disclosure.util.ts`) owns the `SearchType` enum plus outcome-tracking and disclosure-composition logic. `copilot-chat.service.ts` records each tool invocation's outcome in a shared ref (reusing the existing `editorReportRef`/`executionIdRef` pattern) and, after the agent run, deterministically prepends a user-safe disclosure block to the LLM output before persisting and returning it. Disclosure becomes a code guarantee, not an LLM behavior.
+
+**Tech Stack:** TypeScript, NestJS, LangChain tool-calling agent, Vitest (globals enabled, unit project globs `server/**/*.spec.ts`).
+
+---
+
+## Context for the implementer
+
+- Working directory: `/Users/mbsantos/workspace/aletheia_fact/aletheia`
+- Branch: `feat/copilot-partial-failure-disclosure` (already created off `origin/stage`)
+- Spec: `docs/superpowers/specs/2026-07-04-copilot-partial-failure-disclosure-design.md`
+- Run a single unit test file: `yarn test:unit server/copilot/copilot-disclosure.util.spec.ts`
+- Typecheck: `yarn lint` (runs `tsc --noEmit` then eslint). For a faster type-only check use `npx tsc --noEmit`.
+- Vitest has `globals: true` — do NOT import `describe`/`it`/`expect`; they are global (matches `server/editor-parse/editor-parse.service.spec.ts`).
+
+### File structure
+
+- **Create** `server/copilot/copilot-disclosure.util.ts` — owns `SearchType`, `SearchOutcome`, and the pure disclosure functions. Single responsibility: turn a list of search outcomes into a user-safe, localized disclosure string. No Nest/LangChain imports.
+- **Create** `server/copilot/copilot-disclosure.util.spec.ts` — unit tests for the util.
+- **Modify** `server/copilot/copilot-chat.service.ts` — import `SearchType` from the util (remove the local enum), track outcomes via a shared ref, sanitize the failed-leg tool observation, and apply the disclosure to the final content.
+
+---
+
+## Task 1: Pure disclosure util (TDD)
+
+**Files:**
+- Create: `server/copilot/copilot-disclosure.util.ts`
+- Test: `server/copilot/copilot-disclosure.util.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/copilot/copilot-disclosure.util.spec.ts`:
+
+```typescript
+import {
+    SearchType,
+    SearchOutcome,
+    summarizeOutcomes,
+    buildFailureDisclosure,
+    applyFailureDisclosure,
+} from "./copilot-disclosure.util";
+
+describe("copilot-disclosure.util", () => {
+    describe("summarizeOutcomes", () => {
+        it("collapses repeated searchType last-write-wins (failed then ok → ok)", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.online, status: "ok" },
+            ];
+            expect(summarizeOutcomes(outcomes)).toEqual([
+                { searchType: SearchType.online, status: "ok" },
+            ]);
+        });
+
+        it("collapses repeated searchType last-write-wins (ok then failed → failed)", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.gazettes, status: "ok" },
+                { searchType: SearchType.gazettes, status: "failed" },
+            ];
+            expect(summarizeOutcomes(outcomes)).toEqual([
+                { searchType: SearchType.gazettes, status: "failed" },
+            ]);
+        });
+    });
+
+    describe("buildFailureDisclosure", () => {
+        it("returns empty string when nothing failed", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "ok" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            expect(buildFailureDisclosure(outcomes, "Portuguese")).toBe("");
+        });
+
+        it("returns empty string for empty outcomes", () => {
+            expect(buildFailureDisclosure([], "Portuguese")).toBe("");
+        });
+
+        it("discloses failed online leg + retry offer when gazettes succeeded (pt)", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const msg = buildFailureDisclosure(outcomes, "Portuguese");
+            expect(msg).toContain("busca online");
+            expect(msg).toContain("diários oficiais");
+            expect(msg.toLowerCase()).toContain("novamente");
+        });
+
+        it("discloses in English when language is English", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const msg = buildFailureDisclosure(outcomes, "English");
+            expect(msg).toContain("online search");
+            expect(msg).toContain("public gazette search");
+            expect(msg.toLowerCase()).toContain("retry");
+        });
+
+        it("states all searches failed when none succeeded", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+            ];
+            const msg = buildFailureDisclosure(outcomes, "Portuguese");
+            expect(msg.toLowerCase()).toContain("nenhuma");
+            expect(msg).toContain("busca online");
+        });
+    });
+
+    describe("applyFailureDisclosure", () => {
+        it("prepends disclosure above the output when a leg failed", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const result = applyFailureDisclosure(
+                "Resultado dos diários oficiais...",
+                outcomes,
+                "Portuguese"
+            );
+            expect(result.startsWith("⚠️")).toBe(true);
+            expect(result).toContain("Resultado dos diários oficiais...");
+        });
+
+        it("returns output unchanged when nothing failed", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const output = "Resultado...";
+            expect(applyFailureDisclosure(output, outcomes, "Portuguese")).toBe(
+                output
+            );
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test:unit server/copilot/copilot-disclosure.util.spec.ts`
+Expected: FAIL — cannot resolve `./copilot-disclosure.util` (module does not exist yet).
+
+- [ ] **Step 3: Implement the util**
+
+Create `server/copilot/copilot-disclosure.util.ts`:
+
+```typescript
+/**
+ * Pure, dependency-free helpers for disclosing partial fact-check search
+ * failures to the user. Owns the SearchType enum so this module has no
+ * dependency on the copilot service (one-way: service → util).
+ */
+
+export enum SearchType {
+    online = "online",
+    gazettes = "gazettes",
+}
+
+export type SearchStatus = "ok" | "failed";
+
+export interface SearchOutcome {
+    searchType: SearchType;
+    status: SearchStatus;
+}
+
+const SEARCH_LABELS: Record<
+    SearchType,
+    { Portuguese: string; English: string }
+> = {
+    [SearchType.online]: {
+        Portuguese: "busca online",
+        English: "online search",
+    },
+    [SearchType.gazettes]: {
+        Portuguese: "busca nos diários oficiais",
+        English: "public gazette search",
+    },
+};
+
+function label(searchType: SearchType, language: string): string {
+    const entry = SEARCH_LABELS[searchType];
+    return language === "Portuguese" ? entry.Portuguese : entry.English;
+}
+
+function joinList(items: string[], language: string): string {
+    if (items.length <= 1) {
+        return items[0] ?? "";
+    }
+    const conjunction = language === "Portuguese" ? " e " : " and ";
+    return (
+        items.slice(0, -1).join(", ") + conjunction + items[items.length - 1]
+    );
+}
+
+/**
+ * Collapse repeated calls per searchType (last-write-wins), so an LLM retry
+ * of a failed leg that later succeeds does not leave a false "failed" outcome.
+ */
+export function summarizeOutcomes(outcomes: SearchOutcome[]): SearchOutcome[] {
+    const byType = new Map<SearchType, SearchStatus>();
+    for (const outcome of outcomes) {
+        byType.set(outcome.searchType, outcome.status);
+    }
+    return Array.from(byType.entries()).map(([searchType, status]) => ({
+        searchType,
+        status,
+    }));
+}
+
+/**
+ * "" when nothing failed; otherwise a user-safe, localized disclosure block.
+ * Never contains raw error text or tracebacks.
+ */
+export function buildFailureDisclosure(
+    outcomes: SearchOutcome[],
+    language: string
+): string {
+    const summary = summarizeOutcomes(outcomes);
+    const failed = summary.filter((o) => o.status === "failed");
+    if (failed.length === 0) {
+        return "";
+    }
+
+    const succeeded = summary.filter((o) => o.status === "ok");
+    const isPt = language === "Portuguese";
+    const failedList = joinList(
+        failed.map((o) => label(o.searchType, language)),
+        language
+    );
+
+    if (succeeded.length > 0) {
+        const succeededList = joinList(
+            succeeded.map((o) => label(o.searchType, language)),
+            language
+        );
+        return isPt
+            ? `⚠️ A ${failedList} não pôde ser concluída. Segue apenas o resultado da ${succeededList}. Deseja tentar a ${failedList} novamente?`
+            : `⚠️ The ${failedList} could not be completed. Only the result of the ${succeededList} is shown below. Would you like to retry the ${failedList}?`;
+    }
+
+    return isPt
+        ? `⚠️ Nenhuma das buscas solicitadas (${failedList}) pôde ser concluída. Deseja tentar novamente?`
+        : `⚠️ None of the requested searches (${failedList}) could be completed. Would you like to try again?`;
+}
+
+/**
+ * Prepend the disclosure block to the LLM output.
+ * Returns output unchanged when no leg failed.
+ */
+export function applyFailureDisclosure(
+    output: string,
+    outcomes: SearchOutcome[],
+    language: string
+): string {
+    const disclosure = buildFailureDisclosure(outcomes, language);
+    if (!disclosure) {
+        return output;
+    }
+    return `${disclosure}\n\n${output}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test:unit server/copilot/copilot-disclosure.util.spec.ts`
+Expected: PASS — all tests in the suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/copilot/copilot-disclosure.util.ts server/copilot/copilot-disclosure.util.spec.ts
+git commit -m "feat(copilot): add pure partial-failure disclosure util"
+```
+
+---
+
+## Task 2: Wire disclosure into the copilot chat service
+
+**Files:**
+- Modify: `server/copilot/copilot-chat.service.ts`
+
+No new unit test: the behavioral guarantee is covered by Task 1's util tests, and the spec states the service wiring is thin enough to verify by reading + typecheck. Each step below is a precise edit with before/after code.
+
+- [ ] **Step 1: Import `SearchType` from the util and remove the local enum**
+
+In `server/copilot/copilot-chat.service.ts`, add to the import block (near the other `./` imports, after the `CopilotSourceService` import around line 33):
+
+```typescript
+import {
+    SearchType,
+    SearchOutcome,
+    applyFailureDisclosure,
+} from "./copilot-disclosure.util";
+```
+
+Then DELETE the local enum declaration (currently around lines 35-38):
+
+```typescript
+enum SearchType {
+    online = "online",
+    gazettes = "gazettes",
+}
+```
+
+- [ ] **Step 2: Accept a `searchOutcomesRef` in the tool factory**
+
+Change the `createFactCheckingReportTool` signature (currently around lines 51-56) FROM:
+
+```typescript
+    private createFactCheckingReportTool(
+        editorReportRef: { value: any },
+        executionIdRef: { value: string | null },
+        userId: string,
+        sessionId: string
+    ) {
+```
+
+TO:
+
+```typescript
+    private createFactCheckingReportTool(
+        editorReportRef: { value: any },
+        executionIdRef: { value: string | null },
+        searchOutcomesRef: { value: SearchOutcome[] },
+        userId: string,
+        sessionId: string
+    ) {
+```
+
+- [ ] **Step 3: Record an "ok" outcome on the success path**
+
+Inside the tool `func`, the success path ends with `return stream;` (currently line 151). Immediately BEFORE that `return stream;`, add:
+
+```typescript
+                    searchOutcomesRef.value.push({
+                        searchType: data.searchType,
+                        status: "ok",
+                    });
+                    return stream;
+```
+
+- [ ] **Step 4: Record a "failed" outcome and sanitize the observation in `catch`**
+
+Change the tool `func` `catch` block (currently lines 152-155) FROM:
+
+```typescript
+                } catch (error) {
+                    this.logger.error(error);
+                    return String(error);
+                }
+```
+
+TO:
+
+```typescript
+                } catch (error) {
+                    this.logger.error(error);
+                    searchOutcomesRef.value.push({
+                        searchType: data.searchType,
+                        status: "failed",
+                    });
+                    // Return a concise, user-safe observation instead of the raw
+                    // error, so the LLM cannot echo a traceback. Deterministic
+                    // failure disclosure is applied after the agent run.
+                    return `A busca ${data.searchType} falhou e não retornou resultados.`;
+                }
+```
+
+- [ ] **Step 5: Create the `searchOutcomesRef` and pass it into the tool factory**
+
+In `agentChat`, where the refs are created (currently lines 229-240), add the new ref and pass it into `createFactCheckingReportTool`. Change FROM:
+
+```typescript
+            const editorReportRef: { value: any } = { value: null };
+            const executionIdRef: { value: string | null } = { value: null };
+            const tools = [
+                new DynamicStructuredTool(
+                    this.createFactCheckingReportTool(
+                        editorReportRef,
+                        executionIdRef,
+                        userId,
+                        sessionId
+                    ) as any
+                ),
+            ];
+```
+
+TO:
+
+```typescript
+            const editorReportRef: { value: any } = { value: null };
+            const executionIdRef: { value: string | null } = { value: null };
+            const searchOutcomesRef: { value: SearchOutcome[] } = {
+                value: [],
+            };
+            const tools = [
+                new DynamicStructuredTool(
+                    this.createFactCheckingReportTool(
+                        editorReportRef,
+                        executionIdRef,
+                        searchOutcomesRef,
+                        userId,
+                        sessionId
+                    ) as any
+                ),
+            ];
+```
+
+- [ ] **Step 6: Apply the disclosure to the final content, used for both persistence and response**
+
+After `const response = await agentExecutor.invoke({ ... });` (the invoke ends around line 310) and BEFORE building `assistantMessage` (currently line 312), insert:
+
+```typescript
+            // Deterministically disclose any failed search leg, independent of
+            // how the LLM phrased its answer. Used for BOTH the persisted
+            // transcript and the returned payload so the record is faithful.
+            const finalContent = applyFailureDisclosure(
+                response.output,
+                searchOutcomesRef.value,
+                language
+            );
+```
+
+Then change the persisted `assistantMessage.content` (currently line 316) FROM:
+
+```typescript
+            const assistantMessage: any = {
+                sender: SenderEnum.Assistant,
+                content: response.output,
+                type: "info",
+            };
+```
+
+TO:
+
+```typescript
+            const assistantMessage: any = {
+                sender: SenderEnum.Assistant,
+                content: finalContent,
+                type: "info",
+            };
+```
+
+And change the returned `customMessage` payload `content` (currently line 331) FROM:
+
+```typescript
+            return customMessage(HttpStatus.OK, MESSAGES.SUCCESS, {
+                sender: SenderEnum.Assistant,
+                content: response.output,
+                editorReport: editorReportRef.value,
+                executionId: executionIdRef.value,
+            });
+```
+
+TO:
+
+```typescript
+            return customMessage(HttpStatus.OK, MESSAGES.SUCCESS, {
+                sender: SenderEnum.Assistant,
+                content: finalContent,
+                editorReport: editorReportRef.value,
+                executionId: executionIdRef.value,
+            });
+```
+
+- [ ] **Step 7: Add the one-line prompt rule**
+
+In the system prompt's `## Rules` block (currently lines 272-276), add a final bullet after the existing rules, before the closing backtick of the template:
+
+```typescript
+- If a search returns a failure observation, summarize only the searches that succeeded and never include raw error text; the system discloses failed searches to the user automatically.
+```
+
+- [ ] **Step 8: Typecheck and re-run the util tests**
+
+Run: `npx tsc --noEmit`
+Expected: no type errors (in particular, no "Cannot find name 'SearchType'" and no unused-symbol errors).
+
+Run: `yarn test:unit server/copilot/copilot-disclosure.util.spec.ts`
+Expected: PASS — util tests still green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/copilot/copilot-chat.service.ts
+git commit -m "feat(copilot): disclose partial search failures deterministically"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** util module (§Design 1) → Task 1; service wiring incl. shared ref, sanitized catch observation, single `finalContent` for persistence + response (§Design 2) → Task 2 steps 2-6; prompt tweak (§Design 3) → Task 2 step 7; edge cases (single/dup/no-call) → covered by `summarizeOutcomes` + `buildFailureDisclosure` tests in Task 1. Out-of-scope items (UX #2) are intentionally not implemented.
+- **Type consistency:** `SearchType`, `SearchOutcome`, `SearchStatus`, `summarizeOutcomes`, `buildFailureDisclosure`, `applyFailureDisclosure` names are identical across the util, its spec, and the service edits. The service passes `language` (already resolved to `"Portuguese"`/`"English"` earlier in `agentChat`) to `applyFailureDisclosure`, matching the util's branch condition.
+- **No placeholders:** every code step shows complete before/after content.
+```

--- a/docs/superpowers/specs/2026-07-04-copilot-partial-failure-disclosure-design.md
+++ b/docs/superpowers/specs/2026-07-04-copilot-partial-failure-disclosure-design.md
@@ -1,0 +1,147 @@
+# Copilot Partial-Failure Disclosure (Gap A) — Design
+
+**Date:** 2026-07-04
+**Repo:** aletheia
+**Scope:** Aletheia copilot — disclose when one of multiple requested fact-check searches fails, instead of silently presenting only the surviving search.
+
+## Problem
+
+When a fact-checker asks the copilot to run "ambos" (both online + public-gazette searches), the tool-calling agent invokes the `get-fact-checking-report` tool twice within a single `agentChat` run — once per `searchType`, because the tool's `searchType` field is a single-value enum (`online | gazettes`), with no "both" value.
+
+If one leg fails (e.g. the Agência online pipeline errors with `No module named 'bs4'`) and the other completes, the copilot presents **only** the surviving leg and never discloses the failure. The user asked for two searches; one silently died; the response — and the persisted transcript — read as if the full plan was carried out.
+
+### Root cause (two independent defects)
+
+1. **The tool swallows the failure into a free-text observation.**
+   `server/copilot/copilot-chat.service.ts` — the tool `func` `catch` block does `return String(error)`, turning a failed leg into just another tool observation handed back to the LLM.
+
+2. **Nothing forces disclosure.**
+   The final user-facing message is `response.output`, composed freely by the LLM. The system prompt never instructs it to report a failed search, so it optimizes for a clean answer and omits the failed leg. Disclosure of a trust-critical event rides entirely on unguaranteed LLM behavior.
+
+The frontend renders the assistant `content` as plain text (`src/components/Copilot/CopilotConversationCard.tsx`), so a server-composed disclosure line in `response.output` fully covers the fix — no frontend change required.
+
+## Approach (chosen: C — deterministic disclosure)
+
+Make disclosure a **guarantee in code**, not a hope in the prompt. Track each tool invocation's outcome in a shared ref (reusing the existing `editorReportRef` / `executionIdRef` pattern already in the service), then deterministically prepend a user-safe disclosure block to the LLM output after the agent run.
+
+Rejected alternatives:
+- **A — Prompt-only:** the trust-critical guarantee would ride on LLM compliance, and omitting the failure is exactly the LLM behavior we are trying to stop.
+- **B — Structured tool result + prompt:** better signal, but disclosure is still LLM-rendered → still probabilistic.
+
+## Design
+
+### 1. New unit — `server/copilot/copilot-disclosure.util.ts`
+
+A pure, dependency-free, independently-testable module. The `SearchType` enum is **relocated here** from `copilot-chat.service.ts` so the util stays self-contained and the service imports the type from the util (one-way dependency: service → util).
+
+```ts
+export enum SearchType {
+    online = "online",
+    gazettes = "gazettes",
+}
+
+export type SearchStatus = "ok" | "failed";
+
+export interface SearchOutcome {
+    searchType: SearchType;
+    status: SearchStatus;
+}
+
+/**
+ * Collapse repeated calls per searchType (last-write-wins), so an LLM retry
+ * of a failed leg that later succeeds does not leave a false "failed" outcome.
+ */
+export function summarizeOutcomes(outcomes: SearchOutcome[]): SearchOutcome[];
+
+/**
+ * "" when nothing failed; otherwise a user-safe, localized disclosure block.
+ * Never contains raw error text or tracebacks.
+ */
+export function buildFailureDisclosure(
+    outcomes: SearchOutcome[],
+    language: string
+): string;
+
+/**
+ * Prepend the disclosure block to the LLM output.
+ * Returns output unchanged when no leg failed.
+ */
+export function applyFailureDisclosure(
+    output: string,
+    outcomes: SearchOutcome[],
+    language: string
+): string;
+```
+
+**Disclosure content:**
+- Names the failed leg(s) in the user's language: `online` → "busca online"; `gazettes` → "busca nos diários oficiais" (en: "online search" / "public gazette search").
+- When at least one leg also **succeeded**, adds the "segue apenas o resultado de X" framing and a retry offer ("Deseja tentar a busca online novamente?").
+- When **all** requested legs failed, states that none of the requested searches could be completed (a user-safe line; deeper full-failure UX is out of scope — see below).
+- Contains **no** raw error text; tracebacks remain in server logs only.
+
+`language` at the call site is already the resolved string `"Portuguese"` / `"English"` (the service converts it before building the prompt), so the util branches on that value — consistent with how the existing prompt already branches on language.
+
+### 2. Wiring into `copilot-chat.service.ts`
+
+Follow the existing local-ref pattern (introduced to fix a prior concurrency bug):
+
+- Add `const searchOutcomesRef: { value: SearchOutcome[] } = { value: [] };` and pass it into `createFactCheckingReportTool` alongside `editorReportRef` / `executionIdRef`.
+- In the tool `func`:
+  - **Success path:** push `{ searchType: data.searchType, status: "ok" }`.
+  - **`catch` block:** push `{ searchType: data.searchType, status: "failed" }`, keep `this.logger.error(error)`, and return a concise sanitized observation (e.g. `` `A busca ${data.searchType} falhou e não retornou resultados.` ``) **instead of** `String(error)`, so the LLM cannot echo a traceback.
+- After `agentExecutor.invoke(...)`, compute **once**:
+  ```ts
+  const finalContent = applyFailureDisclosure(
+      response.output,
+      searchOutcomesRef.value,
+      language
+  );
+  ```
+  and use `finalContent` for **both** the persisted `assistantMessage.content` and the returned `customMessage` payload — so the stored transcript is faithful (fixes the "transcript hid the failure" complaint), not just the live response.
+- Import `SearchType` from the util; remove the local enum definition.
+
+### 3. Prompt tweak (one line)
+
+Add to the Rules block of the system prompt: instruct the agent to summarize only successful searches and never include raw error text, because the system prepends failure disclosure deterministically. Prevents double-disclosure while the guarantee remains in code.
+
+## Data flow
+
+```
+user: "ambos"
+  → agent calls get-fact-checking-report (online)   → push outcome
+  → agent calls get-fact-checking-report (gazettes)  → push outcome
+  → agentExecutor.invoke returns response.output
+  → applyFailureDisclosure(output, outcomes, language)
+        prepends failure line iff any leg failed
+  → finalContent persisted AND returned
+```
+
+## Error handling & edge cases
+
+| Case | Behavior |
+|------|----------|
+| One leg fails, one succeeds (the Gap A case) | Disclosure line + surviving result; retry offer for the failed leg |
+| Single search, succeeds | No failed outcome → output unchanged |
+| Single search, fails | Failure line prepended (output refinement is UX #2) |
+| Same `searchType` called twice | `summarizeOutcomes` last-wins → a retry that succeeds clears the failure |
+| No tool call (still gathering slots) | Empty outcomes → output unchanged |
+
+## Testing (vitest, TDD)
+
+New `server/copilot/copilot-disclosure.util.spec.ts` unit-tests the pure functions directly (no LangChain mocking required):
+
+- failed `online` + ok `gazettes` → disclosure mentions online failure, includes surviving-result framing + retry offer.
+- all `ok` → `applyFailureDisclosure` returns output unchanged; `buildFailureDisclosure` returns `""`.
+- `summarizeOutcomes`: repeated `online` (failed then ok) collapses to `ok`; repeated (ok then failed) collapses to `failed`.
+- Portuguese vs English wording.
+- empty outcomes → `""` / unchanged.
+
+The service wiring stays thin enough to verify by reading; the behavioral guarantee is covered by the util tests.
+
+## Out of scope (UX #2 — separate follow-up)
+
+- Global raw-error sanitization across all copilot error paths.
+- Mapping every backend error to a friendly user-facing message.
+- Retry circuit-breaking (stop re-offering "tentar novamente" after repeated identical failures).
+
+This change makes only the **partial-failure disclosure line** user-safe; it does not attempt the broader error-UX overhaul.

--- a/server/copilot/copilot-chat.service.ts
+++ b/server/copilot/copilot-chat.service.ts
@@ -31,11 +31,11 @@ import { EditorParseService } from "../editor-parse/editor-parse.service";
 import { ConfigService } from "@nestjs/config";
 import { CopilotSessionService } from "./copilot-session.service";
 import { CopilotSourceService } from "./copilot-source.service";
-
-enum SearchType {
-    online = "online",
-    gazettes = "gazettes",
-}
+import {
+    SearchType,
+    SearchOutcome,
+    applyFailureDisclosure,
+} from "./copilot-disclosure.util";
 
 @Injectable()
 export class CopilotChatService {
@@ -51,6 +51,7 @@ export class CopilotChatService {
     private createFactCheckingReportTool(
         editorReportRef: { value: any },
         executionIdRef: { value: string | null },
+        searchOutcomesRef: { value: SearchOutcome[] },
         userId: string,
         sessionId: string
     ) {
@@ -148,10 +149,21 @@ export class CopilotChatService {
                             );
                     }
 
+                    searchOutcomesRef.value.push({
+                        searchType: data.searchType,
+                        status: "ok",
+                    });
                     return stream;
                 } catch (error) {
                     this.logger.error(error);
-                    return String(error);
+                    searchOutcomesRef.value.push({
+                        searchType: data.searchType,
+                        status: "failed",
+                    });
+                    // Return a concise, user-safe observation instead of the raw
+                    // error, so the LLM cannot echo a traceback. Deterministic
+                    // failure disclosure is applied after the agent run.
+                    return `A busca ${data.searchType} falhou e não retornou resultados.`;
                 }
             },
         };
@@ -228,11 +240,15 @@ export class CopilotChatService {
             // Use local ref objects instead of instance variables (fixes concurrency bug)
             const editorReportRef: { value: any } = { value: null };
             const executionIdRef: { value: string | null } = { value: null };
+            const searchOutcomesRef: { value: SearchOutcome[] } = {
+                value: [],
+            };
             const tools = [
                 new DynamicStructuredTool(
                     this.createFactCheckingReportTool(
                         editorReportRef,
                         executionIdRef,
+                        searchOutcomesRef,
                         userId,
                         sessionId
                     ) as any
@@ -273,7 +289,8 @@ Your primary goal is to gather all relevant information from the user about the 
 - Always pose your questions one at a time and in the specified order.
 - Persist in asking all necessary questions. Do not use the tool until you have thoroughly completed all preceding steps.
 - Maintain the use of formal language in your responses, ensuring that all communication is conducted in {language}.
-- Only after all questions have been addressed and all relevant information has been gathered from the user you should proceed to use the get-fact-checking-report tool.`,
+- Only after all questions have been addressed and all relevant information has been gathered from the user you should proceed to use the get-fact-checking-report tool.
+- If a search returns a failure observation, summarize only the searches that succeeded and never include raw error text; the system discloses failed searches to the user automatically.`,
                 ],
                 new MessagesPlaceholder({ variableName: "chat_history" }),
                 ["user", "{input}"],
@@ -309,10 +326,19 @@ Your primary goal is to gather all relevant information from the user about the 
                 chat_history: messagesHistory,
             });
 
+            // Deterministically disclose any failed search leg, independent of
+            // how the LLM phrased its answer. Used for BOTH the persisted
+            // transcript and the returned payload so the record is faithful.
+            const finalContent = applyFailureDisclosure(
+                response.output,
+                searchOutcomesRef.value,
+                language
+            );
+
             // Persist the assistant response (include editorReport and executionId if produced)
             const assistantMessage: any = {
                 sender: SenderEnum.Assistant,
-                content: response.output,
+                content: finalContent,
                 type: "info",
             };
             if (editorReportRef.value) {
@@ -328,7 +354,7 @@ Your primary goal is to gather all relevant information from the user about the 
 
             return customMessage(HttpStatus.OK, MESSAGES.SUCCESS, {
                 sender: SenderEnum.Assistant,
-                content: response.output,
+                content: finalContent,
                 editorReport: editorReportRef.value,
                 executionId: executionIdRef.value,
             });

--- a/server/copilot/copilot-disclosure.util.spec.ts
+++ b/server/copilot/copilot-disclosure.util.spec.ts
@@ -1,0 +1,102 @@
+import {
+    SearchType,
+    SearchOutcome,
+    summarizeOutcomes,
+    buildFailureDisclosure,
+    applyFailureDisclosure,
+} from "./copilot-disclosure.util";
+
+describe("copilot-disclosure.util", () => {
+    describe("summarizeOutcomes", () => {
+        it("collapses repeated searchType last-write-wins (failed then ok → ok)", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.online, status: "ok" },
+            ];
+            expect(summarizeOutcomes(outcomes)).toEqual([
+                { searchType: SearchType.online, status: "ok" },
+            ]);
+        });
+
+        it("collapses repeated searchType last-write-wins (ok then failed → failed)", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.gazettes, status: "ok" },
+                { searchType: SearchType.gazettes, status: "failed" },
+            ];
+            expect(summarizeOutcomes(outcomes)).toEqual([
+                { searchType: SearchType.gazettes, status: "failed" },
+            ]);
+        });
+    });
+
+    describe("buildFailureDisclosure", () => {
+        it("returns empty string when nothing failed", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "ok" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            expect(buildFailureDisclosure(outcomes, "Portuguese")).toBe("");
+        });
+
+        it("returns empty string for empty outcomes", () => {
+            expect(buildFailureDisclosure([], "Portuguese")).toBe("");
+        });
+
+        it("discloses failed online leg + retry offer when gazettes succeeded (pt)", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const msg = buildFailureDisclosure(outcomes, "Portuguese");
+            expect(msg).toContain("busca online");
+            expect(msg).toContain("diários oficiais");
+            expect(msg.toLowerCase()).toContain("novamente");
+        });
+
+        it("discloses in English when language is English", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const msg = buildFailureDisclosure(outcomes, "English");
+            expect(msg).toContain("online search");
+            expect(msg).toContain("public gazette search");
+            expect(msg.toLowerCase()).toContain("retry");
+        });
+
+        it("states all searches failed when none succeeded", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+            ];
+            const msg = buildFailureDisclosure(outcomes, "Portuguese");
+            expect(msg.toLowerCase()).toContain("nenhuma");
+            expect(msg).toContain("busca online");
+        });
+    });
+
+    describe("applyFailureDisclosure", () => {
+        it("prepends disclosure above the output when a leg failed", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.online, status: "failed" },
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const result = applyFailureDisclosure(
+                "Resultado dos diários oficiais...",
+                outcomes,
+                "Portuguese"
+            );
+            expect(result.startsWith("⚠️")).toBe(true);
+            expect(result).toContain("Resultado dos diários oficiais...");
+        });
+
+        it("returns output unchanged when nothing failed", () => {
+            const outcomes: SearchOutcome[] = [
+                { searchType: SearchType.gazettes, status: "ok" },
+            ];
+            const output = "Resultado...";
+            expect(applyFailureDisclosure(output, outcomes, "Portuguese")).toBe(
+                output
+            );
+        });
+    });
+});

--- a/server/copilot/copilot-disclosure.util.ts
+++ b/server/copilot/copilot-disclosure.util.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure, dependency-free helpers for disclosing partial fact-check search
+ * failures to the user. Owns the SearchType enum so this module has no
+ * dependency on the copilot service (one-way: service → util).
+ */
+
+export enum SearchType {
+    online = "online",
+    gazettes = "gazettes",
+}
+
+export type SearchStatus = "ok" | "failed";
+
+export interface SearchOutcome {
+    searchType: SearchType;
+    status: SearchStatus;
+}
+
+const SEARCH_LABELS: Record<
+    SearchType,
+    { Portuguese: string; English: string }
+> = {
+    [SearchType.online]: {
+        Portuguese: "busca online",
+        English: "online search",
+    },
+    [SearchType.gazettes]: {
+        Portuguese: "busca nos diários oficiais",
+        English: "public gazette search",
+    },
+};
+
+function label(searchType: SearchType, language: string): string {
+    const entry = SEARCH_LABELS[searchType];
+    return language === "Portuguese" ? entry.Portuguese : entry.English;
+}
+
+function joinList(items: string[], language: string): string {
+    if (items.length <= 1) {
+        return items[0] ?? "";
+    }
+    const conjunction = language === "Portuguese" ? " e " : " and ";
+    return (
+        items.slice(0, -1).join(", ") + conjunction + items[items.length - 1]
+    );
+}
+
+/**
+ * Collapse repeated calls per searchType (last-write-wins), so an LLM retry
+ * of a failed leg that later succeeds does not leave a false "failed" outcome.
+ */
+export function summarizeOutcomes(outcomes: SearchOutcome[]): SearchOutcome[] {
+    const byType = new Map<SearchType, SearchStatus>();
+    for (const outcome of outcomes) {
+        byType.set(outcome.searchType, outcome.status);
+    }
+    return Array.from(byType.entries()).map(([searchType, status]) => ({
+        searchType,
+        status,
+    }));
+}
+
+/**
+ * "" when nothing failed; otherwise a user-safe, localized disclosure block.
+ * Never contains raw error text or tracebacks.
+ */
+export function buildFailureDisclosure(
+    outcomes: SearchOutcome[],
+    language: string
+): string {
+    const summary = summarizeOutcomes(outcomes);
+    const failed = summary.filter((o) => o.status === "failed");
+    if (failed.length === 0) {
+        return "";
+    }
+
+    const succeeded = summary.filter((o) => o.status === "ok");
+    const isPt = language === "Portuguese";
+    const failedList = joinList(
+        failed.map((o) => label(o.searchType, language)),
+        language
+    );
+
+    if (succeeded.length > 0) {
+        const succeededList = joinList(
+            succeeded.map((o) => label(o.searchType, language)),
+            language
+        );
+        return isPt
+            ? `⚠️ A ${failedList} não pôde ser concluída. Segue apenas o resultado da ${succeededList}. Deseja tentar a ${failedList} novamente?`
+            : `⚠️ The ${failedList} could not be completed. Only the result of the ${succeededList} is shown below. Would you like to retry the ${failedList}?`;
+    }
+
+    return isPt
+        ? `⚠️ Nenhuma das buscas solicitadas (${failedList}) pôde ser concluída. Deseja tentar novamente?`
+        : `⚠️ None of the requested searches (${failedList}) could be completed. Would you like to try again?`;
+}
+
+/**
+ * Prepend the disclosure block to the LLM output.
+ * Returns output unchanged when no leg failed.
+ */
+export function applyFailureDisclosure(
+    output: string,
+    outcomes: SearchOutcome[],
+    language: string
+): string {
+    const disclosure = buildFailureDisclosure(outcomes, language);
+    if (!disclosure) {
+        return output;
+    }
+    return `${disclosure}\n\n${output}`;
+}


### PR DESCRIPTION
## What & Why

When the copilot fact-checking agent runs its searches (online + public gazettes), a failed search leg was handled inconsistently: the raw error was stringified and returned to the LLM (`return String(error)`), which could echo tracebacks back to the user, and there was no reliable signal telling the user that part of the search silently failed.

This PR makes partial-failure disclosure **deterministic** — independent of how the LLM phrases its answer — so the user is always told which search legs failed, in their language, without any raw error text leaking.

## Changes

- **New pure util** `server/copilot/copilot-disclosure.util.ts` — dependency-free helpers that own the `SearchType` enum and build a user-safe, localized (PT/EN) disclosure block:
  - `summarizeOutcomes` collapses repeated calls per search type (last-write-wins), so an LLM retry of a failed leg that later succeeds doesn't leave a false "failed" outcome.
  - `buildFailureDisclosure` returns `""` when nothing failed, otherwise a localized message covering the all-failed and partial-failure cases. Never contains raw error text.
  - `applyFailureDisclosure` prepends the block to the LLM output.
- **`copilot-chat.service.ts`**:
  - Tracks per-search outcomes via a local `searchOutcomesRef` (consistent with the existing local-ref pattern that fixed the earlier concurrency bug).
  - On search failure, returns a concise user-safe observation instead of `String(error)`, so the LLM cannot echo a traceback.
  - Applies deterministic disclosure to **both** the persisted transcript and the returned payload, so the stored record is faithful.
  - System prompt updated to instruct the LLM to never include raw error text (the system discloses failures automatically).
- **Tests**: `copilot-disclosure.util.spec.ts` — unit coverage for the summarize/build/apply helpers.
- **Docs**: spec + implementation plan for Gap A under `docs/`.

## Testing

- Unit tests added for the disclosure util (summarize dedup, partial vs. all-failed, PT/EN wording, no-failure passthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
