### PR TITLE
fix(auth): fail closed when app_affiliation config is unset in SessionGuard

### DIFF
--- a/server/auth/session.guard.spec.ts
+++ b/server/auth/session.guard.spec.ts
@@ -15,17 +15,14 @@ import { Roles } from "./ability/ability.factory";
 // declared via vi.hoisted() because vi.mock() is hoisted above all imports
 // during the Vitest transform pipeline. Constructor mocks must use `function`
 // (not arrow functions) so `new Configuration(...)` works under Vitest 4.
-const {
-    mockToSession,
-    mockCreateBrowserLogoutFlow,
-    mockUpdateLogoutFlow,
-} = vi.hoisted(() => ({
-    mockToSession: vi.fn(),
-    mockCreateBrowserLogoutFlow: vi.fn().mockResolvedValue({
-        data: { logout_token: "mock-logout-token" },
-    }),
-    mockUpdateLogoutFlow: vi.fn().mockResolvedValue({}),
-}));
+const { mockToSession, mockCreateBrowserLogoutFlow, mockUpdateLogoutFlow } =
+    vi.hoisted(() => ({
+        mockToSession: vi.fn(),
+        mockCreateBrowserLogoutFlow: vi.fn().mockResolvedValue({
+            data: { logout_token: "mock-logout-token" },
+        }),
+        mockUpdateLogoutFlow: vi.fn().mockResolvedValue({}),
+    }));
 
 vi.mock("@ory/client", () => ({
     Configuration: vi.fn().mockImplementation(function () {
@@ -193,9 +190,7 @@ describe("SessionGuard", () => {
         it("should logout and redirect to signup-invite when user not in MongoDB", async () => {
             const session = createMockSession();
             mockToSession.mockResolvedValue({ data: session });
-            usersService.getById.mockRejectedValue(
-                new Error("User not found")
-            );
+            usersService.getById.mockRejectedValue(new Error("User not found"));
 
             const { context, response } = createMockContext(
                 "ory_session=abc",
@@ -218,6 +213,60 @@ describe("SessionGuard", () => {
             const session = createMockSession({
                 traits: { app_affiliation: "wrong-app" },
             });
+            mockToSession.mockResolvedValue({ data: session });
+
+            const { context, response } = createMockContext(
+                "ory_session=abc",
+                false,
+                "/dashboard"
+            );
+
+            const result = await guard.canActivate(context);
+
+            expect(mockCreateBrowserLogoutFlow).toHaveBeenCalled();
+            expect(response.redirect).toHaveBeenCalledWith("/unauthorized");
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("missing app_affiliation config", () => {
+        const setConfigWithoutAffiliation = () => {
+            configService.get.mockImplementation((key: string) => {
+                const config = {
+                    authentication_type: "ory",
+                    "ory.url": "http://localhost:4433",
+                    "ory.access_token": "mock-access-token",
+                    override_public_routes: undefined,
+                };
+                return config[key];
+            });
+        };
+
+        it("should fail closed when config and trait are both unset", async () => {
+            setupDefaultUserMock();
+            setConfigWithoutAffiliation();
+            const session = createMockSession({
+                traits: { app_affiliation: undefined },
+            });
+            mockToSession.mockResolvedValue({ data: session });
+
+            const { context, response } = createMockContext(
+                "ory_session=abc",
+                false,
+                "/dashboard"
+            );
+
+            const result = await guard.canActivate(context);
+
+            expect(mockCreateBrowserLogoutFlow).toHaveBeenCalled();
+            expect(response.redirect).toHaveBeenCalledWith("/unauthorized");
+            expect(result).toBe(false);
+        });
+
+        it("should fail closed when config is unset even if trait is present", async () => {
+            setupDefaultUserMock();
+            setConfigWithoutAffiliation();
+            const session = createMockSession();
             mockToSession.mockResolvedValue({ data: session });
 
             const { context, response } = createMockContext(

--- a/server/auth/session.guard.ts
+++ b/server/auth/session.guard.ts
@@ -31,7 +31,10 @@ export class SessionGuard extends BaseGuard {
             });
         } catch (error) {
             const err = toError(error);
-            this.logger.error(`Error during logout flow: ${err.message}`, err.stack);
+            this.logger.error(
+                `Error during logout flow: ${err.message}`,
+                err.stack
+            );
         }
     }
 
@@ -78,9 +81,15 @@ export class SessionGuard extends BaseGuard {
 
                 const expectedAffiliation =
                     this.configService.get<string>("app_affiliation");
-                const appAffiliation =
-                    session?.identity?.traits?.app_affiliation;
-                if (appAffiliation !== expectedAffiliation) {
+                const traits = session?.identity?.traits;
+                // Fail closed: an unset app_affiliation config must deny access,
+                // otherwise undefined === undefined lets any session through
+                if (
+                    !expectedAffiliation ||
+                    !traits ||
+                    traits.app_affiliation !== expectedAffiliation
+                ) {
+                    const appAffiliation = traits?.app_affiliation;
                     this.logger.error(
                         `Affiliation mismatch: expected ${expectedAffiliation}, got ${appAffiliation}`
                     );
@@ -122,7 +131,10 @@ export class SessionGuard extends BaseGuard {
         } catch (error) {
             const err = toError(error);
 
-            this.logger.error(`Critical failure in AuthGuard: ${err.message}`, err.stack);
+            this.logger.error(
+                `Critical failure in AuthGuard: ${err.message}`,
+                err.stack
+            );
 
             return this.checkAndRedirect(request, response, isPublic, "/login");
         }


### PR DESCRIPTION
# Description
`SessionGuard` compared the Ory identity's `app_affiliation` trait against the `app_affiliation` config key with a plain inequality check. When the config key was unset **and** the identity had no `app_affiliation` trait, the comparison became `undefined !== undefined` → `false`, so the affiliation check passed and any valid Ory session was granted access (fail-open).

The guard now fails closed, mirroring the hardened check used by the MCP auth guard: access is denied whenever the expected affiliation config is missing, the identity traits are missing, or the trait does not match. On denial the guard still logs out the Ory session and redirects to `/unauthorized`, as before.

**Deployment note:** any environment currently running without `app_affiliation` configured will start rejecting all sessions after this change — the config key must be set before/with this deploy.

Related Ticket # (issue)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
- `yarn test server/auth/session.guard.spec.ts` — 10 tests pass, including two new tests under "missing app_affiliation config":
  - config unset + trait unset → denied (the case that previously failed open; verified failing before the fix)
  - config unset + trait present → denied
- `yarn test server/auth` — full auth module suite passes (32 tests / 4 files)
- `yarn build-ts` — type check clean

# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY.

## Backend Changes
- [x] All endpoints are appropriately secured with Middleware authentication

### Tests
- [x] All existing unit and end to end tests pass across all services
- [x] Unit and end to end tests have been added to ensure backend APIs behave as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)