### PR TITLE
feat(captcha): provider abstraction (reCAPTCHA default, none mode, pluggable open providers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,16 @@ Active flags:
 - `enable_reviewers_update_report` — Allow reviewers to update reports
 - `enable_view_report_preview` — Report preview feature
 
+## Captcha Provider
+
+Captcha verification is pluggable via `server/captcha/`: a `CaptchaProvider`
+interface + `CAPTCHA_PROVIDER` DI token, selected by `captcha.provider` config
+(`recaptcha` default, or `none` to disable captcha entirely). All existing
+`captchaService.validate(token)` call sites and the ~20 SSR sitekey-injection
+sites are unaffected by provider choice. See
+`server/captcha/WRITING-A-PROVIDER.md` for adding an open provider (ALTCHA is
+provided as a build-excluded `.example.ts(x)` reference, not a dependency).
+
 ## Key Technical Details
 
 1. **TypeScript**: `strict: false` in root `tsconfig.json`. Three configs: root (type-check only, `noEmit: true`), `server/tsconfig.json` (backend build), `src/tsconfig.json` (frontend)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,16 @@ services:
       #override_public_routes: true
       recaptcha_secret: RECAPTCHA_SECRET
       recaptcha_sitekey: 6Lc2BtYUAAAAAOUBI-9r1sDJUIfG2nt6C43noOXh
+      # Captcha provider selection (recaptcha | none; custom providers add
+      # their own value — see server/captcha/WRITING-A-PROVIDER.md). When
+      # this whole `captcha` block is absent, the legacy recaptcha_secret /
+      # recaptcha_sitekey keys above are used and the provider defaults to
+      # "recaptcha" — existing deployments need no changes.
+      # captcha:
+      #   provider: recaptcha
+      #   recaptcha:
+      #     sitekey: 6Lc2BtYUAAAAAOUBI-9r1sDJUIfG2nt6C43noOXh
+      #     secret: RECAPTCHA_SECRET
       db:
         connection_uri: mongodb://localhost/Aletheia
         type: mongodb

--- a/server/auth/name-space/name-space.controller.ts
+++ b/server/auth/name-space/name-space.controller.ts
@@ -24,6 +24,7 @@ import { Roles } from "../../auth/ability/ability.factory";
 import { NotificationService } from "../../notifications/notifications.service";
 import slugify from "slugify";
 import { ConfigService } from "@nestjs/config";
+import { CaptchaService } from "../../captcha/captcha.service";
 
 @Controller()
 export class NameSpaceController {
@@ -32,7 +33,8 @@ export class NameSpaceController {
         private usersService: UsersService,
         private viewService: ViewService,
         private notificationService: NotificationService,
-        private configService: ConfigService
+        private configService: ConfigService,
+        private captchaService: CaptchaService
     ) {}
 
     @AdminOnly()
@@ -110,6 +112,7 @@ export class NameSpaceController {
 
         const query = Object.assign(parsedUrl.query, {
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             nameSpaces,
             users,
         });

--- a/server/auth/name-space/name-space.module.ts
+++ b/server/auth/name-space/name-space.module.ts
@@ -8,6 +8,7 @@ import { ViewModule } from "../../view/view.module";
 import { AbilityModule } from "../../auth/ability/ability.module";
 import { ConfigModule } from "@nestjs/config";
 import { NotificationModule } from "../../notifications/notifications.module";
+import { CaptchaModule } from "../../captcha/captcha.module";
 
 const NameSpaceModel = MongooseModule.forFeature([
     {
@@ -24,6 +25,7 @@ const NameSpaceModel = MongooseModule.forFeature([
         AbilityModule,
         ConfigModule,
         NotificationModule,
+        CaptchaModule,
     ],
     providers: [NameSpaceService],
     exports: [NameSpaceService],

--- a/server/badge/badge.controller.ts
+++ b/server/badge/badge.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, NotFoundException, Post, Put, Req, Res } from "@nestjs/common";
+import {
+    Body,
+    Controller,
+    Get,
+    NotFoundException,
+    Post,
+    Put,
+    Req,
+    Res,
+} from "@nestjs/common";
 import type { Request, Response } from "express";
 import { ImageService } from "../claim/types/image/image.service";
 import { parse } from "url";
@@ -13,6 +22,7 @@ import { ApiTags } from "@nestjs/swagger";
 import { UtilService } from "../util";
 import { AdminOnly } from "../auth/decorators/auth.decorator";
 import { ConfigService } from "@nestjs/config";
+import { CaptchaService } from "../captcha/captcha.service";
 
 @Controller(":namespace?")
 export class BadgeController {
@@ -22,7 +32,8 @@ export class BadgeController {
         private imageService: ImageService,
         private usersService: UsersService,
         private util: UtilService,
-        private configService: ConfigService
+        private configService: ConfigService,
+        private captchaService: CaptchaService
     ) {}
 
     @AdminOnly()
@@ -155,6 +166,7 @@ export class BadgeController {
             users,
             nameSpace: req.params.namespace,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
         });
 
         await this.viewService.render(req, res, "/admin-badges", query);

--- a/server/badge/badge.module.ts
+++ b/server/badge/badge.module.ts
@@ -9,6 +9,7 @@ import { Badge, BadgeSchema } from "./schemas/badge.schema";
 import { UsersModule } from "../users/users.module";
 import { UtilService } from "../util";
 import { ConfigModule } from "@nestjs/config";
+import { CaptchaModule } from "../captcha/captcha.module";
 
 const BadgeModel = MongooseModule.forFeature([
     {
@@ -25,6 +26,7 @@ const BadgeModel = MongooseModule.forFeature([
         ImageModule,
         UsersModule,
         ConfigModule,
+        CaptchaModule,
     ],
     exports: [BadgeService],
     providers: [BadgeService, UtilService],

--- a/server/captcha/WRITING-A-PROVIDER.md
+++ b/server/captcha/WRITING-A-PROVIDER.md
@@ -1,0 +1,120 @@
+# Writing a Custom Captcha Provider
+
+Aletheia's captcha verification is pluggable. Core ships two providers —
+`recaptcha` (Google reCAPTCHA, the default) and `none` (captcha disabled) —
+and exposes the `CaptchaProvider` interface so you can add your own without
+forking any controller.
+
+## The contract
+
+```ts
+// server/captcha/captcha.types.ts
+export interface CaptchaClientConfig {
+    provider: string;       // e.g. "recaptcha" | "none" | your own value
+    sitekey?: string;       // widget-based providers (e.g. recaptcha)
+    challengeUrl?: string;  // challenge-based providers (e.g. altcha)
+}
+
+export interface CaptchaProvider {
+    readonly name: string;
+    verify(token: string): Promise<boolean>;
+    getClientConfig(): CaptchaClientConfig;
+    getChallenge?(): Promise<unknown>; // only if your provider issues challenges
+}
+```
+
+Implement this interface, and your provider works with:
+
+- `CaptchaService.validate(token)` — every existing controller call site.
+- `GET /api/captcha/config` — the frontend fetches/consumes this via
+  `captcha` in Redux.
+- `GET /api/captcha/challenge` — only relevant if you implement `getChallenge`;
+  otherwise the endpoint 404s automatically, which is fine.
+
+## Worked example: ALTCHA
+
+`server/captcha/providers/altcha.provider.example.ts` and
+`src/components/AletheiaCaptcha.altcha.example.tsx` are a complete,
+end-to-end reference for wiring up [ALTCHA](https://altcha.org), an open,
+self-hosted, privacy-friendly proof-of-work captcha with no external
+verification service. They are excluded from the build (`.example.ts(x)`
+suffix, in every tsconfig's `exclude`) and add no dependency to
+`package.json` — copy them in as your starting point.
+
+## Three wiring steps
+
+### 1. Install your provider's dependencies (if any)
+
+For the ALTCHA example: `yarn add altcha-lib @altcha/widget`.
+
+### 2. Add a `case` to the backend factory
+
+`server/captcha/captcha-provider.factory.ts`:
+
+```ts
+export function createCaptchaProvider(
+    config: ConfigService,
+    http: HttpService
+): CaptchaProvider {
+    switch (config.get<string>("captcha.provider") ?? "recaptcha") {
+        case "none":
+            return new NoopCaptchaProvider();
+        case "altcha": // <- your new case
+            return new AltchaCaptchaProvider(config);
+        default:
+            return new RecaptchaProvider(http, config);
+    }
+}
+```
+
+Copy `providers/altcha.provider.example.ts` to `providers/altcha.provider.ts`
+(dropping `.example`) so it re-enters the TypeScript build, and import it here.
+
+### 3. Add your config block
+
+```yaml
+captcha:
+  provider: altcha
+  altcha:
+    hmac_key: YOUR_HMAC_SECRET
+```
+
+### 4. Extend the frontend dispatch
+
+`src/components/AletheiaCaptcha.tsx`'s `resolveCaptchaRenderMode` currently
+maps everything that isn't `"none"` to `"recaptcha"` (a safe fallback for
+unrecognized providers). To render your own widget instead of falling back,
+widen the render-mode type and add a branch, using
+`AletheiaCaptcha.altcha.example.tsx` as your starting point for the widget
+itself. Keep the same imperative handle contract (`getValue()`,
+`resetRecaptcha()`) so the 7 existing consumers (`SharedFormFooter.tsx`,
+`VerificationRequestDetailDrawer.tsx`, `Modal/ToolbarActionsModal.tsx`,
+`Login/SignUpForm.tsx`, `Claim/CreateClaim/BaseClaimForm.tsx`,
+`Modal/RecaptchaModal.tsx`, and `ClaimReview/form/DynamicReviewTaskForm.tsx`
+via `RecaptchaModal`) keep working unmodified.
+
+## Using the challenge endpoint
+
+If your provider issues challenges (like ALTCHA), implement `getChallenge()`
+on your `CaptchaProvider`. `GET /api/captcha/challenge` automatically calls it
+and returns the result — no controller changes needed. Point your frontend
+widget at the `challengeUrl` your `getClientConfig()` returns (by convention,
+`/api/captcha/challenge`).
+
+## A note on `none`
+
+Setting `captcha.provider: none` disables bot protection on every form that
+uses `AletheiaCaptcha` — verification always succeeds. This is intended for
+closed or self-hosted deployments where public-facing abuse isn't a concern.
+Don't use it on a publicly reachable instance without understanding that
+trade-off.
+
+## Testing your provider
+
+Core's own providers (`RecaptchaProvider`, `NoopCaptchaProvider`) and the
+factory (`createCaptchaProvider`) are covered by plain Vitest unit tests with
+mocked `ConfigService`/`HttpService` — see
+`server/captcha/providers/recaptcha.provider.spec.ts` and
+`server/captcha/captcha-provider.factory.spec.ts` for the pattern. There is no
+requirement to test the `.example.ts(x)` files themselves — they're excluded
+from the build and CI never touches them.

--- a/server/captcha/captcha-provider.factory.spec.ts
+++ b/server/captcha/captcha-provider.factory.spec.ts
@@ -1,0 +1,48 @@
+import { HttpService } from "@nestjs/axios";
+import { ConfigService } from "@nestjs/config";
+import { createCaptchaProvider } from "./captcha-provider.factory";
+import { NoopCaptchaProvider } from "./providers/noop-captcha.provider";
+import { RecaptchaProvider } from "./providers/recaptcha.provider";
+
+function configFrom(values: Record<string, unknown>) {
+    return { get: (key: string) => values[key] } as unknown as ConfigService;
+}
+
+const httpStub = {} as HttpService;
+
+describe("createCaptchaProvider (Unit)", () => {
+    it("returns RecaptchaProvider by default when captcha.provider is unset", () => {
+        const provider = createCaptchaProvider(configFrom({}), httpStub);
+
+        expect(provider).toBeInstanceOf(RecaptchaProvider);
+        expect(provider.name).toBe("recaptcha");
+    });
+
+    it("returns RecaptchaProvider when captcha.provider is explicitly 'recaptcha'", () => {
+        const provider = createCaptchaProvider(
+            configFrom({ "captcha.provider": "recaptcha" }),
+            httpStub
+        );
+
+        expect(provider).toBeInstanceOf(RecaptchaProvider);
+    });
+
+    it("returns NoopCaptchaProvider when captcha.provider is 'none'", () => {
+        const provider = createCaptchaProvider(
+            configFrom({ "captcha.provider": "none" }),
+            httpStub
+        );
+
+        expect(provider).toBeInstanceOf(NoopCaptchaProvider);
+        expect(provider.name).toBe("none");
+    });
+
+    it("falls back to RecaptchaProvider for an unrecognized provider value", () => {
+        const provider = createCaptchaProvider(
+            configFrom({ "captcha.provider": "altcha" }),
+            httpStub
+        );
+
+        expect(provider).toBeInstanceOf(RecaptchaProvider);
+    });
+});

--- a/server/captcha/captcha-provider.factory.ts
+++ b/server/captcha/captcha-provider.factory.ts
@@ -1,0 +1,24 @@
+import { HttpService } from "@nestjs/axios";
+import { ConfigService } from "@nestjs/config";
+import { NoopCaptchaProvider } from "./providers/noop-captcha.provider";
+import { RecaptchaProvider } from "./providers/recaptcha.provider";
+import type { CaptchaProvider } from "./captcha.types";
+
+/**
+ * Selects the CaptchaProvider implementation from `captcha.provider` config,
+ * defaulting to "recaptcha" when unset so existing deployments are
+ * unaffected. This switch is the single, documented place a deployer adds a
+ * `case` for their own provider — see server/captcha/WRITING-A-PROVIDER.md
+ * and the ALTCHA reference example.
+ */
+export function createCaptchaProvider(
+    config: ConfigService,
+    http: HttpService
+): CaptchaProvider {
+    switch (config.get<string>("captcha.provider") ?? "recaptcha") {
+        case "none":
+            return new NoopCaptchaProvider();
+        default:
+            return new RecaptchaProvider(http, config);
+    }
+}

--- a/server/captcha/captcha.controller.spec.ts
+++ b/server/captcha/captcha.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { CaptchaController } from "./captcha.controller";
+import { CaptchaService } from "./captcha.service";
+
+describe("CaptchaController (Unit)", () => {
+    function build(captchaServiceOverrides: Partial<CaptchaService> = {}) {
+        return Test.createTestingModule({
+            controllers: [CaptchaController],
+            providers: [
+                { provide: ConfigService, useValue: { get: () => undefined } },
+                {
+                    provide: CaptchaService,
+                    useValue: {
+                        getClientConfig: vi
+                            .fn()
+                            .mockReturnValue({
+                                provider: "recaptcha",
+                                sitekey: "abc",
+                            }),
+                        getChallenge: vi.fn().mockResolvedValue(undefined),
+                        ...captchaServiceOverrides,
+                    },
+                },
+            ],
+        }).compile();
+    }
+
+    it("GET /api/captcha/config returns the active provider's client config", async () => {
+        const moduleRef: TestingModule = await build();
+        const controller = moduleRef.get(CaptchaController);
+
+        expect(controller.getConfig()).toEqual({
+            provider: "recaptcha",
+            sitekey: "abc",
+        });
+    });
+
+    it("GET /api/captcha/challenge returns the provider's challenge when supported", async () => {
+        const moduleRef: TestingModule = await build({
+            getChallenge: vi.fn().mockResolvedValue({ challenge: "xyz" }),
+        });
+        const controller = moduleRef.get(CaptchaController);
+
+        expect(await controller.getChallengeEndpoint()).toEqual({
+            challenge: "xyz",
+        });
+    });
+
+    it("GET /api/captcha/challenge throws NotFoundException when the provider has no challenge", async () => {
+        const moduleRef: TestingModule = await build({
+            getChallenge: vi.fn().mockResolvedValue(undefined),
+        });
+        const controller = moduleRef.get(CaptchaController);
+
+        await expect(controller.getChallengeEndpoint()).rejects.toThrow(
+            NotFoundException
+        );
+    });
+});

--- a/server/captcha/captcha.controller.ts
+++ b/server/captcha/captcha.controller.ts
@@ -1,11 +1,22 @@
-import { Controller, Get, Header, Res } from "@nestjs/common";
+import {
+    Controller,
+    Get,
+    Header,
+    NotFoundException,
+    Res,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Public } from "../auth/decorators/auth.decorator";
+import { CaptchaService } from "./captcha.service";
+import type { CaptchaClientConfig } from "./captcha.types";
 import type { Response } from "express";
 
 @Controller()
 export class CaptchaController {
-    constructor(private configService: ConfigService) {}
+    constructor(
+        private configService: ConfigService,
+        private readonly captchaService: CaptchaService
+    ) {}
 
     @Public()
     @Get("api/captcha-bridge")
@@ -63,5 +74,23 @@ export class CaptchaController {
   </script>
 </body>
 </html>`);
+    }
+
+    @Public()
+    @Get("api/captcha/config")
+    getConfig(): CaptchaClientConfig {
+        return this.captchaService.getClientConfig();
+    }
+
+    @Public()
+    @Get("api/captcha/challenge")
+    async getChallengeEndpoint(): Promise<unknown> {
+        const challenge = await this.captchaService.getChallenge();
+        if (challenge === undefined) {
+            throw new NotFoundException(
+                "The active captcha provider does not support challenges"
+            );
+        }
+        return challenge;
     }
 }

--- a/server/captcha/captcha.module.ts
+++ b/server/captcha/captcha.module.ts
@@ -1,13 +1,22 @@
-import { HttpModule } from "@nestjs/axios";
+import { HttpModule, HttpService } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
-import { ConfigModule } from "@nestjs/config";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { createCaptchaProvider } from "./captcha-provider.factory";
+import { CAPTCHA_PROVIDER } from "./captcha.tokens";
 import { CaptchaController } from "./captcha.controller";
 import { CaptchaService } from "./captcha.service";
 
 @Module({
     imports: [HttpModule, ConfigModule],
     exports: [CaptchaService],
-    providers: [CaptchaService],
+    providers: [
+        CaptchaService,
+        {
+            provide: CAPTCHA_PROVIDER,
+            inject: [ConfigService, HttpService],
+            useFactory: createCaptchaProvider,
+        },
+    ],
     controllers: [CaptchaController],
 })
 export class CaptchaModule {}

--- a/server/captcha/captcha.service.spec.ts
+++ b/server/captcha/captcha.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { CaptchaService } from "./captcha.service";
+import { CAPTCHA_PROVIDER } from "./captcha.tokens";
+import type { CaptchaProvider } from "./captcha.types";
+
+describe("CaptchaService (Unit)", () => {
+    function buildProvider(
+        overrides: Partial<CaptchaProvider> = {}
+    ): CaptchaProvider {
+        return {
+            name: "stub",
+            verify: vi.fn().mockResolvedValue(true),
+            getClientConfig: vi.fn().mockReturnValue({ provider: "stub" }),
+            ...overrides,
+        };
+    }
+
+    async function build(provider: CaptchaProvider) {
+        const moduleRef: TestingModule = await Test.createTestingModule({
+            providers: [
+                CaptchaService,
+                { provide: CAPTCHA_PROVIDER, useValue: provider },
+            ],
+        }).compile();
+        return moduleRef.get(CaptchaService);
+    }
+
+    it("validate() delegates to the injected provider's verify()", async () => {
+        const provider = buildProvider({
+            verify: vi.fn().mockResolvedValue(true),
+        });
+        const service = await build(provider);
+
+        expect(await service.validate("token-123")).toBe(true);
+        expect(provider.verify).toHaveBeenCalledWith("token-123");
+    });
+
+    it("validate() propagates a false verification result", async () => {
+        const provider = buildProvider({
+            verify: vi.fn().mockResolvedValue(false),
+        });
+        const service = await build(provider);
+
+        expect(await service.validate("bad-token")).toBe(false);
+    });
+
+    it("getClientConfig() delegates to the injected provider", async () => {
+        const provider = buildProvider({
+            getClientConfig: vi
+                .fn()
+                .mockReturnValue({ provider: "stub", sitekey: "abc" }),
+        });
+        const service = await build(provider);
+
+        expect(service.getClientConfig()).toEqual({
+            provider: "stub",
+            sitekey: "abc",
+        });
+    });
+
+    it("getChallenge() resolves undefined when the provider has no getChallenge", async () => {
+        const provider = buildProvider();
+        const service = await build(provider);
+
+        expect(await service.getChallenge()).toBeUndefined();
+    });
+
+    it("getChallenge() delegates when the provider implements it", async () => {
+        const provider = buildProvider({
+            getChallenge: vi.fn().mockResolvedValue({ challenge: "xyz" }),
+        });
+        const service = await build(provider);
+
+        expect(await service.getChallenge()).toEqual({ challenge: "xyz" });
+        expect(provider.getChallenge).toHaveBeenCalled();
+    });
+});

--- a/server/captcha/captcha.service.ts
+++ b/server/captcha/captcha.service.ts
@@ -1,44 +1,23 @@
-import { HttpService } from "@nestjs/axios";
-import { Injectable, Logger } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { firstValueFrom } from "rxjs";
+import { Inject, Injectable } from "@nestjs/common";
+import { CAPTCHA_PROVIDER } from "./captcha.tokens";
+import type { CaptchaClientConfig, CaptchaProvider } from "./captcha.types";
 
 @Injectable()
 export class CaptchaService {
-    private readonly logger = new Logger("CaptchaService");
     constructor(
-        private httpService: HttpService,
-        private configService: ConfigService
+        @Inject(CAPTCHA_PROVIDER)
+        private readonly captchaProvider: CaptchaProvider
     ) {}
 
-    async _checkCaptchaResponse(secret: string, response: string) {
-        const RECAPTCHA_API_URL = "https://www.google.com/recaptcha/api";
-        const querystring = new URLSearchParams({
-            secret,
-            response,
-        }).toString();
-        const { data } = await firstValueFrom(
-            this.httpService.post(
-                `${RECAPTCHA_API_URL}/siteverify`,
-                querystring
-            )
-        );
-
-        return data;
+    validate(token: string): Promise<boolean> {
+        return this.captchaProvider.verify(token);
     }
 
-    async validate(recaptchaString: string) {
-        try {
-            const secret =
-                this.configService.get<string>("recaptcha_secret") ?? "";
-            const captchaVerification = await this._checkCaptchaResponse(
-                secret,
-                recaptchaString
-            );
-            return captchaVerification.success;
-        } catch (err) {
-            this.logger.error(`error/recaptcha ${err} `);
-            return false;
-        }
+    getClientConfig(): CaptchaClientConfig {
+        return this.captchaProvider.getClientConfig();
+    }
+
+    getChallenge(): Promise<unknown> | undefined {
+        return this.captchaProvider.getChallenge?.();
     }
 }

--- a/server/captcha/captcha.tokens.ts
+++ b/server/captcha/captcha.tokens.ts
@@ -1,0 +1,1 @@
+export const CAPTCHA_PROVIDER = Symbol("CAPTCHA_PROVIDER");

--- a/server/captcha/captcha.types.ts
+++ b/server/captcha/captcha.types.ts
@@ -1,0 +1,16 @@
+export interface CaptchaClientConfig {
+    /** Known core values: "recaptcha" | "none". Custom providers add their own. */
+    provider: string;
+    sitekey?: string; // recaptcha
+    challengeUrl?: string; // challenge-based providers (e.g. altcha)
+}
+
+export interface CaptchaProvider {
+    readonly name: string;
+    /** Verify a solved captcha token/payload. */
+    verify(token: string): Promise<boolean>;
+    /** Config the frontend needs to render the right widget. */
+    getClientConfig(): CaptchaClientConfig;
+    /** Optional: issue a challenge (for challenge-based providers). */
+    getChallenge?(): Promise<unknown>;
+}

--- a/server/captcha/providers/altcha.provider.example.ts
+++ b/server/captcha/providers/altcha.provider.example.ts
@@ -1,0 +1,70 @@
+/**
+ * REFERENCE EXAMPLE — excluded from the TypeScript build (see the
+ * `*.example.ts` entries in server/tsconfig.json and the root tsconfig.json
+ * `exclude` arrays). Not imported anywhere in core, adds no dependency, and
+ * is never type-checked or run by CI.
+ *
+ * A worked, end-to-end CaptchaProvider for ALTCHA (https://altcha.org), a
+ * self-hosted, open, privacy-friendly proof-of-work captcha with no external
+ * verification service, to illustrate what an "open provider" wired into
+ * this abstraction looks like. To actually use it:
+ *
+ *   1. `yarn add altcha-lib`
+ *   2. Copy this file to `server/captcha/providers/altcha.provider.ts`
+ *      (dropping the `.example` suffix re-enters it into the build).
+ *   3. Add a `case "altcha":` branch to `createCaptchaProvider` in
+ *      `server/captcha/captcha-provider.factory.ts`.
+ *   4. Add `captcha.altcha.hmac_key` to your config.
+ *
+ * See server/captcha/WRITING-A-PROVIDER.md for the full walkthrough. The
+ * altcha-lib API used below (createChallenge/verifySolution) reflects the
+ * package's documented server-side API at the time this example was
+ * written — since this file is excluded from the build and never
+ * type-checked, confirm it against your installed altcha-lib version's docs
+ * before relying on it.
+ */
+import { createChallenge, verifySolution } from "altcha-lib";
+import type { ConfigService } from "@nestjs/config";
+import type { CaptchaClientConfig, CaptchaProvider } from "../captcha.types";
+
+export class AltchaCaptchaProvider implements CaptchaProvider {
+    readonly name = "altcha";
+
+    constructor(private readonly configService: ConfigService) {}
+
+    private resolveHmacKey(): string {
+        const key = this.configService.get<string>("captcha.altcha.hmac_key");
+        if (!key) {
+            throw new Error(
+                "AltchaCaptchaProvider requires captcha.altcha.hmac_key to be configured."
+            );
+        }
+        return key;
+    }
+
+    /** Issues a fresh proof-of-work challenge for the widget to solve. */
+    async getChallenge(): Promise<unknown> {
+        return createChallenge({
+            hmacKey: this.resolveHmacKey(),
+            maxNumber: 100000,
+        });
+    }
+
+    /** Verifies the solved-challenge payload the widget posts back. */
+    async verify(payload: string): Promise<boolean> {
+        try {
+            return await verifySolution(payload, this.resolveHmacKey());
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * ALTCHA has no sitekey — the widget fetches its own challenge from
+     * GET /api/captcha/challenge (see CaptchaController), so only
+     * challengeUrl is needed on the client.
+     */
+    getClientConfig(): CaptchaClientConfig {
+        return { provider: this.name, challengeUrl: "/api/captcha/challenge" };
+    }
+}

--- a/server/captcha/providers/noop-captcha.provider.spec.ts
+++ b/server/captcha/providers/noop-captcha.provider.spec.ts
@@ -1,0 +1,20 @@
+import { NoopCaptchaProvider } from "./noop-captcha.provider";
+
+describe("NoopCaptchaProvider (Unit)", () => {
+    it("has name 'none'", () => {
+        expect(new NoopCaptchaProvider().name).toBe("none");
+    });
+
+    it("verify() always resolves true, regardless of input", async () => {
+        const provider = new NoopCaptchaProvider();
+
+        expect(await provider.verify("anything")).toBe(true);
+        expect(await provider.verify("")).toBe(true);
+    });
+
+    it("getClientConfig() returns only { provider: 'none' } — no sitekey", () => {
+        expect(new NoopCaptchaProvider().getClientConfig()).toEqual({
+            provider: "none",
+        });
+    });
+});

--- a/server/captcha/providers/noop-captcha.provider.ts
+++ b/server/captcha/providers/noop-captcha.provider.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+import type { CaptchaClientConfig, CaptchaProvider } from "../captcha.types";
+
+/**
+ * Disables captcha verification entirely. Intended for closed / self-hosted
+ * deployments that don't need bot protection on public forms — the guide in
+ * WRITING-A-PROVIDER.md calls this out explicitly.
+ */
+@Injectable()
+export class NoopCaptchaProvider implements CaptchaProvider {
+    readonly name = "none";
+
+    async verify(): Promise<boolean> {
+        return true;
+    }
+
+    getClientConfig(): CaptchaClientConfig {
+        return { provider: this.name };
+    }
+}

--- a/server/captcha/providers/recaptcha.provider.spec.ts
+++ b/server/captcha/providers/recaptcha.provider.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { HttpService } from "@nestjs/axios";
+import { ConfigService } from "@nestjs/config";
+import { of } from "rxjs";
+import { RecaptchaProvider } from "./recaptcha.provider";
+
+function configFrom(values: Record<string, unknown>) {
+    return { get: (key: string) => values[key] } as unknown as ConfigService;
+}
+
+function httpServiceReturning(data: unknown) {
+    return {
+        post: vi.fn().mockReturnValue(of({ data })),
+    } as unknown as HttpService;
+}
+
+describe("RecaptchaProvider (Unit)", () => {
+    async function build(values: Record<string, unknown>, http: HttpService) {
+        const moduleRef: TestingModule = await Test.createTestingModule({
+            providers: [
+                RecaptchaProvider,
+                { provide: HttpService, useValue: http },
+                { provide: ConfigService, useValue: configFrom(values) },
+            ],
+        }).compile();
+        return moduleRef.get(RecaptchaProvider);
+    }
+
+    it("has name 'recaptcha'", async () => {
+        const provider = await build(
+            {},
+            httpServiceReturning({ success: true })
+        );
+        expect(provider.name).toBe("recaptcha");
+    });
+
+    it("verify() posts to the Google siteverify endpoint and returns true on success", async () => {
+        const http = httpServiceReturning({ success: true });
+        const provider = await build(
+            { recaptcha_secret: "legacy-secret" },
+            http
+        );
+
+        const result = await provider.verify("token-123");
+
+        expect(result).toBe(true);
+        expect(http.post).toHaveBeenCalledWith(
+            "https://www.google.com/recaptcha/api/siteverify",
+            new URLSearchParams({
+                secret: "legacy-secret",
+                response: "token-123",
+            }).toString()
+        );
+    });
+
+    it("verify() returns false when siteverify reports failure", async () => {
+        const provider = await build(
+            {},
+            httpServiceReturning({ success: false })
+        );
+        expect(await provider.verify("bad-token")).toBe(false);
+    });
+
+    it("verify() returns false and swallows network errors", async () => {
+        const http = {
+            post: vi.fn().mockImplementation(() => {
+                throw new Error("network down");
+            }),
+        } as unknown as HttpService;
+        const provider = await build({}, http);
+
+        expect(await provider.verify("token")).toBe(false);
+    });
+
+    it("prefers captcha.recaptcha.secret over the legacy recaptcha_secret", async () => {
+        const http = httpServiceReturning({ success: true });
+        const provider = await build(
+            {
+                "captcha.recaptcha.secret": "new-secret",
+                recaptcha_secret: "legacy-secret",
+            },
+            http
+        );
+
+        await provider.verify("token");
+
+        expect(http.post).toHaveBeenCalledWith(
+            expect.any(String),
+            new URLSearchParams({
+                secret: "new-secret",
+                response: "token",
+            }).toString()
+        );
+    });
+
+    it("getClientConfig() returns provider + sitekey, preferring captcha.recaptcha.sitekey", async () => {
+        const provider = await build(
+            {
+                "captcha.recaptcha.sitekey": "new-sitekey",
+                recaptcha_sitekey: "legacy-sitekey",
+            },
+            httpServiceReturning({ success: true })
+        );
+
+        expect(provider.getClientConfig()).toEqual({
+            provider: "recaptcha",
+            sitekey: "new-sitekey",
+        });
+    });
+
+    it("getClientConfig() falls back to the legacy recaptcha_sitekey", async () => {
+        const provider = await build(
+            { recaptcha_sitekey: "legacy-sitekey" },
+            httpServiceReturning({ success: true })
+        );
+
+        expect(provider.getClientConfig()).toEqual({
+            provider: "recaptcha",
+            sitekey: "legacy-sitekey",
+        });
+    });
+});

--- a/server/captcha/providers/recaptcha.provider.ts
+++ b/server/captcha/providers/recaptcha.provider.ts
@@ -1,0 +1,64 @@
+import { HttpService } from "@nestjs/axios";
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { firstValueFrom } from "rxjs";
+import type { CaptchaClientConfig, CaptchaProvider } from "../captcha.types";
+
+@Injectable()
+export class RecaptchaProvider implements CaptchaProvider {
+    readonly name = "recaptcha";
+    private readonly logger = new Logger("RecaptchaProvider");
+
+    constructor(
+        private readonly httpService: HttpService,
+        private readonly configService: ConfigService
+    ) {}
+
+    private resolveSecret(): string {
+        return (
+            this.configService.get<string>("captcha.recaptcha.secret") ??
+            this.configService.get<string>("recaptcha_secret") ??
+            ""
+        );
+    }
+
+    private resolveSitekey(): string | undefined {
+        return (
+            this.configService.get<string>("captcha.recaptcha.sitekey") ??
+            this.configService.get<string>("recaptcha_sitekey")
+        );
+    }
+
+    private async checkCaptchaResponse(secret: string, response: string) {
+        const RECAPTCHA_API_URL = "https://www.google.com/recaptcha/api";
+        const querystring = new URLSearchParams({
+            secret,
+            response,
+        }).toString();
+        const { data } = await firstValueFrom(
+            this.httpService.post(
+                `${RECAPTCHA_API_URL}/siteverify`,
+                querystring
+            )
+        );
+
+        return data;
+    }
+
+    async verify(token: string): Promise<boolean> {
+        try {
+            const captchaVerification = await this.checkCaptchaResponse(
+                this.resolveSecret(),
+                token
+            );
+            return captchaVerification.success;
+        } catch (err) {
+            this.logger.error(`error/recaptcha ${err} `);
+            return false;
+        }
+    }
+
+    getClientConfig(): CaptchaClientConfig {
+        return { provider: this.name, sitekey: this.resolveSitekey() };
+    }
+}

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -380,6 +380,7 @@ export class ClaimController {
             reviewTask,
             claimReview,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             hideDescriptions,
             enableCollaborativeEditor,
             enableEditorAnnotations,
@@ -438,6 +439,7 @@ export class ClaimController {
         const queryObject = Object.assign(parsedUrl.query, {
             claim,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             nameSpace: req.params.namespace,
         });
 
@@ -471,6 +473,7 @@ export class ClaimController {
         const queryObject = Object.assign(parsedUrl.query, {
             claim,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             websocketUrl: this.configService.get<string>("websocketUrl"),
             nameSpace: req.params.namespace,
             enableCollaborativeEditor,
@@ -551,6 +554,7 @@ export class ClaimController {
         const queryObject = Object.assign(parsedUrl.query, {
             personality,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             nameSpace: req.params.namespace,
             verificationRequestGroup,
         });
@@ -604,6 +608,7 @@ export class ClaimController {
         const queryObject = Object.assign(parsedUrl.query, {
             claim,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             enableCollaborativeEditor,
             enableEditorAnnotations,
             enableCopilotChatBot,
@@ -644,6 +649,7 @@ export class ClaimController {
         const queryObject = Object.assign(parsedUrl.query, {
             claim,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             enableCollaborativeEditor,
             enableEditorAnnotations,
             enableCopilotChatBot: enableCopilotChatBot,
@@ -703,6 +709,7 @@ export class ClaimController {
             personality,
             claim,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             enableCollaborativeEditor,
             enableEditorAnnotations,
             enableCopilotChatBot,

--- a/server/events/event.controller.spec.ts
+++ b/server/events/event.controller.spec.ts
@@ -11,8 +11,10 @@ import {
     mockEventsService,
     mockFeatureFlagService,
     mockViewService,
+    mockCaptchaService
 } from "../mocks/EventMock";
 import { EventsStatus } from "../types/enums";
+import { CaptchaService } from "../captcha/captcha.service";
 
 describe("EventsController (Unit)", () => {
     let controller: EventsController;
@@ -25,6 +27,7 @@ describe("EventsController (Unit)", () => {
                 { provide: EventsService, useValue: mockEventsService },
                 { provide: ViewService, useValue: mockViewService },
                 { provide: FeatureFlagService, useValue: mockFeatureFlagService },
+                { provide: CaptchaService, useValue: mockCaptchaService },
             ],
         })
             .overrideGuard(AbilitiesGuard)

--- a/server/events/event.controller.ts
+++ b/server/events/event.controller.ts
@@ -10,7 +10,7 @@ import {
     Post,
     Query,
     Req,
-    Res
+    Res,
 } from "@nestjs/common";
 import { CreateEventDTO, UpdateEventDTO } from "./dto/event.dto";
 import { ApiTags } from "@nestjs/swagger";
@@ -25,6 +25,7 @@ import { ViewService } from "../view/view.service";
 import { EventsService } from "./event.service";
 import { toError } from "../util/error-handling";
 import { FeatureFlagService } from "../feature-flag/feature-flag.service";
+import { CaptchaService } from "../captcha/captcha.service";
 
 @Controller(":namespace?")
 export class EventsController {
@@ -44,7 +45,8 @@ export class EventsController {
         private readonly eventsService: EventsService,
         private viewService: ViewService,
         private featureFlagService: FeatureFlagService,
-    ) { }
+        private readonly captchaService: CaptchaService
+    ) {}
 
     @FactCheckerOnly()
     @ApiTags("event")
@@ -83,12 +85,11 @@ export class EventsController {
     @ApiTags("pages")
     @Get("event")
     @Header("Cache-Control", "max-age=60")
-    public async eventPage(
-        @Req() req: BaseRequest,
-        @Res() res: Response
-    ) {
+    public async eventPage(@Req() req: BaseRequest, @Res() res: Response) {
         if (!this.featureFlagService.isEnableEventsFeature()) {
-            const namespace = this.getSafeNamespaceRedirect(req.params.namespace);
+            const namespace = this.getSafeNamespaceRedirect(
+                req.params.namespace
+            );
             return res.redirect(namespace);
         }
 
@@ -97,14 +98,10 @@ export class EventsController {
         const queryObject = Object.assign(parsedUrl.query, {
             nameSpace: req.params.namespace,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
         });
 
-        await this.viewService.render(
-            req,
-            res,
-            "/event-page",
-            queryObject
-        );
+        await this.viewService.render(req, res, "/event-page", queryObject);
     }
 
     @FactCheckerOnly()
@@ -115,34 +112,31 @@ export class EventsController {
         @Res() res: Response
     ) {
         if (!this.featureFlagService.isEnableEventsFeature()) {
-            const namespace = this.getSafeNamespaceRedirect(req.params.namespace);
+            const namespace = this.getSafeNamespaceRedirect(
+                req.params.namespace
+            );
             return res.redirect(namespace);
         }
 
         const parsedUrl = parse(req.url, true);
         const queryObject = Object.assign(parsedUrl.query, {
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             nameSpace: req.params.namespace,
         });
 
-        await this.viewService.render(
-            req,
-            res,
-            "/event-create",
-            queryObject
-        );
+        await this.viewService.render(req, res, "/event-create", queryObject);
     }
 
     @Public()
     @ApiTags("pages")
     @Get("event/:data_hash/:event_slug")
     @Header("Cache-Control", "max-age=60, must-revalidate")
-    public async eventViewPage(
-        @Req() req: BaseRequest,
-        @Res() res: Response,
-    ) {
+    public async eventViewPage(@Req() req: BaseRequest, @Res() res: Response) {
         if (!this.featureFlagService.isEnableEventsFeature()) {
-            const namespace = this.getSafeNamespaceRedirect(req.params.namespace);
+            const namespace = this.getSafeNamespaceRedirect(
+                req.params.namespace
+            );
             return res.redirect(namespace);
         }
 
@@ -160,6 +154,7 @@ export class EventsController {
                 event,
                 namespace: req.params.namespace,
                 sitekey: this.configService.get<string>("recaptcha_sitekey"),
+                captcha: this.captchaService.getClientConfig(),
             });
 
             await this.viewService.render(
@@ -171,7 +166,10 @@ export class EventsController {
         } catch (error) {
             if (!(error instanceof NotFoundException)) {
                 const err = toError(error);
-                this.logger.error(`Error rendering event page: ${err.message}`, err.stack);
+                this.logger.error(
+                    `Error rendering event page: ${err.message}`,
+                    err.stack
+                );
             }
             throw error;
         }

--- a/server/events/event.module.ts
+++ b/server/events/event.module.ts
@@ -10,6 +10,7 @@ import { TopicModule } from "../topic/topic.module";
 import { AbilityModule } from "../auth/ability/ability.module";
 import { Topic, TopicSchema } from "../topic/schemas/topic.schema";
 import { FeatureFlagModule } from "../feature-flag/feature-flag.module";
+import { CaptchaModule } from "../captcha/captcha.module";
 
 const EventModel = MongooseModule.forFeature([
     {
@@ -19,7 +20,7 @@ const EventModel = MongooseModule.forFeature([
     {
         name: Topic.name,
         schema: TopicSchema,
-    }
+    },
 ]);
 
 @Module({
@@ -31,6 +32,7 @@ const EventModel = MongooseModule.forFeature([
         ClaimReviewModule,
         TopicModule,
         FeatureFlagModule,
+        CaptchaModule,
     ],
     controllers: [EventsController],
     providers: [EventsService],

--- a/server/mocks/EventMock.ts
+++ b/server/mocks/EventMock.ts
@@ -54,3 +54,9 @@ export const mockRequest = {
 export const mockFeatureFlagService = {
     isEnableEventsFeature: vi.fn(),
 };
+
+export const mockCaptchaService = {
+    validate: vi.fn(),
+    getClientConfig: vi.fn(),
+    getChallenge: vi.fn(),
+};

--- a/server/personality/personality.controller.ts
+++ b/server/personality/personality.controller.ts
@@ -199,6 +199,7 @@ export class PersonalityController {
             hideDescriptions,
             nameSpace: req.params.namespace,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
         });
 
         await this.viewService.render(

--- a/server/review-task/review-task.controller.ts
+++ b/server/review-task/review-task.controller.ts
@@ -206,6 +206,7 @@ export class ReviewTaskController {
 
         const queryObject = Object.assign(parsedUrl.query, {
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             enableCollaborativeEditor,
             enableEditorAnnotations,
             enableCopilotChatBot,

--- a/server/source/source.controller.ts
+++ b/server/source/source.controller.ts
@@ -95,6 +95,7 @@ export class SourceController {
         const parsedUrl = parse(req.url, true);
         const queryObject = Object.assign(parsedUrl.query, {
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             nameSpace: req.params.namespace,
         });
 
@@ -192,6 +193,7 @@ export class SourceController {
             reviewTask,
             claimReview,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             hideDescriptions,
             enableCollaborativeEditor,
             enableEditorAnnotations,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -22,5 +22,6 @@
     "exclude": [
         "node_modules",
         "./**/*.spec.ts",
+        "./**/*.example.ts",
     ]
 }

--- a/server/users/users.controller.ts
+++ b/server/users/users.controller.ts
@@ -55,11 +55,12 @@ export class UsersController {
     public async signUp(@Req() req: Request, @Res() res: Response) {
         const parsedUrl = parse(req.url, true);
         const sitekey = this.configService.get<string>("recaptcha_sitekey");
+        const captcha = this.captchaService.getClientConfig();
         await this.viewService.render(
             req,
             res,
             "/sign-up",
-            Object.assign(parsedUrl.query, { sitekey })
+            Object.assign(parsedUrl.query, { sitekey, captcha })
         );
     }
 
@@ -77,7 +78,10 @@ export class UsersController {
         try {
             return await this.usersService.register(createUserDto);
         } catch (errorResponse) {
-            const { error } = (errorResponse as { error?: { status?: number; message?: string } }) ?? {};
+            const { error } =
+                (errorResponse as {
+                    error?: { status?: number; message?: string };
+                }) ?? {};
             if (error?.status === 409) {
                 // Ory identity already exists
                 throw new ConflictException(error?.message);

--- a/server/verification-request/verification-request.controller.ts
+++ b/server/verification-request/verification-request.controller.ts
@@ -306,6 +306,7 @@ export class VerificationRequestController {
         const parsedUrl = parse(req.url, true);
         const queryObject = Object.assign(parsedUrl.query, {
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             nameSpace: req.params.namespace,
         });
 
@@ -368,6 +369,7 @@ export class VerificationRequestController {
         const queryObject = Object.assign(parsedUrl.query, {
             nameSpace: req.params.namespace,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
         });
 
         await this.viewService.render(
@@ -420,6 +422,7 @@ export class VerificationRequestController {
             reviewTask,
             recommendations,
             sitekey: this.configService.get<string>("recaptcha_sitekey"),
+            captcha: this.captchaService.getClientConfig(),
             hideDescriptions: {},
             websocketUrl: this.configService.get<string>("websocketUrl"),
             nameSpace: req.params.namespace,

--- a/src/components/AletheiaCaptcha.altcha.example.tsx
+++ b/src/components/AletheiaCaptcha.altcha.example.tsx
@@ -1,0 +1,74 @@
+/**
+ * REFERENCE EXAMPLE — excluded from the build (see src/tsconfig.json's
+ * `*.example.tsx` exclude entry). Not imported anywhere in core, adds no
+ * dependency, never type-checked or run by CI.
+ *
+ * Shows how an ALTCHA branch would slot into AletheiaCaptcha's provider
+ * dispatch (see AletheiaCaptcha.tsx and
+ * server/captcha/WRITING-A-PROVIDER.md). Requires `yarn add @altcha/widget`
+ * (registers the <altcha-widget> custom element as an import side effect).
+ *
+ * The @altcha/widget custom-element attribute/event names below reflect its
+ * documented API at the time this example was written; confirm against your
+ * installed version's docs before relying on it, since this file is never
+ * type-checked or run.
+ */
+import "@altcha/widget";
+import React, { useEffect, useRef } from "react";
+
+interface AltchaWidgetHandle {
+    getValue: () => string;
+    resetRecaptcha: () => void;
+}
+
+interface AltchaWidgetProps {
+    challengeUrl: string;
+    onChange: (token: string) => void;
+}
+
+/**
+ * Thin wrapper around <altcha-widget>, adapted to the same imperative
+ * handle contract AletheiaCaptcha exposes (getValue, resetRecaptcha) so it
+ * can be swapped in without touching the 7 consuming forms/modals.
+ */
+const AltchaCaptchaExample = React.forwardRef<
+    AltchaWidgetHandle,
+    AltchaWidgetProps
+>(({ challengeUrl, onChange }, ref) => {
+    const valueRef = useRef("");
+    const widgetRef = useRef<HTMLElement & { reset?: () => void }>(null);
+
+    React.useImperativeHandle(ref, () => ({
+        getValue: () => valueRef.current,
+        resetRecaptcha: () => {
+            valueRef.current = "";
+            widgetRef.current?.reset?.();
+        },
+    }));
+
+    useEffect(() => {
+        const el = widgetRef.current;
+        const handleStateChange = (event: Event) => {
+            const detail = (event as CustomEvent).detail;
+            if (detail?.state === "verified" && detail?.payload) {
+                valueRef.current = detail.payload;
+                onChange(detail.payload);
+            } else if (
+                detail?.state === "expired" ||
+                detail?.state === "error"
+            ) {
+                valueRef.current = "";
+                onChange("");
+            }
+        };
+        el?.addEventListener("statechange", handleStateChange);
+        return () => el?.removeEventListener("statechange", handleStateChange);
+    }, [onChange]);
+
+    return React.createElement("altcha-widget", {
+        ref: widgetRef,
+        challengeurl: challengeUrl,
+    });
+});
+
+export default AltchaCaptchaExample;

--- a/src/components/AletheiaCaptcha.spec.ts
+++ b/src/components/AletheiaCaptcha.spec.ts
@@ -1,0 +1,19 @@
+import { resolveCaptchaRenderMode } from "./AletheiaCaptcha";
+
+describe("resolveCaptchaRenderMode (Unit)", () => {
+    it("returns 'recaptcha' when provider is 'recaptcha'", () => {
+        expect(resolveCaptchaRenderMode("recaptcha")).toBe("recaptcha");
+    });
+
+    it("returns 'none' when provider is 'none'", () => {
+        expect(resolveCaptchaRenderMode("none")).toBe("none");
+    });
+
+    it("falls back to 'recaptcha' for an unknown provider value", () => {
+        expect(resolveCaptchaRenderMode("altcha")).toBe("recaptcha");
+    });
+
+    it("falls back to 'recaptcha' when provider is undefined", () => {
+        expect(resolveCaptchaRenderMode(undefined)).toBe("recaptcha");
+    });
+});

--- a/src/components/AletheiaCaptcha.tsx
+++ b/src/components/AletheiaCaptcha.tsx
@@ -1,10 +1,30 @@
 import { useTranslation } from "next-i18next";
-import React, { forwardRef, useImperativeHandle, useState } from "react";
+import React, {
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useState,
+} from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { useAppSelector } from "../store/store";
 import Typography from "@mui/material/Typography";
 import colors from "../styles/colors";
+
 const recaptchaRef = React.createRef<ReCAPTCHA>();
+
+/** Sentinel token the "none" provider reports so gated forms read as solved. */
+export const NONE_PROVIDER_TOKEN = "none";
+
+export type CaptchaRenderMode = "recaptcha" | "none";
+
+/**
+ * Maps captcha.provider to how AletheiaCaptcha renders. Unknown/unset values
+ * fall back to "recaptcha" (the safe default) — a deployer adding a custom
+ * provider extends this per server/captcha/WRITING-A-PROVIDER.md.
+ */
+export function resolveCaptchaRenderMode(provider?: string): CaptchaRenderMode {
+    return provider === "none" ? "none" : "recaptcha";
+}
 
 interface CaptchaProps {
     onChange: (captchaString: string) => void;
@@ -13,16 +33,22 @@ interface CaptchaProps {
 const AletheiaCaptcha = forwardRef(({ onChange }: CaptchaProps, ref) => {
     const [showRequired, setShowRequired] = useState(true);
     const { t } = useTranslation();
-    // Allows the parent component to call function inside this block by using a ref
+    const { captcha, vw } = useAppSelector((state) => state);
+    const renderMode = resolveCaptchaRenderMode(captcha?.provider);
+
     useImperativeHandle(ref, () => ({
         resetRecaptcha: () => {
             if (recaptchaRef.current) {
                 recaptchaRef.current.reset();
             }
         },
+        getValue: () => {
+            if (renderMode === "none") {
+                return NONE_PROVIDER_TOKEN;
+            }
+            return recaptchaRef.current?.getValue() ?? "";
+        },
     }));
-
-    const { sitekey, vw } = useAppSelector((state) => state);
 
     const handleChangeCaptcha = async () => {
         const recaptchaString: string = recaptchaRef.current.getValue();
@@ -35,17 +61,36 @@ const AletheiaCaptcha = forwardRef(({ onChange }: CaptchaProps, ref) => {
         setShowRequired(true);
     };
 
+    // "none": no widget to render — report the sentinel immediately so gated
+    // forms read as already solved, without any change to the 7 consumers.
+    useEffect(() => {
+        if (renderMode === "none") {
+            onChange(NONE_PROVIDER_TOKEN);
+            setShowRequired(false);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [renderMode]);
+
+    if (renderMode === "none") {
+        return null;
+    }
+
     return (
         <div>
             <ReCAPTCHA
                 ref={recaptchaRef}
-                sitekey={sitekey}
+                sitekey={captcha?.sitekey}
                 size={vw?.xs ? "compact" : "normal"}
                 onChange={handleChangeCaptcha}
                 onExpired={onExpiredCaptcha}
             />
             {showRequired && (
-                <Typography variant="h1" style={{ color: colors.error, fontSize: 16 }} >{t("common:requiredFieldError")}</Typography>
+                <Typography
+                    variant="h1"
+                    style={{ color: colors.error, fontSize: 16 }}
+                >
+                    {t("common:requiredFieldError")}
+                </Typography>
             )}
         </div>
     );

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "next-i18next";
 import claimApi from "../../api/claimApi";
 import { useDispatch } from "react-redux";
 import { ActionTypes } from "../../store/types";
+import { CaptchaClientConfig } from "../../types/Captcha";
 
 const extensions = () => [
     new EditorClaimCardExtension({ disableExtraAttributes: true }),
@@ -22,9 +23,10 @@ const extensions = () => [
 export interface IEditorProps {
     claim: any;
     sitekey: string;
+    captcha: CaptchaClientConfig;
 }
 
-const Editor = ({ claim, sitekey }: IEditorProps) => {
+const Editor = ({ claim, sitekey, captcha }: IEditorProps) => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const personalities = claim.personalities;
@@ -41,6 +43,10 @@ const Editor = ({ claim, sitekey }: IEditorProps) => {
     dispatch({
         type: ActionTypes.SET_SITEKEY,
         sitekey,
+    });
+    dispatch({
+        type: ActionTypes.SET_CAPTCHA_CONFIG,
+        captcha,
     });
 
     const [debate, setDebate] = useAtom(debateAtom);
@@ -80,16 +86,21 @@ const Editor = ({ claim, sitekey }: IEditorProps) => {
                 justifyContent: "center",
             }}
         >
-            <Grid item sm={11} style={{ display: "flex", justifyContent: "end" }}>
+            <Grid
+                item
+                sm={11}
+                style={{ display: "flex", justifyContent: "end" }}
+            >
                 <AletheiaButton
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={handleClickUpdateStatus}
                     type={ButtonType.whiteBlack}
                 >
                     {t(
-                        `debates:${isLive
-                            ? "finishDebateButtonLabel"
-                            : "reopenDebateButtonLabel"
+                        `debates:${
+                            isLive
+                                ? "finishDebateButtonLabel"
+                                : "reopenDebateButtonLabel"
                         }`
                     )}
                 </AletheiaButton>

--- a/src/pages/admin-badges.tsx
+++ b/src/pages/admin-badges.tsx
@@ -18,7 +18,8 @@ const AdminBadgesPage: NextPage<{ data: string }> = ({
     badges,
     users,
     nameSpace,
-    sitekey
+    sitekey,
+    captcha,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     const setBadgesList = useSetAtom(atomBadgesList);
     const setUserlist = useSetAtom(atomUserList);
@@ -31,10 +32,14 @@ const AdminBadgesPage: NextPage<{ data: string }> = ({
     const { t } = useTranslation();
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <>
-            <Seo title={t("header:badgesItem")} description={t("badges:title")} />
+            <Seo
+                title={t("header:badgesItem")}
+                description={t("badges:title")}
+            />
             <BadgesView />
             <BadgesFormDrawer />
         </>
@@ -51,6 +56,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             users: JSON.parse(JSON.stringify(query.users)),
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
             sitekey: query.sitekey,
+            captcha: query.captcha,
         },
     };
 }

--- a/src/pages/admin-namespaces.tsx
+++ b/src/pages/admin-namespaces.tsx
@@ -12,6 +12,7 @@ import actions from "../store/actions";
 
 const AdminNameSpacesPage: NextPage<{ data: string }> = ({
     sitekey,
+    captcha,
     nameSpaces,
     users,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
@@ -21,6 +22,7 @@ const AdminNameSpacesPage: NextPage<{ data: string }> = ({
     setUserlist(users);
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <>
@@ -38,6 +40,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             ...(await serverSideTranslations(locale)),
             nameSpaces: JSON.parse(JSON.stringify(query.nameSpaces)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             users: JSON.parse(JSON.stringify(query.users)),
         },
     };

--- a/src/pages/claim-create.tsx
+++ b/src/pages/claim-create.tsx
@@ -18,6 +18,7 @@ import { currentNameSpace } from "../atoms/namespace";
 
 const ClaimCreatePage: NextPage<any> = ({
     sitekey,
+    captcha,
     personality,
     nameSpace,
     verificationRequestGroup,
@@ -27,6 +28,7 @@ const ClaimCreatePage: NextPage<any> = ({
     setCurrentNameSpace(nameSpace);
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     return (
         <>
             <Seo
@@ -58,6 +60,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
         props: {
             ...(await serverSideTranslations(locale)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             // Nextjs have problems with client re-hydration for some serialized objects
             // This is a hack until a better solution https://github.com/vercel/next.js/issues/11993
             personality: query?.personality

--- a/src/pages/claim-page.tsx
+++ b/src/pages/claim-page.tsx
@@ -11,11 +11,13 @@ import { useTranslation } from "next-i18next";
 import { NameSpaceEnum } from "../types/Namespace";
 import { useSetAtom } from "jotai";
 import { currentNameSpace } from "../atoms/namespace";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 export interface ClaimPageProps {
     personality: any;
     claim: any;
     sitekey: string;
+    captcha: CaptchaClientConfig;
     href: string;
     enableCollaborativeEditor: boolean;
     enableCopilotChatBot: boolean;
@@ -32,6 +34,7 @@ const ClaimPage: NextPage<ClaimPageProps> = (props) => {
         personality,
         claim,
         sitekey,
+        captcha,
         enableCollaborativeEditor,
         enableCopilotChatBot,
         enableEditorAnnotations,
@@ -45,6 +48,7 @@ const ClaimPage: NextPage<ClaimPageProps> = (props) => {
 
     dispatch(actions.setWebsocketUrl(props.websocketUrl));
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     dispatch(actions.closeCopilotDrawer());
     dispatch(
         actions.setEditorEnvironment(
@@ -103,6 +107,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
                 : null,
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
             sitekey: query.sitekey,
+            captcha: query.captcha,
             enableCollaborativeEditor: query?.enableCollaborativeEditor,
             enableCopilotChatBot: query?.enableCopilotChatBot,
             enableEditorAnnotations: query?.enableEditorAnnotations,

--- a/src/pages/claim-review.tsx
+++ b/src/pages/claim-review.tsx
@@ -17,12 +17,14 @@ import { NameSpaceEnum } from "../types/Namespace";
 import { useSetAtom } from "jotai";
 import { currentNameSpace } from "../atoms/namespace";
 import { ReviewTaskTypeEnum } from "../machines/reviewTask/enums";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 export interface ClaimReviewPageProps {
     personality?: any;
     claim: any;
     content: any;
     sitekey: string;
+    captcha: CaptchaClientConfig;
     reviewTask: any;
     claimReview: any;
     hideDescriptions: object;
@@ -47,6 +49,7 @@ const ClaimReviewPage: NextPage<ClaimReviewPageProps> = (props) => {
         content,
         claimReview,
         sitekey,
+        captcha,
         enableCollaborativeEditor,
         enableCopilotChatBot,
         enableEditorAnnotations,
@@ -58,6 +61,7 @@ const ClaimReviewPage: NextPage<ClaimReviewPageProps> = (props) => {
 
     dispatch(actions.setWebsocketUrl(props.websocketUrl));
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     dispatch(actions.closeCopilotDrawer());
     dispatch(
         actions.setEditorEnvironment(
@@ -67,7 +71,7 @@ const ClaimReviewPage: NextPage<ClaimReviewPageProps> = (props) => {
             false,
             enableReviewersUpdateReport,
             enableViewReportPreview,
-            enableInformativeNews,
+            enableInformativeNews
         )
     );
     dispatch(actions.setSelectPersonality(personality));
@@ -161,6 +165,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             reviewTask: JSON.parse(JSON.stringify(query.reviewTask)),
             claimReview: JSON.parse(JSON.stringify(query.claimReview)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             hideDescriptions: JSON.parse(
                 JSON.stringify(query.hideDescriptions)
             ),

--- a/src/pages/debate-editor.tsx
+++ b/src/pages/debate-editor.tsx
@@ -17,10 +17,10 @@ const Editor = dynamic<IEditorProps>(
 
 const DebateEditor: NextPage<
     InferGetServerSidePropsType<typeof getServerSideProps>
-> = ({ claim, sitekey, nameSpace }) => {
+> = ({ claim, sitekey, captcha, nameSpace }) => {
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(nameSpace);
-    return <Editor claim={claim} sitekey={sitekey} />;
+    return <Editor claim={claim} sitekey={sitekey} captcha={captcha} />;
 };
 
 export async function getServerSideProps({ query, locale, locales, req }) {
@@ -31,6 +31,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             ...(await serverSideTranslations(locale)),
             claim: JSON.parse(JSON.stringify(query?.claim)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
         },
     };

--- a/src/pages/debate-page.tsx
+++ b/src/pages/debate-page.tsx
@@ -14,6 +14,7 @@ import { currentNameSpace } from "../atoms/namespace";
 const DebatePage: NextPage<any> = ({
     claim,
     sitekey,
+    captcha,
     nameSpace,
     enableCollaborativeEditor,
     enableCopilotChatBot,
@@ -25,6 +26,7 @@ const DebatePage: NextPage<any> = ({
     setCurrentNameSpace(nameSpace);
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     dispatch(
         actions.setEditorEnvironment(
             enableCollaborativeEditor,
@@ -52,6 +54,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             ...(await serverSideTranslations(locale)),
             claim: JSON.parse(JSON.stringify(query?.claim)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
             enableCollaborativeEditor: query?.enableCollaborativeEditor,
             enableCopilotChatBot: query?.enableCopilotChatBot,

--- a/src/pages/event-create.tsx
+++ b/src/pages/event-create.tsx
@@ -9,17 +9,20 @@ import { GetLocale } from "../utils/GetLocale";
 import { NameSpaceEnum } from "../types/Namespace";
 import { currentNameSpace } from "../atoms/namespace";
 import CreateEventView from "../components/Event/EventForm/CreateEventView";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 const CreateEventPage: NextPage<{
     nameSpace: NameSpaceEnum;
     sitekey: string;
-}> = ({ nameSpace, sitekey }) => {
+    captcha: CaptchaClientConfig;
+}> = ({ nameSpace, sitekey, captcha }) => {
     const { t } = useTranslation();
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(nameSpace);
 
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <>
@@ -40,6 +43,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
         props: {
             ...(await serverSideTranslations(locale)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
         },
     };

--- a/src/pages/event-page.tsx
+++ b/src/pages/event-page.tsx
@@ -8,16 +8,19 @@ import { useDispatch } from "react-redux";
 import actions from "../store/actions";
 import EventsList from "../components/Event/EventList/EventsList";
 import AffixButton from "../components/AffixButton/AffixButton";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 const EventPage: NextPage<{
     nameSpace: NameSpaceEnum;
     sitekey: string;
-}> = ({ nameSpace, sitekey }) => {
+    captcha: CaptchaClientConfig;
+}> = ({ nameSpace, sitekey, captcha }) => {
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(nameSpace);
 
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <>
@@ -36,6 +39,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             ...(await serverSideTranslations(locale)),
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
             sitekey: query.sitekey,
+            captcha: query.captcha,
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
         },
     };

--- a/src/pages/event-view-page.tsx
+++ b/src/pages/event-view-page.tsx
@@ -9,30 +9,31 @@ import { useDispatch } from "react-redux";
 import actions from "../store/actions";
 import EventView from "../components/Event/EventView/EventView";
 import AffixButton from "../components/AffixButton/AffixButton";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 interface EventPageProps {
     event: EventPayload;
     nameSpace: NameSpaceEnum;
     sitekey: string;
+    captcha: CaptchaClientConfig;
 }
 
 const EventViewPage: NextPage<EventPageProps> = ({
     event,
     nameSpace,
-    sitekey
+    sitekey,
+    captcha,
 }) => {
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(nameSpace);
 
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <main>
-            <EventView
-                event={event}
-                nameSpace={nameSpace}
-            />
+            <EventView event={event} nameSpace={nameSpace} />
             <AffixButton />
         </main>
     );
@@ -48,6 +49,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             event: query.event || null,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
             sitekey: query.sitekey,
+            captcha: query.captcha,
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
         },
     };

--- a/src/pages/kanban-page.tsx
+++ b/src/pages/kanban-page.tsx
@@ -18,6 +18,7 @@ import Cookies from "js-cookie";
 
 const KanbanPage: NextPage<{
     sitekey;
+    captcha;
     enableCollaborativeEditor: boolean;
     enableCopilotChatBot: boolean;
     enableEditorAnnotations: boolean;
@@ -31,6 +32,7 @@ const KanbanPage: NextPage<{
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(props.nameSpace);
     dispatch(actions.setSitekey(props.sitekey));
+    dispatch(actions.setCaptchaConfig(props.captcha));
     dispatch(actions.setWebsocketUrl(props.websocketUrl));
     dispatch(actions.closeCopilotDrawer());
     dispatch(
@@ -77,6 +79,7 @@ export async function getServerSideProps({ locale, locales, req, query }) {
         props: {
             ...(await serverSideTranslations(locale)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             enableCollaborativeEditor: query?.enableCollaborativeEditor,
             enableCopilotChatBot: query?.enableCopilotChatBot,
             enableEditorAnnotations: query?.enableEditorAnnotations,

--- a/src/pages/personality-page.tsx
+++ b/src/pages/personality-page.tsx
@@ -15,12 +15,14 @@ import { useEffect } from "react";
 import { currentNameSpace } from "../atoms/namespace";
 import { NameSpaceEnum } from "../types/Namespace";
 import { isAdmin } from "../utils/GetUserPermission";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 const PersonalityPage: NextPage<{
     personality: any;
     href: any;
     personalities: any[];
     sitekey: string;
+    captcha: CaptchaClientConfig;
     hideDescriptions: object;
     nameSpace: NameSpaceEnum;
 }> = ({
@@ -28,6 +30,7 @@ const PersonalityPage: NextPage<{
     href,
     personalities,
     sitekey,
+    captcha,
     hideDescriptions,
     nameSpace,
 }) => {
@@ -38,7 +41,8 @@ const PersonalityPage: NextPage<{
 
     useEffect(() => {
         dispatch(actions.setSitekey(sitekey));
-    }, [dispatch, sitekey]);
+        dispatch(actions.setCaptchaConfig(captcha));
+    }, [dispatch, sitekey, captcha]);
 
     const jsonldContent = {
         "@context": "https://schema.org",
@@ -87,6 +91,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
             sitekey: query.sitekey,
+            captcha: query.captcha,
         },
     };
 }

--- a/src/pages/sign-up.tsx
+++ b/src/pages/sign-up.tsx
@@ -7,22 +7,25 @@ import actions from "../store/actions";
 
 import Seo from "../components/Seo";
 import { GetLocale } from "../utils/GetLocale";
+import { CaptchaClientConfig } from "../types/Captcha";
 
-const SignUpPage: NextPage<{ sitekey: string }> = ({ sitekey }) => {
-    const { t } = useTranslation();
-    const dispatch = useDispatch();
-    dispatch(actions.setSitekey(sitekey));
+const SignUpPage: NextPage<{ sitekey: string; captcha: CaptchaClientConfig }> =
+    ({ sitekey, captcha }) => {
+        const { t } = useTranslation();
+        const dispatch = useDispatch();
+        dispatch(actions.setSitekey(sitekey));
+        dispatch(actions.setCaptchaConfig(captcha));
 
-    return (
-        <>
-            <Seo
-                title={t("login:signup")}
-                description={t("login:signupFormHeader")}
-            />
-            <LoginView isSignUp />
-        </>
-    );
-};
+        return (
+            <>
+                <Seo
+                    title={t("login:signup")}
+                    description={t("login:signupFormHeader")}
+                />
+                <LoginView isSignUp />
+            </>
+        );
+    };
 
 export async function getServerSideProps({ locale, locales, req, query }) {
     locale = GetLocale(req, locale, locales);
@@ -32,6 +35,7 @@ export async function getServerSideProps({ locale, locales, req, query }) {
         props: {
             ...(await serverSideTranslations(locale)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
         },
     };
 }

--- a/src/pages/source-review.tsx
+++ b/src/pages/source-review.tsx
@@ -16,10 +16,12 @@ import { ReviewTaskTypeEnum } from "../machines/reviewTask/enums";
 import ClaimReviewView from "../components/ClaimReview/ClaimReviewView";
 import { ClassificationEnum } from "../types/enums";
 import JsonLd from "../components/JsonLd";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 export interface SourceReviewPageProps {
     source: any;
     sitekey: string;
+    captcha: CaptchaClientConfig;
     reviewTask: any;
     sourceReview: any;
     hideDescriptions: object;
@@ -41,6 +43,7 @@ const SourceReviewPage: NextPage<SourceReviewPageProps> = (props) => {
         source,
         sourceReview: claimReview,
         sitekey,
+        captcha,
         enableCollaborativeEditor,
         enableCopilotChatBot,
         enableEditorAnnotations,
@@ -51,6 +54,7 @@ const SourceReviewPage: NextPage<SourceReviewPageProps> = (props) => {
 
     dispatch(actions.setWebsocketUrl(props.websocketUrl));
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     dispatch(actions.closeCopilotDrawer());
     dispatch(
         actions.setEditorEnvironment(
@@ -132,6 +136,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             reviewTask: JSON.parse(JSON.stringify(query.reviewTask)),
             sourceReview: JSON.parse(JSON.stringify(query.claimReview)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             hideDescriptions: JSON.parse(
                 JSON.stringify(query.hideDescriptions)
             ),

--- a/src/pages/sources-create.tsx
+++ b/src/pages/sources-create.tsx
@@ -10,12 +10,13 @@ import { NameSpaceEnum } from "../types/Namespace";
 import { currentNameSpace } from "../atoms/namespace";
 import CreateSourceView from "../components/Source/CreateSource/CreateSourceView";
 
-const CreateSourcesPage: NextPage<any> = ({ sitekey, nameSpace }) => {
+const CreateSourcesPage: NextPage<any> = ({ sitekey, captcha, nameSpace }) => {
     const { t } = useTranslation();
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(nameSpace);
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     return (
         <>
             <Seo
@@ -34,6 +35,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
         props: {
             ...(await serverSideTranslations(locale)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
         },
     };

--- a/src/pages/verification-request-create.tsx
+++ b/src/pages/verification-request-create.tsx
@@ -12,6 +12,7 @@ import CreateVerificationRequestView from "../components/VerificationRequest/ver
 
 const CreateVerificationRequestPage: NextPage<any> = ({
     sitekey,
+    captcha,
     nameSpace,
 }) => {
     const { t } = useTranslation();
@@ -19,6 +20,7 @@ const CreateVerificationRequestPage: NextPage<any> = ({
     setCurrentNameSpace(nameSpace);
     const dispatch = useDispatch();
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
     return (
         <>
             <Seo
@@ -37,6 +39,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
         props: {
             ...(await serverSideTranslations(locale)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
         },
     };

--- a/src/pages/verification-request-page.tsx
+++ b/src/pages/verification-request-page.tsx
@@ -12,13 +12,18 @@ import VerificationRequestView from "../components/VerificationRequest/Verificat
 import { useDispatch } from "react-redux";
 import actions from "../store/actions";
 
-const VerificationRequestPage: NextPage<{ nameSpace, sitekey }> = ({ nameSpace, sitekey }) => {
+const VerificationRequestPage: NextPage<{ nameSpace; sitekey; captcha }> = ({
+    nameSpace,
+    sitekey,
+    captcha,
+}) => {
     const { t } = useTranslation();
     const dispatch = useDispatch();
 
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(nameSpace);
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <>
@@ -42,6 +47,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             // This is a hack until a better solution https://github.com/vercel/next.js/issues/11993
             href: req.protocol + "://" + req.get("host") + req.originalUrl,
             sitekey: query.sitekey,
+            captcha: query.captcha,
             nameSpace: query.nameSpace ? query.nameSpace : NameSpaceEnum.Main,
         },
     };

--- a/src/pages/verification-request-review-page.tsx
+++ b/src/pages/verification-request-review-page.tsx
@@ -13,10 +13,12 @@ import ClaimReviewView from "../components/ClaimReview/ClaimReviewView";
 import { ReviewTaskTypeEnum } from "../machines/reviewTask/enums";
 import { VerificationRequestProvider } from "../components/VerificationRequest/VerificationRequestProvider";
 import { VerificationRequest } from "../types/VerificationRequest";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 export interface SourceReviewPageProps {
     verificationRequest: VerificationRequest;
     sitekey: string;
+    captcha: CaptchaClientConfig;
     reviewTask: any;
     hideDescriptions: object;
     websocketUrl: string;
@@ -25,13 +27,19 @@ export interface SourceReviewPageProps {
 }
 
 const SourceReviewPage: NextPage<SourceReviewPageProps> = (props) => {
-    const { verificationRequest, sitekey, hideDescriptions, recommendations } =
-        props;
+    const {
+        verificationRequest,
+        sitekey,
+        captcha,
+        hideDescriptions,
+        recommendations,
+    } = props;
     const dispatch = useDispatch();
     const setCurrentNameSpace = useSetAtom(currentNameSpace);
     setCurrentNameSpace(props.nameSpace as NameSpaceEnum);
     dispatch(actions.setWebsocketUrl(props.websocketUrl));
     dispatch(actions.setSitekey(sitekey));
+    dispatch(actions.setCaptchaConfig(captcha));
 
     return (
         <>
@@ -69,6 +77,7 @@ export async function getServerSideProps({ query, locale, locales, req }) {
             recommendations: JSON.parse(JSON.stringify(query.recommendations)),
             reviewTask: JSON.parse(JSON.stringify(query.reviewTask)),
             sitekey: query.sitekey,
+            captcha: query.captcha,
             hideDescriptions: JSON.parse(
                 JSON.stringify(query.hideDescriptions)
             ),

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -56,6 +56,10 @@ const actions = {
         type: ActionTypes.SET_SITEKEY,
         sitekey,
     }),
+    setCaptchaConfig: (captcha) => ({
+        type: ActionTypes.SET_CAPTCHA_CONFIG,
+        captcha,
+    }),
     setWebsocketUrl: (websocketUrl) => ({
         type: ActionTypes.SET_WEBSOCKET_URL,
         websocketUrl,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -236,6 +236,12 @@ const reducer = (state, action) => {
                 ...state,
                 sitekey: action.sitekey,
             };
+        case ActionTypes.SET_CAPTCHA_CONFIG:
+            return {
+                ...state,
+                captcha: action.captcha,
+                sitekey: action.captcha?.sitekey,
+            };
         default:
             return state;
     }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -240,7 +240,9 @@ const reducer = (state, action) => {
             return {
                 ...state,
                 captcha: action.captcha,
-                sitekey: action.captcha?.sitekey,
+                // Keep any existing sitekey if this config omits one, so a
+                // captcha-less dispatch can't clear a previously set sitekey.
+                sitekey: action.captcha?.sitekey ?? state.sitekey,
             };
         default:
             return state;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,6 +1,7 @@
 import { Content } from "../types/Content";
 import { Personality } from "../types/Personality";
 import { WidthBreakpoints } from "../hooks/useMediaQueryBreakpoints";
+import { CaptchaClientConfig } from "../types/Captcha";
 
 export enum ActionTypes {
     SET_WEBSOCKET_URL,
@@ -37,6 +38,7 @@ export enum ActionTypes {
     SET_SEARCH_OVERLAY_NAME,
     SET_STATUS_FILTER_USED,
     SET_IMPACT_AREA_FILTER_USED,
+    SET_CAPTCHA_CONFIG,
 }
 
 export enum SearchTypes {
@@ -86,4 +88,5 @@ export interface RootState {
     selectedTarget: any;
     selectedContent: Content;
     sitekey: string;
+    captcha: CaptchaClientConfig;
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -24,6 +24,7 @@
     "./**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.example.tsx"
   ]
 }

--- a/src/types/Captcha.ts
+++ b/src/types/Captcha.ts
@@ -1,0 +1,6 @@
+export interface CaptchaClientConfig {
+    /** Known core values: "recaptcha" | "none". Custom providers add their own. */
+    provider: string;
+    sitekey?: string;
+    challengeUrl?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,7 @@
     "node_modules",
     "dist",
     "docs",
-    "server/**/*.spec.ts"
+    "server/**/*.spec.ts",
+    "server/**/*.example.ts"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
                     setupFiles: ["./server/tests/per-worker-setup.ts"],
                     teardownTimeout: 10000,
                     testTimeout: 30000,
+                    hookTimeout: 30000,
                     pool: "forks",
                 },
             },


### PR DESCRIPTION
## Why

Captcha validation was hardcoded to Google reCAPTCHA — the backend called Google's `siteverify` and the frontend rendered `react-google-recaptcha`. A deployer couldn't disable captcha or substitute an open alternative without editing source. This PR makes captcha a **provider abstraction** selected by configuration, advancing platform independence. The abstraction itself is the deliverable: **core ships only `recaptcha` (unchanged default) and `none`**; an open provider (ALTCHA) is delivered as a build-excluded reference example + guide, so core takes on no new third-party dependency.

## What

**Backend**
- `CaptchaProvider` interface + `CAPTCHA_PROVIDER` DI token, bound by a config-selected factory in `CaptchaModule`.
- `RecaptchaProvider` (default; the existing siteverify logic, with **legacy `recaptcha_secret`/`recaptcha_sitekey` fallback**) and `NoopCaptchaProvider` (`verify()` → `true`).
- `CaptchaService.validate(token)` now just delegates to the injected provider, so **all ~8 existing controller call sites are unchanged**. Adds `getClientConfig()` / `getChallenge()` pass-throughs.
- Two new `@Public()` endpoints: `GET /api/captcha/config` and `GET /api/captcha/challenge` (404 when the active provider has no challenge). The existing `captcha-bridge` handler is **untouched** (it's under active development elsewhere).
- ~20 SSR page-prop sites now inject `captcha: getClientConfig()` alongside the retained `sitekey`; three controllers (`name-space`, `events`, `badge`) got `CaptchaModule` wired in.

**Frontend**
- Redux gains a `captcha` config object + `setCaptchaConfig` action (the existing `sitekey` is kept/derived for transition).
- `AletheiaCaptcha.tsx` becomes a small dispatcher: `recaptcha` → the existing widget; `none` → renders nothing and emits a non-empty sentinel token on mount so the **7 consuming forms need no changes** and submission isn't blocked; unknown → reCAPTCHA fallback. The pure decision logic is extracted to `resolveCaptchaRenderMode` and unit-tested.

**Open provider as example (no dependency)**
- `server/captcha/providers/altcha.provider.example.ts` and `src/components/AletheiaCaptcha.altcha.example.tsx` are **excluded from all tsconfigs**, so their `altcha-lib` / `@altcha/widget` imports never affect `yarn build-ts`. `server/captcha/WRITING-A-PROVIDER.md` documents how to wire an open provider (factory `case`, config, frontend switch, deps).

## Configure

```yaml
captcha:
  provider: recaptcha   # recaptcha | none  (custom providers add their own value)
  recaptcha:
    sitekey: "<sitekey>"
    secret: RECAPTCHA_SECRET
```
Absent `captcha.*` → falls back to the legacy flat keys with `provider: recaptcha`. **Existing deployments need zero config change.** Set `provider: none` to disable captcha.

## Testing

- 26 unit tests pass (providers, factory, service delegation, controller 404-on-no-challenge, noop→true, legacy fallback, and the frontend `resolveCaptchaRenderMode` helper). `yarn build-ts` clean (verified the excluded example files don't break the build despite their deps being absent).
- Not exercised locally: a full `next build` and a live runtime smoke of the endpoints / a `none`-configured form submit — worth a quick manual check before/after merge.

## Scope

Captcha only. The LLM/embeddings abstraction and New Relic removal are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)