### PR TITLE
Fix not-fact report validation

### DIFF
--- a/public/locales/en/claimReview.json
+++ b/public/locales/en/claimReview.json
@@ -7,6 +7,7 @@
     "summarySectionTitle": "Summary of conclusion",
     "questionsSectionTitle": "What questions should the verification answer?",
     "verificationSectionTitle": "Verification report",
+    "notFactStandardMessage": "Not fact: subjective information, opinions, or value judgments - this is not information with a theoretical basis;",
     "howSectionTitle": "How do we check?",
     "warningAlertTitle": "This report is hidden",
     "descriptionInputPlaceholder": "Insert the description",

--- a/public/locales/pt/claimReview.json
+++ b/public/locales/pt/claimReview.json
@@ -7,6 +7,7 @@
     "summarySectionTitle": "Resumo da conclusão",
     "questionsSectionTitle": "Quais perguntas a verificação deverá responder?",
     "verificationSectionTitle": "Relatório da verificação",
+    "notFactStandardMessage": "Não é fato: informações subjetivas, opiniões ou juízo de valor - não é uma informação com embasamento teórico;",
     "howSectionTitle": "Como verificamos?",
     "warningAlertTitle": "Este relatório está oculto",
     "descriptionInputPlaceholder": "Preencha a descrição",

--- a/server/review-task/validation.spec.ts
+++ b/server/review-task/validation.spec.ts
@@ -58,6 +58,47 @@ describe("validateFormSubmission", () => {
 
             expect(errors.some((e) => e.field === "sources")).toBe(false);
         });
+
+        it("should not require report content for not-fact classification", () => {
+            const errors = validateFormSubmission(
+                buildInput({
+                    formData: {
+                        classification: "not-fact",
+                        visualEditor: null,
+                    },
+                })
+            );
+
+            expect(errors.some((e) => e.field === "visualEditor")).toBe(false);
+        });
+
+        it("should still require sources for not-fact classification", () => {
+            const errors = validateFormSubmission(
+                buildInput({
+                    formData: {
+                        classification: "not-fact",
+                        visualEditor: null,
+                    },
+                    editorSources: [],
+                    machineSources: [],
+                })
+            );
+
+            expect(errors.some((e) => e.field === "sources")).toBe(true);
+        });
+
+        it("should still require report content for regular classifications", () => {
+            const errors = validateFormSubmission(
+                buildInput({
+                    formData: {
+                        classification: "false",
+                        visualEditor: null,
+                    },
+                })
+            );
+
+            expect(errors.some((e) => e.field === "visualEditor")).toBe(true);
+        });
     });
 
     describe("publish", () => {
@@ -106,6 +147,34 @@ describe("validateFormSubmission", () => {
             );
 
             expect(errors.some((e) => e.field === "sources")).toBe(false);
+        });
+
+        it("should not require report content for not-fact classification", () => {
+            const errors = validateFormSubmission(
+                buildInput({
+                    event: ReviewTaskEvents.publish,
+                    formData: {
+                        classification: "not-fact",
+                        visualEditor: null,
+                    },
+                })
+            );
+
+            expect(errors.some((e) => e.field === "visualEditor")).toBe(false);
+        });
+
+        it("should still require report content for regular classifications", () => {
+            const errors = validateFormSubmission(
+                buildInput({
+                    event: ReviewTaskEvents.publish,
+                    formData: {
+                        classification: "trustworthy",
+                        visualEditor: null,
+                    },
+                })
+            );
+
+            expect(errors.some((e) => e.field === "visualEditor")).toBe(true);
         });
     });
 

--- a/src/components/SentenceReport/SentenceReportContent.tsx
+++ b/src/components/SentenceReport/SentenceReportContent.tsx
@@ -10,6 +10,8 @@ import { useSelector } from "@xstate/react";
 import { publishedSelector } from "../../machines/reviewTask/selectors";
 import { ReviewTaskMachineContext } from "../../machines/reviewTask/ReviewTaskMachineProvider";
 
+const NOT_FACT_CLASSIFICATION = "not-fact";
+
 const SentenceReportContent = ({
     context,
     classification,
@@ -27,6 +29,7 @@ const SentenceReportContent = ({
         useSelector(machineService, publishedSelector) ||
         publishedReview?.review
     );
+    const isNotFact = classification === NOT_FACT_CLASSIFICATION;
 
     return (
         <SentenceReportContentStyle>
@@ -74,13 +77,19 @@ const SentenceReportContent = ({
                     <Divider className="report-Divider" />
                 </Grid>
             )}
-            {report && (
+            {(report || isNotFact) && (
                 <Grid item xs={12}>
                     <Typography variant="body1" className="title">
                         {t("claimReview:verificationSectionTitle")}
                     </Typography>
                     <p
-                        dangerouslySetInnerHTML={{ __html: sanitizer(report) }}
+                        dangerouslySetInnerHTML={{
+                            __html: sanitizer(
+                                isNotFact
+                                    ? t("claimReview:notFactStandardMessage")
+                                    : report
+                            ),
+                        }}
                         className="paragraph"
                     />
                     <Divider className="report-Divider" />

--- a/src/machines/reviewTask/validation.ts
+++ b/src/machines/reviewTask/validation.ts
@@ -24,6 +24,8 @@ const EVENTS_REQUIRING_SOURCES = [
     ReviewTaskEvents.publish,
 ];
 
+const NOT_FACT_CLASSIFICATION = "not-fact";
+
 export function validateFormSubmission(
     input: ValidationInput
 ): ValidationError[] {
@@ -43,13 +45,16 @@ export function validateFormSubmission(
         });
     }
 
+    const requiresReportContent =
+        formData.classification !== NOT_FACT_CLASSIFICATION;
+
     // Editor content required — check each block individually to report ALL missing fields
-    if (!formData.visualEditor) {
+    if (requiresReportContent && !formData.visualEditor) {
         errors.push({
             field: "visualEditor",
             message: "common:requiredFieldError",
         });
-    } else {
+    } else if (requiresReportContent) {
         const editorParser = new EditorParser();
         const editorJson =
             formData.visualEditor.toJSON?.() || formData.visualEditor;


### PR DESCRIPTION
# Description
Fixes #1082.

Reviews classified as `not-fact` should not require the normal fact-check report because this classification is used for subjective information, opinions, or value judgments rather than a factual claim requiring the standard verification workflow.

This change:
- skips the normal report-content requirement for `not-fact` on finish/report and publish validation
- preserves the classification and source requirements
- preserves normal report-content validation for other classifications
- displays the standard localized `not-fact` explanation in the final report content
- adds focused regression coverage for the validation behavior

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
Ran:
- `corepack yarn test server/review-task/validation.spec.ts`
- `corepack yarn build-ts`
- `corepack yarn lint`

Verified scenarios:
- `not-fact` can pass `finishReport` validation without normal report content
- `not-fact` can pass `publish` validation without normal report content
- `not-fact` still requires sources
- regular classifications still require normal report content
- final report rendering uses the localized standard `not-fact` message

Not run:
- full unit test suite
- Cypress/end-to-end test suite
- full local Docker-backed manual workflow

# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas
- [ ] Repository documentation has been updated (Readme.md) with additional steps required for a local environment setup.
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY.
- [ ] Documented with TSDoc all library and controller new functions

## Frontend Changes
- [x] No new styling is added through CSS files (Unless it's a bugfix/hotfix)
- [x] All types are added correctly

## Backend Changes
- [ ] All endpoints are appropriately secured with Middleware authentication
- [ ] All new endpoints have a interface schema defined

### Tests
- [ ] All existing unit and end to end tests pass across all services
- [x] Unit tests have been added to cover the validation behavior

### Test IDs
- [ ] Include the test ID when adding new tasks or components.
- [x] Check that test IDs are present in the modified components.

# Merge Request Review Checklist
- [x] An issue is linked to this PR and these changes meet the requirements outlined in the linked issue(s)
- [ ] High risk and core workflows have been tested and verified in a local environment.
- [x] Enhancements or opportunities to improve performance, stability, security or code readability have been noted and documented in Project do Github issues if not being addressed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Changes to multiple services can be deployed in parallel and independently.