### PR TITLE
fix(cache): serve hashed Next assets as immutable and mark guarded routes private

### DIFF
--- a/CACHING.md
+++ b/CACHING.md
@@ -1,0 +1,149 @@
+# Caching
+
+This document describes how Aletheia caches pages and assets. Cloudflare is in
+front of the NestJS server in production. Read this document before you change a
+`Cache-Control` header or a Cloudflare rule.
+
+## How the edge behaves
+
+Cloudflare caches a response by file extension by default. Files such as `.js`,
+`.css`, `.ico`, and `.woff2` follow the `Cache-Control` header from the origin.
+HTML has no extension, so Cloudflare marks it `DYNAMIC` and does not cache it.
+A `Cache-Control` header on a page controller reaches browsers only. To cache
+HTML at the edge, you must add a Cache Rule in the Cloudflare dashboard.
+
+## Static assets under `/_next/static`
+
+`ViewController.staticAssets` serves these files with
+`public, max-age=31536000, immutable`.
+
+A long lifetime is safe here. Every URL under `/_next/static` contains a content
+hash or the build ID. Two examples from production:
+
+- `/_next/static/chunks/framework-c17f08e07d1abc.js` — content hash
+- `/_next/static/tqciPJRFLbeIk7IdD7S/_buildManifest.js` — build ID
+
+A new build writes new file names. The old URL never points to new bytes.
+A cached copy of an old URL therefore stays correct. Next.js sets the same
+header for these files by default.
+
+Do not apply this header to `/_next/image` or `/_next/data`. Those paths return
+content that changes between builds under the same URL. `ViewController.assets`
+keeps them at 60 seconds.
+
+## The deploy risk to watch
+
+The risk is stale **HTML**, not stale assets.
+
+An HTML page names the chunk URLs for that build. A browser that holds old HTML
+after a deploy requests old chunk URLs. The new pod does not contain those
+files, so the request returns 404 and the page fails to load.
+
+Two facts control the size of this risk:
+
+1. The browser TTL of the HTML. A page cached for 5 minutes creates a 5 minute
+   window. A page cached for a day creates a one day window.
+2. The Kubernetes rollout. `deployment/app.yml` runs 1 replica and the
+   HorizontalPodAutoscaler allows 3. During a rollout, an old pod and a new pod
+   both serve traffic. Only the old pod holds the old chunks.
+
+Do not raise the HTML TTL without a cache purge in the deploy pipeline. See
+"Purge the cache on deploy" below.
+
+## Public and private responses
+
+Cloudflare does not store a response that carries `Cache-Control: private`.
+Every endpoint behind a guard sends `private`. Every endpoint marked `@Public()`
+does not. This split is what makes a broad Cache Rule safe: a rule that matches
+too much still cannot store a guarded response.
+
+Keep this rule when you add an endpoint:
+
+- `@Public()` endpoint — use `max-age=...` without `private`.
+- Guarded endpoint — start the header with `private,`.
+
+## Cloudflare Cache Rules
+
+Add these rules in the Cloudflare dashboard, under Rules > Caching > Cache Rules.
+Order matters. Cloudflare applies the first rule that matches.
+
+### Rule 1 — bypass the API
+
+Expression:
+
+```
+starts_with(http.request.uri.path, "/api/")
+```
+
+Setting: Bypass cache.
+
+### Rule 2 — cache public pages
+
+Expression:
+
+```
+http.request.uri.path in {"/" "/about" "/privacy-policy" "/code-of-conduct" "/supportive-materials" "/signup-invite" "/404"}
+or starts_with(http.request.uri.path, "/personality/")
+or starts_with(http.request.uri.path, "/claim/")
+or starts_with(http.request.uri.path, "/source/")
+```
+
+Settings:
+
+- Cache eligibility: Eligible for cache
+- Edge TTL: Override origin, 300 seconds
+- Browser TTL: Respect origin
+- Cache key: add the cookie `default_language`
+
+The cookie in the cache key is required. `GetLanguageMiddleware` reads
+`default_language` and the server renders a different page for `pt` and for `en`.
+A cache key without this cookie serves the wrong language.
+
+You do not need to exclude logged-in readers. `_app.tsx` calls `GetUserRole()`
+in the browser, so the HTML is the same for a reader who signed in and a reader
+who did not.
+
+### Rule 3 — respect the origin for static assets
+
+Expression:
+
+```
+starts_with(http.request.uri.path, "/_next/static/")
+```
+
+Settings: Eligible for cache, Edge TTL "Use cache-control header if present".
+
+This rule is optional. Cloudflare already caches these files by extension. The
+rule makes the behaviour explicit and protects it from a later change.
+
+## Purge the cache on deploy
+
+Run this command after each production deploy. It removes the HTML that names
+the old chunk URLs.
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"hosts":["aletheiafact.org","www.aletheiafact.org"]}'
+```
+
+The purge also drops the cached static assets. This cost is small, because the
+new build uses new file names and the old files are no longer requested.
+
+## How to check the result
+
+Use `curl` and read `cf-cache-status`:
+
+```bash
+curl -sS -o /dev/null -D - https://aletheiafact.org/ | grep -Ei "cache-control|cf-cache-status"
+```
+
+The values mean:
+
+- `HIT` — Cloudflare served the response from cache. This is the target.
+- `MISS` — Cloudflare stored the response for the next request.
+- `REVALIDATED` — the TTL was too short and Cloudflare asked the origin again.
+- `EXPIRED` — the same, after the copy went stale.
+- `DYNAMIC` — Cloudflare did not cache the response. HTML shows this until you
+  add Rule 2.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,6 +9,11 @@ PRODUCTION_AWS_ACCESS_KEY_ID=...
 PRODUCTION_AWS_SECRET_ACCESS_KEY=...
 ```
 
+## Caching
+Cloudflare is in front of the production server. Read [CACHING.md](CACHING.md)
+before you change a `Cache-Control` header or a Cloudflare rule. That document
+also holds the cache purge command that each production deploy must run.
+
 ## Troubleshooting
 
 ### Database connection error

--- a/server/automated-fact-checking/automated-fact-checking.controller.ts
+++ b/server/automated-fact-checking/automated-fact-checking.controller.ts
@@ -11,7 +11,7 @@ export class AutomatedFactCheckingController {
 
     @ApiTags("automated-fact-checking")
     @Post("api/ai-fact-checking")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async create(@Body() { claim, context }: CreateAutomatedFactCheckingDTO) {
         return this.automatedFactCheckingService.getResponseFromAgents({
             claim,

--- a/server/cache-control.spec.ts
+++ b/server/cache-control.spec.ts
@@ -1,0 +1,104 @@
+import { HEADERS_METADATA } from "@nestjs/common/constants";
+import fg from "fast-glob";
+import path from "path";
+
+/**
+ * Cloudflare does not store a response that carries "Cache-Control: private".
+ * That header is what keeps a guarded response out of the shared cache, even
+ * when a broad Cloudflare Cache Rule matches its path. This test holds the
+ * convention in place. See CACHING.md.
+ */
+describe("Cache-Control convention (Unit)", () => {
+    type Endpoint = {
+        file: string;
+        controller: string;
+        handler: string;
+        cacheControl: string;
+        isPublic: boolean;
+    };
+
+    async function collectEndpoints(): Promise<Endpoint[]> {
+        const files = await fg("server/**/*.controller.ts", {
+            ignore: ["**/dist/**", "**/node_modules/**"],
+        });
+        const endpoints: Endpoint[] = [];
+
+        for (const file of files) {
+            const moduleExports = await import(path.resolve(file));
+
+            for (const exported of Object.values(moduleExports)) {
+                if (typeof exported !== "function" || !exported.prototype) {
+                    continue;
+                }
+                const controller: any = exported;
+                const classIsPublic =
+                    Reflect.getMetadata("public", controller) === true;
+
+                for (const handlerName of Object.getOwnPropertyNames(
+                    controller.prototype
+                )) {
+                    if (handlerName === "constructor") {
+                        continue;
+                    }
+                    const handler = controller.prototype[handlerName];
+                    if (typeof handler !== "function") {
+                        continue;
+                    }
+                    const headers: Array<{ name: string; value: string }> =
+                        Reflect.getMetadata(HEADERS_METADATA, handler) || [];
+                    const cacheControl = headers.find(
+                        (header) =>
+                            header.name.toLowerCase() === "cache-control"
+                    );
+                    if (!cacheControl) {
+                        continue;
+                    }
+                    endpoints.push({
+                        file,
+                        controller: controller.name,
+                        handler: handlerName,
+                        cacheControl: cacheControl.value,
+                        isPublic:
+                            classIsPublic ||
+                            Reflect.getMetadata("public", handler) === true,
+                    });
+                }
+            }
+        }
+        return endpoints;
+    }
+
+    let endpoints: Endpoint[];
+
+    beforeAll(async () => {
+        endpoints = await collectEndpoints();
+    });
+
+    it("finds the endpoints that set Cache-Control", () => {
+        expect(endpoints.length).toBeGreaterThan(40);
+    });
+
+    it("marks every guarded endpoint as private", () => {
+        const leaks = endpoints
+            .filter((endpoint) => !endpoint.isPublic)
+            .filter((endpoint) => !endpoint.cacheControl.startsWith("private"))
+            .map(
+                (endpoint) =>
+                    `${endpoint.controller}.${endpoint.handler} -> "${endpoint.cacheControl}" (${endpoint.file})`
+            );
+
+        expect(leaks).toEqual([]);
+    });
+
+    it("keeps every public endpoint out of the private cache", () => {
+        const mislabelled = endpoints
+            .filter((endpoint) => endpoint.isPublic)
+            .filter((endpoint) => endpoint.cacheControl.startsWith("private"))
+            .map(
+                (endpoint) =>
+                    `${endpoint.controller}.${endpoint.handler} -> "${endpoint.cacheControl}" (${endpoint.file})`
+            );
+
+        expect(mislabelled).toEqual([]);
+    });
+});

--- a/server/claim/claim.controller.ts
+++ b/server/claim/claim.controller.ts
@@ -421,7 +421,7 @@ export class ClaimController {
     @AdminOnly()
     @Get("claim/:claimId/debate/edit")
     @ApiTags("pages")
-    @Header("Cache-Control", "max-age=60, must-revalidate")
+    @Header("Cache-Control", "private, max-age=60, must-revalidate")
     public async getDebateEditor(
         @Req() req: BaseRequest,
         @Res() res: Response

--- a/server/review-task/review-task.controller.ts
+++ b/server/review-task/review-task.controller.ts
@@ -39,7 +39,7 @@ export class ReviewTaskController {
 
     @ApiTags("review-task")
     @Get("api/reviewtask")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     public async getByMachineValue(@Query() getTasksDTO: GetTasksDTO) {
         const {
             page = 0,
@@ -89,14 +89,14 @@ export class ReviewTaskController {
 
     @ApiTags("review-task")
     @Get("api/reviewtask/:id")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async getById(@Param("id") id: string) {
         return this.reviewTaskService.getById(id);
     }
 
     @ApiTags("review-task")
     @Post("api/reviewtask")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async create(@Body() createReviewTask: CreateReviewTaskDTO): Promise<any> {
         if (createReviewTask.recaptcha) {
             const validateCaptcha = await this.captchaService.validate(
@@ -111,7 +111,7 @@ export class ReviewTaskController {
 
     @ApiTags("review-task")
     @Put("api/reviewtask/save-draft/:data_hash")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async saveDraft(
         @Param("data_hash") data_hash: string,
         @Body() saveDraftBody: SaveDraftDTO
@@ -121,7 +121,7 @@ export class ReviewTaskController {
 
     @ApiTags("review-task")
     @Put("api/reviewtask/:data_hash")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async autoSaveDraft(
         @Param("data_hash") data_hash: string,
         @Body() reviewTaskBody: UpdateReviewTaskDTO
@@ -145,14 +145,14 @@ export class ReviewTaskController {
     // TODO: remove hash from the url
     @ApiTags("review-task")
     @Get("api/reviewtask/hash/:data_hash")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async getByDataHash(@Param("data_hash") data_hash: string) {
         return this.reviewTaskService.getReviewTaskByDataHash(data_hash);
     }
 
     @ApiTags("review-task")
     @Get("api/reviewtask/editor-content/:data_hash")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async getEditorContentByDataHash(
         @Param("data_hash") data_hash: string,
         @Query() query: { reportModel: string; reviewTaskType: string }
@@ -170,7 +170,7 @@ export class ReviewTaskController {
 
     @ApiTags("review-task")
     @Put("api/reviewtask/add-comment/:data_hash")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async addComment(
         @Param("data_hash") data_hash: string,
         @Body() body: { comment: any }
@@ -180,7 +180,7 @@ export class ReviewTaskController {
 
     @ApiTags("review-task")
     @Put("api/reviewtask/delete-comment/:data_hash")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     async deleteComment(
         @Param("data_hash") data_hash: string,
         @Body() body: { commentId: string }
@@ -190,7 +190,7 @@ export class ReviewTaskController {
 
     @ApiTags("pages")
     @Get("kanban")
-    @Header("Cache-Control", "no-cache")
+    @Header("Cache-Control", "private, no-cache")
     public async kanbanList(@Req() req: Request, @Res() res: Response) {
         const parsedUrl = parse(req.url, true);
         const enableCollaborativeEditor =

--- a/server/root/root.controller.ts
+++ b/server/root/root.controller.ts
@@ -5,7 +5,7 @@ import { Public } from "../auth/decorators/auth.decorator";
 export class RootController {
     @Public()
     @Get("robots.txt")
-    @Header("Cache-Control", "max-age=60, must-revalidate")
+    @Header("Cache-Control", "public, max-age=86400")
     robots(@Res() res: any, @Req() req: any) {
         const host = req.protocol + "://" + req.get("host");
         res.type("text/plain").end(

--- a/server/users/users.controller.ts
+++ b/server/users/users.controller.ts
@@ -189,7 +189,7 @@ export class UsersController {
 
     @ApiTags("user")
     @Get("api/user")
-    @Header("Cache-Control", "max-age=60, must-revalidate")
+    @Header("Cache-Control", "private, max-age=60, must-revalidate")
     @Auth()
     public async getAll(@Query() getUsers: GetUsersDTO) {
         return this.usersService.findAll(getUsers);
@@ -206,7 +206,7 @@ export class UsersController {
     @ApiTags("user")
     @Get("api/user/:id")
     @Auth()
-    @Header("Cache-Control", "max-age=60, must-revalidate")
+    @Header("Cache-Control", "private, max-age=60, must-revalidate")
     public async getUser(@Param("id") userId: string) {
         const value = new Types.ObjectId(userId);
         return this.usersService.getById(value);

--- a/server/verification-request/verification-request.controller.ts
+++ b/server/verification-request/verification-request.controller.ts
@@ -121,7 +121,7 @@ export class VerificationRequestController {
 
     @ApiTags("verification-request")
     @Get("api/verification-request/search")
-    @Header("Cache-Control", "max-age=60, must-revalidate")
+    @Header("Cache-Control", "private, max-age=60, must-revalidate")
     @ApiQuery({
         name: "sourceUrl",
         required: false,
@@ -157,7 +157,7 @@ export class VerificationRequestController {
 
     @ApiTags("verification-request")
     @Get("api/verification-request/:id")
-    @Header("Cache-Control", "max-age=60, must-revalidate")
+    @Header("Cache-Control", "private, max-age=60, must-revalidate")
     public async getById(@Param("id") verificationRequestId: string) {
         return this.verificationRequestService.getById(verificationRequestId);
     }

--- a/server/view/view.controller.spec.ts
+++ b/server/view/view.controller.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import request from "supertest";
+import { ViewController } from "./view.controller";
+import { ViewService } from "./view.service";
+import { CaptchaService } from "../captcha/captcha.service";
+
+describe("ViewController cache headers (Unit)", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        const moduleRef: TestingModule = await Test.createTestingModule({
+            controllers: [ViewController],
+            providers: [
+                {
+                    provide: ViewService,
+                    useValue: {
+                        render: vi.fn((_req, res) => {
+                            res.end("ok");
+                            return Promise.resolve();
+                        }),
+                    },
+                },
+                { provide: ConfigService, useValue: { get: () => undefined } },
+                {
+                    provide: CaptchaService,
+                    useValue: { getClientConfig: () => ({}) },
+                },
+            ],
+        }).compile();
+
+        app = moduleRef.createNestApplication();
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app?.close();
+    });
+
+    it("serves hashed /_next/static assets as immutable for a year", async () => {
+        const response = await request(app.getHttpServer()).get(
+            "/_next/static/chunks/framework-c17f08e07d1abc.js"
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers["cache-control"]).toBe(
+            "public, max-age=31536000, immutable"
+        );
+    });
+
+    it("keeps a short TTL for other /_next paths", async () => {
+        const response = await request(app.getHttpServer()).get(
+            "/_next/image?url=%2Flogo.png&w=64&q=75"
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers["cache-control"]).toBe("public, max-age=60");
+    });
+});

--- a/server/view/view.controller.ts
+++ b/server/view/view.controller.ts
@@ -150,13 +150,7 @@ export class ViewController {
     @Get("_next/static*")
     @Header("Cache-Control", "public, max-age=31536000, immutable")
     public async staticAssets(@Req() req: Request, @Res() res: Response) {
-        const parsedUrl = parse(req.url, true);
-        await this.viewService.render(
-            req,
-            res,
-            parsedUrl.pathname ?? "/",
-            parsedUrl.query
-        );
+        await this.handler(req, res);
     }
 
     /**
@@ -167,13 +161,7 @@ export class ViewController {
     @Get("_next*")
     @Header("Cache-Control", "public, max-age=60")
     public async assets(@Req() req: Request, @Res() res: Response) {
-        const parsedUrl = parse(req.url, true);
-        await this.viewService.render(
-            req,
-            res,
-            parsedUrl.pathname ?? "/",
-            parsedUrl.query
-        );
+        await this.handler(req, res);
     }
 
     /**

--- a/server/view/view.controller.ts
+++ b/server/view/view.controller.ts
@@ -140,9 +140,32 @@ export class ViewController {
         );
     }
 
+    /**
+     * Files under /_next/static carry a content hash in the name, so a given
+     * URL always returns the same bytes. They can stay in the browser and in
+     * the CDN for a year. This route must come before the general "_next*"
+     * route below, because Express matches routes in declaration order.
+     */
+    @Public()
+    @Get("_next/static*")
+    @Header("Cache-Control", "public, max-age=31536000, immutable")
+    public async staticAssets(@Req() req: Request, @Res() res: Response) {
+        const parsedUrl = parse(req.url, true);
+        await this.viewService.render(
+            req,
+            res,
+            parsedUrl.pathname ?? "/",
+            parsedUrl.query
+        );
+    }
+
+    /**
+     * Other /_next paths (the image optimizer, the data routes) change when
+     * the content changes, so they get a short TTL.
+     */
     @Public()
     @Get("_next*")
-    @Header("Cache-Control", "max-age=60")
+    @Header("Cache-Control", "public, max-age=60")
     public async assets(@Req() req: Request, @Res() res: Response) {
         const parsedUrl = parse(req.url, true);
         await this.viewService.render(
@@ -167,7 +190,7 @@ export class ViewController {
     }
 
     @Get("totp")
-    @Header("Cache-Control", "max-age=86400")
+    @Header("Cache-Control", "private, max-age=86400")
     public async showTotpCheck(@Req() req: Request, @Res() res: Response) {
         const parsedUrl = parse(req.url, true);
         await this.viewService.render(


### PR DESCRIPTION
# Description

Cloudflare reported a **5.8% cache hit ratio** on the production zone, with `html` as the top uncached content type. Live headers showed two independent causes, one of which is fixed here in code. The other needs a Cloudflare dashboard change, which this PR documents rather than performs.

Measured on production before the change:

| URL | `cache-control` | `cf-cache-status` |
|---|---|---|
| `/_next/static/chunks/polyfills-…js` | `max-age=60` | REVALIDATED |
| `/robots.txt` | `max-age=60, must-revalidate` | EXPIRED |
| `/` and `/about` | `max-age=60` / `max-age=86400` | DYNAMIC |
| `/favicon.ico` | `public, max-age=31536000, immutable` | HIT |

### 1. Hashed Next.js assets were expiring every 60 seconds

The catch-all `@Get("_next*")` route in `ViewController` carried `@Header("Cache-Control", "max-age=60")`. That decorator overrode the `public, max-age=31536000, immutable` header Next.js sets for these files, so the highest-volume paths on the site revalidated against the origin once a minute. These are the same paths that fill the "top cached paths" panel in the Cloudflare dashboard.

The route is now split. `/_next/static*` gets the immutable header; `/_next/image` and `/_next/data` keep the 60-second TTL, because those do return new content under the same URL.

**On the staleness risk:** every URL under `/_next/static` carries a content hash or the build ID (`chunks/framework-c17f08e07d1abc.js`, `tqciPJRFLbeIk7IdD7S/_buildManifest.js`). A new build writes new filenames, so an old URL never starts returning new bytes and a cached copy cannot go stale. This restores Next.js's own default rather than inventing a longer one.

The real deploy hazard is stale **HTML**, not stale assets — old HTML names chunk URLs the new pod no longer has. That risk arrives with edge-caching HTML, so `CACHING.md` bounds it with a 300s edge TTL plus a purge-on-deploy step.

### 2. `robots.txt`

`max-age=60, must-revalidate` → `public, max-age=86400`.

### 3. Guarded endpoints now send `private`

17 endpoints behind a guard sent a positive `max-age` or `no-cache` with no `private`. Cloudflare skips them today only because they have no file extension. That stops being true the moment a Cache Rule marks HTML eligible for cache, at which point per-user JSON becomes edge-cacheable.

`private` is the safety net underneath the Cache Rules: a rule that matches too much still cannot store a guarded response. This had to land before anyone enables HTML caching.

### 4. `CACHING.md`

Records the three Cloudflare Cache Rules with their expressions and settings, the purge-on-deploy command, and the reasoning above. Two points in it are easy to get wrong and expensive:

- **The cache key for public pages must include the `default_language` cookie.** `GetLanguageMiddleware` reads it and the server renders different HTML for `pt` and `en`. Verified: `/` returns different bytes for each. A default cache key would serve the wrong language site-wide.
- **Each production deploy must purge the cache**, or a reader holding old HTML hits 404s on chunk URLs the new pod does not have.

The document also notes that logged-in readers do *not* need to be excluded from the cache: `_app.tsx` resolves identity in the browser via `GetUserRole()`, so page HTML is identical either way. That is what makes a useful hit ratio reachable.

Related Ticket # (issue)

# Type of change

- [x] Existing feature enhancement (non-breaking change which modifies existing functionality)

# Testing

```bash
yarn build-ts
NODE_OPTIONS=--experimental-require-module npx vitest run --project unit
```

339 unit tests pass across 42 files. Type check is clean.

Two new specs:

- `server/view/view.controller.spec.ts` — boots the controller and asserts that `/_next/static/...` returns the immutable header while `/_next/image` keeps 60s. This covers the route **ordering**, which is the load-bearing detail: Express matches in declaration order, so the specific route must stay above the catch-all.
- `server/cache-control.spec.ts` — reads Nest route metadata across all 39 controllers and asserts that every guarded endpoint starts with `private` and no `@Public()` endpoint does. Verified this test actually fails: removing `private` from `UsersController.getAll` fails the run and names the offending endpoint.

**After merge**, to see the hit ratio move, someone with Cloudflare access needs to apply the rules in `CACHING.md`. The asset fix in this PR helps on its own; HTML stays `DYNAMIC` until Rule 2 exists.

Manual check:

```bash
curl -sS -o /dev/null -D - https://aletheiafact.org/_next/static/chunks/<chunk>.js | grep -Ei "cache-control|cf-cache-status"
```

`REVALIDATED` should become `HIT` once the deploy has warmed.

# Developer Checklist
## General
- [x] Code is appropriately commented, particularly in hard-to-understand areas
- [x] Repository documentation has been updated (`CACHING.md`, linked from `DEPLOYMENT.md`)
- [x] No `console.log` or related logging is added.
- [x] No code is repeated/duplicated in violation of DRY.
- [x] Documented with TSDoc all library and controller new functions

## Backend Changes
- [x] All endpoints are appropriately secured with Middleware authentication — auth is unchanged; this PR only changes `Cache-Control` values
- [x] All new endpoints have a interface schema defined — no new endpoints

### Tests
- [x] All existing unit and end to end tests pass across all services
- [x] Unit and end to end tests have been added to ensure backend APIs behave as expected

# Reviewer notes

- **No auth or routing behaviour changes.** Only `Cache-Control` header values, plus one route split in `ViewController`.
- The `private` sweep was applied by script and then audited: an early pass wrongly marked three `@Public()` endpoints in `verification-request.controller.ts` as private, because those files place `@Public()` *after* `@Header`. Those were reverted, and `cache-control.spec.ts` scans decorators in both directions so the same mistake cannot recur silently.
- `api/user/ory/:id` is `@Public()` and returns a user record for a 60s cacheable window. Left as-is because changing its auth is outside this PR's scope, but it is worth a look.
- Scanner traffic (`/wp-login.php`, `/fleen.php`, `/static//home/user/.env`) hits origin for 404s and dilutes the ratio. A WAF rule would drop it at the edge. Not addressed here.
- During a rollout, old and new pods overlap and only the old pod holds the old chunks, so a reader on old HTML can be routed to a pod without their chunks. Pre-existing and orthogonal to caching; worth a separate issue about retaining the previous build's `static/` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
